### PR TITLE
Removed the shrinkwrap Archive as a requirement

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -16,11 +16,7 @@
 
 package io.smallrye.openapi.api;
 
-import java.util.HashSet;
 import java.util.Set;
-
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.openapi.OASConfig;
 
 /**
  * Accessor to OpenAPI configuration options.
@@ -29,129 +25,30 @@ import org.eclipse.microprofile.openapi.OASConfig;
  *
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiConfig {
+public interface OpenApiConfig {
 
-    private Config config;
+    public String modelReader();
 
-    private String modelReader;
-    private String filter;
-    private Boolean scanDisable;
-    private Set<String> scanPackages;
-    private Set<String> scanClasses;
-    private Set<String> scanExcludePackages;
-    private Set<String> scanExcludeClasses;
-    private Set<String> servers;
-    private Boolean scanDependenciesDisable;
-    private Set<String> scanDependenciesJars;
+    public String filter();
 
-    public OpenApiConfig(Config config) {
-        this.config = config;
-    }
+    public boolean scanDisable();
 
-    /**
-     * @return the MP config instance
-     */
-    protected Config getConfig() {
-        // We cannot use ConfigProvider.getConfig() as the archive is not deployed yet - TCCL cannot be set
-        return config;
-    }
+    public Set<String> scanPackages();
 
-    public String modelReader() {
-        if (modelReader == null) {
-            modelReader = getConfig().getOptionalValue(OASConfig.MODEL_READER, String.class).orElse(null);
-        }
-        return modelReader;
-    }
+    public Set<String> scanClasses();
 
-    public String filter() {
-        if (filter == null) {
-            filter = getConfig().getOptionalValue(OASConfig.FILTER, String.class).orElse(null);
-        }
-        return filter;
-    }
+    public Set<String> scanExcludePackages();
 
-    public boolean scanDisable() {
-        if (scanDisable == null) {
-            scanDisable = getConfig().getOptionalValue(OASConfig.SCAN_DISABLE, Boolean.class).orElse(false);
-        }
-        return scanDisable;
-    }
+    public Set<String> scanExcludeClasses();
 
-    public Set<String> scanPackages() {
-        if (scanPackages == null) {
-            String packages = getConfig().getOptionalValue(OASConfig.SCAN_PACKAGES, String.class).orElse(null);
-            scanPackages = asCsvSet(packages);
-        }
-        return scanPackages;
-    }
+    public Set<String> servers();
 
-    public Set<String> scanClasses() {
-        if (scanClasses == null) {
-            String classes = getConfig().getOptionalValue(OASConfig.SCAN_CLASSES, String.class).orElse(null);
-            scanClasses = asCsvSet(classes);
-        }
-        return scanClasses;
-    }
+    public Set<String> pathServers(String path);
 
-    public Set<String> scanExcludePackages() {
-        if (scanExcludePackages == null) {
-            String packages = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_PACKAGES, String.class).orElse(null);
-            scanExcludePackages = asCsvSet(packages);
-        }
-        return scanExcludePackages;
-    }
+    public Set<String> operationServers(String operationId);
 
-    public Set<String> scanExcludeClasses() {
-        if (scanExcludeClasses == null) {
-            String classes = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_CLASSES, String.class).orElse(null);
-            scanExcludeClasses = asCsvSet(classes);
-        }
-        return scanExcludeClasses;
-    }
+    public boolean scanDependenciesDisable();
 
-    public Set<String> servers() {
-        if (servers == null) {
-            String theServers = getConfig().getOptionalValue(OASConfig.SERVERS, String.class).orElse(null);
-            servers = asCsvSet(theServers);
-        }
-        return servers;
-    }
-
-    public Set<String> pathServers(String path) {
-        String servers = getConfig().getOptionalValue(OASConfig.SERVERS_PATH_PREFIX + path, String.class).orElse(null);
-        return asCsvSet(servers);
-    }
-
-    public Set<String> operationServers(String operationId) {
-        String servers = getConfig().getOptionalValue(OASConfig.SERVERS_OPERATION_PREFIX + operationId, String.class).orElse(null);
-        return asCsvSet(servers);
-    }
-
-    public boolean scanDependenciesDisable() {
-        if (scanDependenciesDisable == null) {
-            scanDependenciesDisable = getConfig().getOptionalValue(OpenApiConstants.SCAN_DEPENDENCIES_DISABLE, Boolean.class).orElse(false);
-        }
-        return scanDependenciesDisable;
-    }
-
-    public Set<String> scanDependenciesJars() {
-        if (scanDependenciesJars == null) {
-            String classes = getConfig().getOptionalValue(OpenApiConstants.SCAN_DEPENDENCIES_JARS, String.class).orElse(null);
-            scanDependenciesJars = asCsvSet(classes);
-        }
-        return scanDependenciesJars;
-    }
-
-
-    private static Set<String> asCsvSet(String items) {
-        Set<String> rval = new HashSet<>();
-        if (items != null) {
-            String[] split = items.split(",");
-            for (String item : split) {
-                rval.add(item.trim());
-            }
-        }
-        return rval;
-    }
+    public Set<String> scanDependenciesJars();
 
 }

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.openapi.api;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.openapi.OASConfig;
+
+/**
+ * Implementation of the {@link OpenApiConfig} interface that gets config information from a
+ * standard MP Config object.
+ * 
+ * @author eric.wittmann@gmail.com
+ */
+public class OpenApiConfigImpl implements OpenApiConfig {
+
+    private Config config;
+
+    private String modelReader;
+    private String filter;
+    private Boolean scanDisable;
+    private Set<String> scanPackages;
+    private Set<String> scanClasses;
+    private Set<String> scanExcludePackages;
+    private Set<String> scanExcludeClasses;
+    private Set<String> servers;
+    private Boolean scanDependenciesDisable;
+    private Set<String> scanDependenciesJars;
+
+    /**
+     * Constructor.
+     * @param config
+     */
+    public OpenApiConfigImpl(Config config) {
+        this.config = config;
+    }
+
+    /**
+     * @return the MP config instance
+     */
+    protected Config getConfig() {
+        // We cannot use ConfigProvider.getConfig() as the archive is not deployed yet - TCCL cannot be set
+        return config;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#modelReader()
+     */
+    @Override
+    public String modelReader() {
+        if (modelReader == null) {
+            modelReader = getConfig().getOptionalValue(OASConfig.MODEL_READER, String.class).orElse(null);
+        }
+        return modelReader;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#filter()
+     */
+    @Override
+    public String filter() {
+        if (filter == null) {
+            filter = getConfig().getOptionalValue(OASConfig.FILTER, String.class).orElse(null);
+        }
+        return filter;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#scanDisable()
+     */
+    @Override
+    public boolean scanDisable() {
+        if (scanDisable == null) {
+            scanDisable = getConfig().getOptionalValue(OASConfig.SCAN_DISABLE, Boolean.class).orElse(false);
+        }
+        return scanDisable;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#scanPackages()
+     */
+    @Override
+    public Set<String> scanPackages() {
+        if (scanPackages == null) {
+            String packages = getConfig().getOptionalValue(OASConfig.SCAN_PACKAGES, String.class).orElse(null);
+            scanPackages = asCsvSet(packages);
+        }
+        return scanPackages;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#scanClasses()
+     */
+    @Override
+    public Set<String> scanClasses() {
+        if (scanClasses == null) {
+            String classes = getConfig().getOptionalValue(OASConfig.SCAN_CLASSES, String.class).orElse(null);
+            scanClasses = asCsvSet(classes);
+        }
+        return scanClasses;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#scanExcludePackages()
+     */
+    @Override
+    public Set<String> scanExcludePackages() {
+        if (scanExcludePackages == null) {
+            String packages = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_PACKAGES, String.class).orElse(null);
+            scanExcludePackages = asCsvSet(packages);
+        }
+        return scanExcludePackages;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#scanExcludeClasses()
+     */
+    @Override
+    public Set<String> scanExcludeClasses() {
+        if (scanExcludeClasses == null) {
+            String classes = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_CLASSES, String.class).orElse(null);
+            scanExcludeClasses = asCsvSet(classes);
+        }
+        return scanExcludeClasses;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#servers()
+     */
+    @Override
+    public Set<String> servers() {
+        if (servers == null) {
+            String theServers = getConfig().getOptionalValue(OASConfig.SERVERS, String.class).orElse(null);
+            servers = asCsvSet(theServers);
+        }
+        return servers;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#pathServers(java.lang.String)
+     */
+    @Override
+    public Set<String> pathServers(String path) {
+        String servers = getConfig().getOptionalValue(OASConfig.SERVERS_PATH_PREFIX + path, String.class).orElse(null);
+        return asCsvSet(servers);
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#operationServers(java.lang.String)
+     */
+    @Override
+    public Set<String> operationServers(String operationId) {
+        String servers = getConfig().getOptionalValue(OASConfig.SERVERS_OPERATION_PREFIX + operationId, String.class).orElse(null);
+        return asCsvSet(servers);
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#scanDependenciesDisable()
+     */
+    @Override
+    public boolean scanDependenciesDisable() {
+        if (scanDependenciesDisable == null) {
+            scanDependenciesDisable = getConfig().getOptionalValue(OpenApiConstants.SCAN_DEPENDENCIES_DISABLE, Boolean.class).orElse(false);
+        }
+        return scanDependenciesDisable;
+    }
+
+    /**
+     * @see io.smallrye.openapi.api.OpenApiConfig#scanDependenciesJars()
+     */
+    @Override
+    public Set<String> scanDependenciesJars() {
+        if (scanDependenciesJars == null) {
+            String classes = getConfig().getOptionalValue(OpenApiConstants.SCAN_DEPENDENCIES_JARS, String.class).orElse(null);
+            scanDependenciesJars = asCsvSet(classes);
+        }
+        return scanDependenciesJars;
+    }
+
+
+    private static Set<String> asCsvSet(String items) {
+        Set<String> rval = new HashSet<>();
+        if (items != null) {
+            String[] split = items.split(",");
+            for (String item : split) {
+                rval.add(item.trim());
+            }
+        }
+        return rval;
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/openapi/api/util/ArchiveUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/util/ArchiveUtil.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.openapi.api.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.classloader.ShrinkWrapClassLoader;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConfigImpl;
+import io.smallrye.openapi.api.OpenApiConstants;
+import io.smallrye.openapi.runtime.OpenApiStaticFile;
+import io.smallrye.openapi.runtime.io.OpenApiSerializer.Format;
+import io.smallrye.openapi.runtime.scanner.OpenApiAnnotationScanner;
+
+/**
+ * Some useful methods for creating stuff from ShrinkWrap {@link Archive}s.
+ * @author eric.wittmann@gmail.com
+ */
+public class ArchiveUtil {
+    
+    /**
+     * Constructor.
+     */
+    private ArchiveUtil() {
+    }
+    
+    /**
+     * Creates an {@link OpenApiConfig} instance from the given ShrinkWrap archive.
+     * @param archive
+     */
+    public static OpenApiConfig archiveToConfig(Archive<?> archive) {
+        try (ShrinkWrapClassLoader cl = new ShrinkWrapClassLoader(archive)) {
+            return new OpenApiConfigImpl(ConfigProvider.getConfig(cl));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Finds the static OpenAPI file located in the deployment and, if it exists, returns
+     * it as an {@link OpenApiStaticFile}.  If not found, returns null.  The static file
+     * (when not null) contains an {@link InputStream} to the contents of the static file.
+     * The caller is responsible for closing this stream.
+     * @param archive
+     */
+    public static OpenApiStaticFile archiveToStaticFile(Archive<?> archive) {
+        OpenApiStaticFile rval = new OpenApiStaticFile();
+        rval.setFormat(Format.YAML);
+
+        // Check for the file in both META-INF and WEB-INF/classes/META-INF
+        Node node = archive.get("/META-INF/openapi.yaml");
+        if (node == null) {
+            node = archive.get("/WEB-INF/classes/META-INF/openapi.yml");
+        }
+        if (node == null) {
+            node = archive.get("/META-INF/openapi.yml");
+        }
+        if (node == null) {
+            node = archive.get("/WEB-INF/classes/META-INF/openapi.yml");
+        }
+        if (node == null) {
+            node = archive.get("/META-INF/openapi.json");
+            rval.setFormat(Format.JSON);
+        }
+        if (node == null) {
+            node = archive.get("/WEB-INF/classes/META-INF/openapi.json");
+            rval.setFormat(Format.JSON);
+        }
+
+        if (node == null) {
+            return null;
+        }
+        
+        rval.setContent(node.getAsset().openStream());
+
+        return rval;
+    }
+
+    /**
+     * Index the ShrinkWrap archive to produce a jandex index.
+     * @param config
+     * @param archive
+     */
+    public static IndexView archiveToIndex(OpenApiConfig config, Archive<?> archive) {
+        if (archive == null) {
+            throw new RuntimeException("Archive was null!");
+        }
+
+        Indexer indexer = new Indexer();
+        index(indexer, "io/smallrye/openapi/runtime/scanner/CollectionStandin.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/MapStandin.class");
+        indexArchive(config, indexer, archive);
+        return indexer.complete();
+    }
+
+    private static void index(Indexer indexer, String resName) {
+        ClassLoader cl = OpenApiAnnotationScanner.class.getClassLoader();
+        try (InputStream klazzStream = cl.getResourceAsStream(resName)) {
+            indexer.index(klazzStream);
+        } catch (IOException ioe) {
+            throw new UncheckedIOException(ioe);
+        }
+    }
+
+
+    /**
+     * Indexes the given archive.
+     * @param config
+     * @param indexer
+     * @param archive
+     */
+    private static void indexArchive(OpenApiConfig config, Indexer indexer, Archive<?> archive) {
+        Map<ArchivePath, Node> c = archive.getContent();
+        try {
+            for (Map.Entry<ArchivePath, Node> each : c.entrySet()) {
+                ArchivePath archivePath = each.getKey();
+                if (archivePath.get().endsWith(OpenApiConstants.CLASS_SUFFIX) && acceptClassForScanning(config, archivePath.get())) {
+                    try (InputStream contentStream = each.getValue().getAsset().openStream()) {
+                        //LOG.debugv("Indexing asset: {0} from archive: {1}", archivePath.get(), archive.getName());
+                        indexer.index(contentStream);
+                    }
+                    continue;
+                }
+                if (archivePath.get().endsWith(OpenApiConstants.JAR_SUFFIX) && acceptJarForScanning(config, archivePath.get())) {
+                    try (InputStream contentStream = each.getValue().getAsset().openStream()) {
+                        JavaArchive jarArchive = ShrinkWrap.create(JavaArchive.class, archivePath.get())
+                                .as(ZipImporter.class).importFrom(contentStream).as(JavaArchive.class);
+                        indexArchive(config, indexer, jarArchive);
+                    }
+                    continue;
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns true if the given JAR archive (dependency) should be cracked open and indexed
+     * along with the rest of the deployment's classes.
+     * @param config
+     * @param jarName
+     */
+    private static boolean acceptJarForScanning(OpenApiConfig config, String jarName) {
+        if (config.scanDependenciesDisable()) {
+            return false;
+        }
+        Set<String> scanDependenciesJars = config.scanDependenciesJars();
+        String nameOnly = new File(jarName).getName();
+        if (scanDependenciesJars.isEmpty() || scanDependenciesJars.contains(nameOnly)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the class represented by the given archive path should be included in
+     * the annotation index.
+     * @param config
+     * @param archivePath
+     */
+    private static boolean acceptClassForScanning(OpenApiConfig config, String archivePath) {
+        if (archivePath == null) {
+            return false;
+        }
+
+        Set<String> scanClasses = config.scanClasses();
+        Set<String> scanPackages = config.scanPackages();
+        Set<String> scanExcludeClasses = config.scanExcludeClasses();
+        Set<String> scanExcludePackages = config.scanExcludePackages();
+        if (scanClasses.isEmpty() && scanPackages.isEmpty() && scanExcludeClasses.isEmpty() && scanExcludePackages.isEmpty()) {
+            return true;
+        }
+
+        if (archivePath.startsWith(OpenApiConstants.WEB_ARCHIVE_CLASS_PREFIX)) {
+            archivePath = archivePath.substring(OpenApiConstants.WEB_ARCHIVE_CLASS_PREFIX.length());
+        }
+        String fqcn = archivePath.replaceAll("/", ".").substring(0, archivePath.lastIndexOf(OpenApiConstants.CLASS_SUFFIX));
+        String packageName = "";
+        if (fqcn.contains(".")) {
+            int idx = fqcn.lastIndexOf(".");
+            packageName = fqcn.substring(0, idx);
+        }
+
+        boolean accept;
+        // Includes
+        if (scanClasses.isEmpty() && scanPackages.isEmpty()) {
+            accept = true;
+        } else if (!scanClasses.isEmpty() && scanPackages.isEmpty()) {
+            accept = scanClasses.contains(fqcn);
+        } else if (scanClasses.isEmpty() && !scanPackages.isEmpty()) {
+            accept = scanPackages.contains(packageName);
+        } else {
+            accept = scanClasses.contains(fqcn) || scanPackages.contains(packageName);
+        }
+        // Excludes override includes
+        if (!scanExcludeClasses.isEmpty() && scanExcludeClasses.contains(fqcn)) {
+            accept = false;
+        }
+        if (!scanExcludePackages.isEmpty() && scanExcludePackages.contains(packageName)) {
+            accept = false;
+        }
+        return accept;
+    }
+    
+}

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/OpenApiStaticFile.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/OpenApiStaticFile.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.openapi.runtime;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+import io.smallrye.openapi.runtime.io.OpenApiSerializer.Format;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class OpenApiStaticFile implements Closeable {
+    
+    private Format format;
+    private InputStream content;
+    
+    /**
+     * Constructor.
+     */
+    public OpenApiStaticFile() {
+    }
+
+    /**
+     * Constructor.
+     * @param content
+     * @param format
+     */
+    public OpenApiStaticFile(InputStream content, Format format) {
+        this.setContent(content);
+        this.setFormat(format);
+    }
+
+    /**
+     * @see java.io.Closeable#close()
+     */
+    @Override
+    public void close() throws IOException {
+        if (this.getContent() != null) {
+            this.getContent().close();
+        }
+    }
+
+    /**
+     * @return the format
+     */
+    public Format getFormat() {
+        return format;
+    }
+
+    /**
+     * @param format the format to set
+     */
+    public void setFormat(Format format) {
+        this.format = format;
+    }
+
+    /**
+     * @return the content
+     */
+    public InputStream getContent() {
+        return content;
+    }
+
+    /**
+     * @param content the content to set
+     */
+    public void setContent(InputStream content) {
+        this.content = content;
+    }
+
+}

--- a/tck/src/test/java/test/io/smallrye/openapi/tck/TckTestRunner.java
+++ b/tck/src/test/java/test/io/smallrye/openapi/tck/TckTestRunner.java
@@ -33,6 +33,7 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.jandex.IndexView;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -44,7 +45,9 @@ import org.junit.runners.model.Statement;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiDocument;
+import io.smallrye.openapi.api.util.ArchiveUtil;
 import io.smallrye.openapi.runtime.OpenApiProcessor;
+import io.smallrye.openapi.runtime.OpenApiStaticFile;
 import io.smallrye.openapi.runtime.io.OpenApiSerializer;
 import io.smallrye.openapi.runtime.io.OpenApiSerializer.Format;
 
@@ -77,14 +80,17 @@ public class TckTestRunner extends ParentRunner<ProxiedTckTest> {
         // The Archive (shrinkwrap deployment)
         Archive archive = archive();
         // MPConfig
-        OpenApiConfig config = OpenApiProcessor.configFromArchive(archive);
+        OpenApiConfig config = ArchiveUtil.archiveToConfig(archive);
 
         try {
+            IndexView index = ArchiveUtil.archiveToIndex(config, archive);
+            OpenApiStaticFile staticFile = ArchiveUtil.archiveToStaticFile(archive);
+            
             // Reset and then initialize the OpenApiDocument for this test.
             OpenApiDocument.INSTANCE.reset();
             OpenApiDocument.INSTANCE.config(config);
-            OpenApiDocument.INSTANCE.modelFromStaticFile(OpenApiProcessor.modelFromStaticFile(config, archive));
-            OpenApiDocument.INSTANCE.modelFromAnnotations(OpenApiProcessor.modelFromAnnotations(config, archive));
+            OpenApiDocument.INSTANCE.modelFromStaticFile(OpenApiProcessor.modelFromStaticFile(staticFile));
+            OpenApiDocument.INSTANCE.modelFromAnnotations(OpenApiProcessor.modelFromAnnotations(config, index));
             OpenApiDocument.INSTANCE.modelFromReader(OpenApiProcessor.modelFromReader(config, getContextClassLoader()));
             OpenApiDocument.INSTANCE.filter(OpenApiProcessor.getFilter(config, getContextClassLoader()));
             OpenApiDocument.INSTANCE.initialize();


### PR DESCRIPTION
Removed the shrinkwrap Archive as a requirement for using SmallRye OpenAPI.  

However, a ShrinkWrap IndexView is still required.

Also added `ArchiveUtils` to create everything that is now needed.  So if you have an `Archive` you're still good to go!

Signed-off-by: Eric Wittmann <eric.wittmann@gmail.com>