### PR TITLE
Introduce support for @JsonIgnore, @JsonIgnoreProperties, @JsonIgnoreType

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import io.smallrye.openapi.api.OpenApiConstants;
+import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.runtime.util.JandexUtil;
+import io.smallrye.openapi.runtime.util.SchemaFactory;
+import io.smallrye.openapi.runtime.util.TypeUtil;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Type;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Process annotation targets such as {@link FieldInfo}.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class AnnotationTargetProcessor {
+//    private static final Logger LOG = Logger.getLogger(AnnotationTargetProcessor.class);
+
+    private final AugmentedIndexView index;
+    private final DataObjectDeque objectStack;
+    private final DataObjectDeque.PathEntry parentPathEntry;
+    private final TypeResolver typeResolver;
+    private final String entityName;
+    private final Type entityType;
+
+    // This can be overridden.
+    private Schema fieldSchema;
+    // May be null if field is unannotated.
+    private AnnotationTarget annotationTarget;
+
+    public AnnotationTargetProcessor(AugmentedIndexView index,
+                                     DataObjectDeque objectStack,
+                                     DataObjectDeque.PathEntry parentPathEntry,
+                                     TypeResolver typeResolver,
+                                     AnnotationTarget annotationTarget,
+                                     String entityName,
+                                     Type entityType) {
+        this.index = index;
+        this.objectStack = objectStack;
+        this.parentPathEntry = parentPathEntry;
+        this.typeResolver = typeResolver;
+        this.entityName = entityName;
+        this.entityType = entityType;
+        this.annotationTarget = annotationTarget;
+        this.fieldSchema = new SchemaImpl();
+    }
+
+    public AnnotationTargetProcessor(AugmentedIndexView index,
+                                     DataObjectDeque objectStack,
+                                     TypeResolver typeResolver,
+                                     DataObjectDeque.PathEntry parentPathEntry,
+                                     FieldInfo fieldInfo) {
+        this(index, objectStack, parentPathEntry, typeResolver, fieldInfo, fieldInfo.name(), fieldInfo.type());
+    }
+
+    public AnnotationTargetProcessor(AugmentedIndexView index,
+                                     DataObjectDeque objectStack,
+                                     TypeResolver typeResolver,
+                                     DataObjectDeque.PathEntry parentPathEntry,
+                                     Type type) {
+        this(index, objectStack, parentPathEntry, typeResolver, index.getClass(type), type.name().toString(), type);
+    }
+
+    public static Schema process(AugmentedIndexView index,
+                          DataObjectDeque objectStack,
+                          TypeResolver typeResolver,
+                          DataObjectDeque.PathEntry parentPathEntry,
+                          FieldInfo field) {
+        AnnotationTargetProcessor fp = new AnnotationTargetProcessor(index, objectStack, typeResolver, parentPathEntry, field);
+        return fp.processField();
+    }
+
+    public static Schema process(AugmentedIndexView index,
+                                 DataObjectDeque objectStack,
+                                 TypeResolver typeResolver,
+                                 DataObjectDeque.PathEntry parentPathEntry,
+                                 Type type) {
+        AnnotationTargetProcessor fp = new AnnotationTargetProcessor(index, objectStack, typeResolver, parentPathEntry, type);
+        return fp.processField();
+    }
+
+    public Schema processField() {
+        AnnotationInstance schemaAnnotation = TypeUtil.getSchemaAnnotation(annotationTarget);
+
+        if (schemaAnnotation == null && shouldInferUnannotatedFields()) {
+            // Handle unannotated field and just do simple inference.
+            readUnannotatedField();
+        } else {
+            // Handle field annotated with @Schema.
+            readSchemaAnnotatedField(schemaAnnotation);
+        }
+        parentPathEntry.getSchema().addProperty(entityName, fieldSchema);
+        return fieldSchema;
+    }
+
+    private void readSchemaAnnotatedField(@NotNull AnnotationInstance annotation) {
+        if (annotation == null) {
+            throw new IllegalArgumentException("Annotation must not be null");
+        }
+
+        //LOG.debugv("Processing @Schema annotation {0} on a field {1}", annotation, entityName);
+
+        // Schemas can be hidden. Skip if that's the case.
+        Boolean isHidden = JandexUtil.booleanValue(annotation, OpenApiConstants.PROP_HIDDEN);
+        if (isHidden != null && isHidden == Boolean.TRUE) {
+            return;
+        }
+
+        // If "required" attribute is on field. It should be applied to the *parent* schema.
+        // Required is false by default.
+        if (JandexUtil.booleanValueWithDefault(annotation, OpenApiConstants.PROP_REQUIRED)) {
+            parentPathEntry.getSchema().addRequired(entityName);
+        }
+
+        // Type could be replaced (e.g. generics).
+        TypeProcessor typeProcessor = new TypeProcessor(index, objectStack, parentPathEntry, typeResolver, entityType, fieldSchema, annotationTarget);
+
+        Type postProcessedField = typeProcessor.processType();
+        fieldSchema = typeProcessor.getSchema();
+
+        // TypeFormat pair contains mappings for Java <-> OAS types and formats.
+        TypeUtil.TypeWithFormat typeFormat = TypeUtil.getTypeFormat(postProcessedField);
+
+        // Provide inferred type and format if relevant.
+        Map<String, Object> overrides = new HashMap<>();
+        overrides.put(OpenApiConstants.PROP_TYPE, typeFormat.getSchemaType());
+        overrides.put(OpenApiConstants.PROP_FORMAT, typeFormat.getFormat().format());
+        // readSchema *may* replace the existing schema, so we must assign.
+        this.fieldSchema = SchemaFactory.readSchema(index, fieldSchema, annotation, overrides);
+    }
+
+    private void readUnannotatedField() {
+        //LOG.debugv("Processing unannotated field {0}", entityType);
+
+        TypeProcessor typeProcessor = new TypeProcessor(index, objectStack, parentPathEntry, typeResolver, entityType, fieldSchema, annotationTarget);
+
+        Type postProcessedField = typeProcessor.processType();
+        fieldSchema = typeProcessor.getSchema();
+
+        TypeUtil.TypeWithFormat typeFormat = TypeUtil.getTypeFormat(postProcessedField);
+        fieldSchema.setType(typeFormat.getSchemaType());
+
+        if (typeFormat.getFormat().hasFormat()) {
+            fieldSchema.setFormat(typeFormat.getFormat().format());
+        }
+    }
+
+    private boolean shouldInferUnannotatedFields() {
+        String infer = System.getProperties().getProperty("openapi.infer-unannotated-types", "true");
+        return Boolean.parseBoolean(infer);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import io.smallrye.openapi.runtime.util.TypeUtil;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
+
+/**
+ * IndexView augmented with additional methods for common operations
+ * used throughout the data object scanning code.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class AugmentedIndexView implements IndexView {
+
+    private final IndexView index;
+
+    public AugmentedIndexView(@NotNull IndexView index) {
+        this.index = index;
+    }
+
+    public ClassInfo getClass(@NotNull Type type) {
+        return index.getClassByName(TypeUtil.getName(type));
+    }
+
+    public boolean containsClass(@NotNull Type type) {
+        return getClass(type) != null;
+    }
+
+    public ClassInfo getClass(@NotNull Class<?> klazz) {
+        return index.getClassByName(DotName.createSimple(klazz.getName()));
+    }
+
+    @Override
+    public Collection<ClassInfo> getKnownClasses() {
+        return index.getKnownClasses();
+    }
+
+    @Override
+    public ClassInfo getClassByName(@NotNull DotName className) {
+        return index.getClassByName(className);
+    }
+
+    @Override
+    public Collection<ClassInfo> getKnownDirectSubclasses(@NotNull DotName className) {
+        return index.getKnownDirectSubclasses(className);
+    }
+
+    @Override
+    public Collection<ClassInfo> getAllKnownSubclasses(@NotNull DotName className) {
+        return index.getAllKnownSubclasses(className);
+    }
+
+    @Override
+    public Collection<ClassInfo> getKnownDirectImplementors(@NotNull DotName className) {
+        return index.getKnownDirectSubclasses(className);
+    }
+
+    @Override
+    public Collection<ClassInfo> getAllKnownImplementors(@NotNull DotName interfaceName) {
+        return index.getAllKnownImplementors(interfaceName);
+    }
+
+    @Override
+    public Collection<AnnotationInstance> getAnnotations(@NotNull DotName annotationName) {
+        return index.getAnnotations(annotationName);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/DataObjectDeque.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/DataObjectDeque.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Deque for exploring object graph.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class DataObjectDeque {
+
+//    private final Logger LOG = Logger.getLogger(DataObjectDeque.class);
+    private final Deque<PathEntry> path = new ArrayDeque<>();
+    private final AugmentedIndexView index;
+
+    public DataObjectDeque(AugmentedIndexView index) {
+        this.index = index;
+    }
+
+    /**
+     * @see Deque#size()
+     * @return the number of elements in this Deque
+     */
+    public int size() {
+        return path.size();
+    }
+
+    /**
+     * @see Deque#isEmpty()
+     * @return true if no elements in this Deque
+     */
+    public boolean isEmpty() {
+        return path.isEmpty();
+    }
+
+    /**
+     * Look at top of stack, but don't remove.
+     *
+     * @see Deque#peek()
+     * @return the top element of the stack
+     */
+    public PathEntry peek() {
+        return path.peek();
+    }
+
+    /**
+     * Push entry to stack. Does not perform cycle detection.
+     *
+     * @see Deque#push(Object)
+     * @param entry the entry
+     */
+    public void push(PathEntry entry) {
+        path.push(entry);
+    }
+
+    /**
+     * Remove and return top element from stack.
+     *
+     * @see Deque#pop()
+     * @return the top element of the stack
+     */
+    public PathEntry pop() {
+        return path.pop();
+    }
+
+    /**
+     * Create new entry and push to stack. Performs cycle detection.
+     *
+     * @param annotationTarget annotation target
+     * @param parentPathEntry parent path entry
+     * @param type the annotated type
+     * @param schema the schema corresponding to this position
+     */
+    public void push(AnnotationTarget annotationTarget,
+                     @NotNull PathEntry parentPathEntry,
+                     @NotNull Type type,
+                     @NotNull Schema schema) {
+        PathEntry entry = leafNode(parentPathEntry, annotationTarget, type, schema);
+        ClassInfo klazzInfo = entry.getClazz();
+        if (parentPathEntry.hasParent(entry)) {
+            // Cycle detected, don't push path.
+            //LOG.debugv("Possible cycle was detected at: {0}. Will not search further.", klazzInfo);
+            //LOG.debugv("Path: {0}", entry.toStringWithGraph());
+            if (schema.getDescription() == null) {
+                schema.description("Cyclic reference to " + klazzInfo.name());
+            }
+        } else {
+            // Push path to be inspected later.
+            //LOG.debugv("Adding child node to path: {0}", klazzInfo);
+            path.push(entry);
+        }
+    }
+
+    /**
+     * Create a root node (first entry in graph).
+     *
+     * @param annotationTarget annotation target
+     * @param type the annotated type
+     * @param classInfo the root classInfo
+     * @param rootSchema the schema corresponding to this position
+     * @return a new root node
+     */
+    public PathEntry rootNode(AnnotationTarget annotationTarget, ClassInfo classInfo, Type type, Schema rootSchema) {
+        return new PathEntry(null, annotationTarget, classInfo, type, rootSchema);
+    }
+
+    /**
+     * Create a leaf node (i.e. is attached to a parent)
+     *
+     * @param parentNode parent node
+     * @param annotationTarget annotation target
+     * @param classType the class type
+     * @param schema the schema
+     * @return the new leaf node
+     */
+    public PathEntry leafNode(PathEntry parentNode,
+                              AnnotationTarget annotationTarget,
+                              Type classType,
+                              Schema schema) {
+        ClassInfo classInfo = index.getClass(classType);
+        return new PathEntry(parentNode, annotationTarget, classInfo, classType, schema);
+    }
+
+    /**
+     * An entry on the object stack.
+     */
+    public static final class PathEntry {
+        private final PathEntry enclosing;
+        private final AnnotationTarget annotationTarget;
+        private final Type clazzType;
+        private final ClassInfo clazz;
+
+        // May be changed
+        private Schema schema;
+
+        private PathEntry(PathEntry enclosing,
+                  AnnotationTarget annotationTarget,
+                  @NotNull ClassInfo clazz,
+                  @NotNull Type clazzType,
+                  @NotNull Schema schema) {
+            this.enclosing = enclosing;
+            this.annotationTarget = annotationTarget;
+            this.clazz = clazz;
+            this.clazzType = clazzType;
+            this.schema = schema;
+        }
+
+        public boolean hasParent(PathEntry candidate) {
+            PathEntry test = this;
+            while (test != null) {
+                if (candidate.equals(test)) {
+                    return true;
+                }
+                test = test.enclosing;
+            }
+            return false;
+        }
+
+        public AnnotationTarget getAnnotationTarget() {
+            return annotationTarget;
+        }
+
+        public PathEntry getEnclosing() {
+            return enclosing;
+        }
+
+        public Type getClazzType() {
+            return clazzType;
+        }
+
+        public ClassInfo getClazz() {
+            return clazz;
+        }
+
+        public Schema getSchema() {
+            return schema;
+        }
+
+        public void setSchema(Schema schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            PathEntry otherEntry = (PathEntry) o;
+
+            boolean result = clazz != null ? clazz.equals(otherEntry.clazz) : otherEntry.clazz == null;
+
+            // For parameterized types, do a simple check of generic arguments to
+            // permit nested generic types like List<List<String>>.
+            if (this.clazzType.kind() == Type.Kind.PARAMETERIZED_TYPE &&
+                    otherEntry.clazzType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+                return result && argsEqual(otherEntry);
+            }
+
+            return result;
+        }
+
+        private boolean argsEqual(PathEntry otherPair) {
+            ParameterizedType thisClazzPType = clazzType.asParameterizedType();
+            ParameterizedType otherClazzPType = otherPair.clazzType.asParameterizedType();
+
+            List<Type> thisArgs = thisClazzPType.arguments();
+            List<Type> otherArgs = otherClazzPType.arguments();
+            return thisArgs.equals(otherArgs);
+        }
+
+        @Override
+        public int hashCode() {
+            return clazz != null ? clazz.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            return "PathEntry{" +
+                    "clazz=" + clazz +
+                    ", schema=" + schema +
+                    '}';
+        }
+
+//        public String toStringWithGraph() {
+//            return "PathEntry{" +
+//                    "clazz=" + clazz +
+//                    ", schema=" + schema +
+//                    ", parent=" + (enclosing != null ? enclosing.toStringWithGraph() : "<root>") + "}";
+//        }
+
+    }
+}

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import io.smallrye.openapi.runtime.util.TypeUtil;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Type;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class IgnoreResolver {
+
+//    private static final Logger LOG = Logger.getLogger(IgnoreResolver.class);
+    private final Map<DotName, IgnoreAnnotationHandler> IGNORE_ANNOTATION_MAP = new LinkedHashMap<>();
+    private final AugmentedIndexView index;
+
+    {
+        IgnoreAnnotationHandler[] ignoreHandlers = {
+                new JsonIgnorePropertiesHandler(),
+                new JsonIgnoreHandler(),
+                new JsonIgnoreTypeHandler()
+        };
+
+        for (IgnoreAnnotationHandler handler : ignoreHandlers) {
+            IGNORE_ANNOTATION_MAP.put(handler.getName(), handler);
+        }
+    }
+
+    public IgnoreResolver(AugmentedIndexView index) {
+        this.index = index;
+    }
+
+    public boolean isIgnore(AnnotationTarget annotationTarget, DataObjectDeque.PathEntry pathEntry) {
+        for (IgnoreAnnotationHandler handler : IGNORE_ANNOTATION_MAP.values()) {
+            boolean result = handler.shouldIgnore(annotationTarget, pathEntry);
+            if (result) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Handler for Jackson's {@link JsonIgnoreProperties}
+     */
+    private final class JsonIgnorePropertiesHandler implements IgnoreAnnotationHandler {
+
+        @Override
+        public boolean shouldIgnore(AnnotationTarget target, DataObjectDeque.PathEntry parentPathEntry) {
+
+            if (target.kind() == AnnotationTarget.Kind.FIELD) {
+                // First look at declaring class for @JsonIgnoreProperties
+                // Then look at enclosing type.
+                FieldInfo field = target.asField();
+                return declaringClassIgnore(field) || nestingFieldIgnore(parentPathEntry.getAnnotationTarget(), field.name());
+            } // TODO add method
+            return false;
+        }
+
+        // Declaring class ignore
+        //
+        //  @JsonIgnoreProperties("ignoreMe")
+        //  class A {
+        //    String ignoreMe;
+        //  }
+        private boolean declaringClassIgnore(FieldInfo field) {
+            AnnotationInstance declaringClassJIP = TypeUtil.getAnnotation(field.declaringClass(), getName());
+            return shouldIgnoreTarget(declaringClassJIP, field.name());
+        }
+
+        // Look for nested/enclosing type @JsonIgnoreProperties.
+        //
+        // class A {
+        //   @JsonIgnoreProperties("ignoreMe")
+        //   B foo;
+        // }
+        //
+        // class B {
+        //   String ignoreMe; // Ignored during scan via A.
+        //   String doNotIgnoreMe;
+        // }
+        private boolean nestingFieldIgnore(AnnotationTarget nesting, String fieldName) {
+            if (nesting == null) {
+                return false;
+            }
+            AnnotationInstance nestedTypeJIP = TypeUtil.getAnnotation(nesting, getName());
+            return shouldIgnoreTarget(nestedTypeJIP, fieldName);
+        }
+
+        private boolean shouldIgnoreTarget(AnnotationInstance jipAnnotation, String targetName) {
+            if (jipAnnotation == null || jipAnnotation.value() == null) {
+                return false;
+            }
+            String[] jipValues = jipAnnotation.value().asStringArray();
+            return Arrays.stream(jipValues).anyMatch(v -> v.equals(targetName));
+        }
+
+        @Override
+        public DotName getName() {
+            return DotName.createSimple(JsonIgnoreProperties.class.getName());
+        }
+    }
+
+    /**
+     * Handler for Jackson's @{@link JsonIgnore}
+     */
+    private final class JsonIgnoreHandler implements IgnoreAnnotationHandler {
+
+        @Override
+        public boolean shouldIgnore(AnnotationTarget target, DataObjectDeque.PathEntry parentPathEntry) {
+            AnnotationInstance annotationInstance = TypeUtil.getAnnotation(target, getName());
+            if (annotationInstance != null) {
+                return valueAsBooleanOrTrue(annotationInstance);
+            }
+            return false;
+        }
+
+        @Override
+        public DotName getName() {
+            return DotName.createSimple(JsonIgnore.class.getName());
+        }
+    }
+
+    /**
+     * Handler for @{@link JsonIgnoreType}
+     */
+    private final class JsonIgnoreTypeHandler implements IgnoreAnnotationHandler {
+        private Set<DotName> ignoredTypes = new LinkedHashSet<>();
+
+        @Override
+        public boolean shouldIgnore(AnnotationTarget target, DataObjectDeque.PathEntry parentPathEntry) {
+            Type classType;
+
+            if (target.kind() == AnnotationTarget.Kind.FIELD) {
+                classType = target.asField().type();
+            } else { // TODO add target.kind() method
+                return false;
+            }
+
+            // Primitive and non-indexed types will result in a null
+            if (classType.kind() == Type.Kind.PRIMITIVE ||
+                    classType.kind() == Type.Kind.VOID ||
+                    !index.containsClass(classType)) {
+                return false;
+            }
+
+            // Find the real class implementation where the @JsonIgnoreType annotation may be.
+            ClassInfo classInfo = index.getClass(classType);
+
+            if (ignoredTypes.contains(classInfo.name())) {
+                //LOG.debugv("Ignoring type that is member of ignore set: {0}", classInfo.name());
+                return true;
+            }
+
+            AnnotationInstance annotationInstance = TypeUtil.getAnnotation(classInfo, getName());
+            if (annotationInstance != null && valueAsBooleanOrTrue(annotationInstance)) {
+                // Add the ignored field or class name
+                //LOG.debugv("Ignoring type and adding to ignore set: {0}", classInfo.name());
+                ignoredTypes.add(classInfo.name());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public DotName getName() {
+            return DotName.createSimple(JsonIgnoreType.class.getName());
+        }
+    }
+
+    private boolean valueAsBooleanOrTrue(AnnotationInstance annotation) {
+        return Optional.ofNullable(annotation.value())
+                .map(AnnotationValue::asBoolean)
+                .orElse(true);
+    }
+
+    private interface IgnoreAnnotationHandler {
+        boolean shouldIgnore(AnnotationTarget target, DataObjectDeque.PathEntry parentPathEntry);
+
+        DotName getName();
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.runtime.util.TypeUtil;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+
+import static io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner.ARRAY_TYPE_OBJECT;
+import static io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner.COLLECTION_TYPE;
+import static io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner.ENUM_TYPE;
+import static io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner.MAP_TYPE;
+import static io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner.OBJECT_TYPE;
+import static io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner.STRING_TYPE;
+
+/**
+ * Process {@link Type} instances.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class TypeProcessor {
+//    private static final Logger LOG = Logger.getLogger(TypeProcessor.class);
+
+    private final Schema schema;
+    private final AugmentedIndexView index;
+    private final AnnotationTarget annotationTarget;
+    private final DataObjectDeque objectStack;
+    private final TypeResolver typeResolver;
+    private final DataObjectDeque.PathEntry parentPathEntry;
+
+    // Type may be changed.
+    private Type type;
+
+    public TypeProcessor(AugmentedIndexView index,
+                         DataObjectDeque objectStack,
+                         DataObjectDeque.PathEntry parentPathEntry, TypeResolver typeResolver,
+                         Type type,
+                         Schema schema,
+                         AnnotationTarget annotationTarget) {
+        this.objectStack = objectStack;
+        this.typeResolver = typeResolver;
+        this.parentPathEntry = parentPathEntry;
+        this.type = type;
+        this.schema = schema;
+        this.index = index;
+        this.annotationTarget = annotationTarget;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    public Type processType() {
+        // If it's a terminal type.
+        if (isTerminalType(type)) {
+            return type;
+        }
+
+        if (type.kind() == Type.Kind.WILDCARD_TYPE) {
+            type = TypeUtil.resolveWildcard(type.asWildcardType());
+        }
+
+        if (type.kind() == Type.Kind.ARRAY) {
+            //LOG.debugv("Processing an array {0}", type);
+            ArrayType arrayType = type.asArrayType();
+
+            // TODO handle multi-dimensional arrays.
+
+            // Array-type schema
+            SchemaImpl arrSchema = new SchemaImpl();
+            schema.type(Schema.SchemaType.ARRAY);
+            schema.items(arrSchema);
+
+            // Only use component (excludes the special name formatting for arrays).
+            TypeUtil.TypeWithFormat typeFormat = TypeUtil.getTypeFormat(arrayType.component());
+            arrSchema.setType(typeFormat.getSchemaType());
+            arrSchema.setFormat(typeFormat.getFormat().format());
+
+            // If it's not a terminal type, then push for later inspection.
+            if (!isTerminalType(arrayType.component()) && index.containsClass(type)) {
+                pushToStack(type, arrSchema);
+            }
+            return arrayType;
+        }
+
+        if (isA(type, ENUM_TYPE) && index.containsClass(type)) {
+            //LOG.debugv("Processing an enum {0}", type);
+            ClassInfo enumKlazz = index.getClass(type);
+
+            for (FieldInfo enumField : enumKlazz.fields()) {
+                // Ignore the hidden enum array as it's not accessible. Add fields that look like enums (of type enumKlazz)
+                // NB: Eclipse compiler and OpenJDK compiler have different names for this field.
+                if (!enumField.name().endsWith("$VALUES") && TypeUtil.getName(enumField.type()).equals(enumKlazz.name())) {
+                    // Enum's value fields.
+                    schema.addEnumeration(enumField.name());
+                }
+            }
+            return STRING_TYPE;
+        }
+
+        if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            // Parameterised type (e.g. Foo<A, B>)
+            //return readParamType(annotationTarget, pathEntry, schema, fieldType.asParameterizedType(), typeResolver);
+            return readParameterizedType(type.asParameterizedType());
+        }
+
+        if (type.kind() == Type.Kind.TYPE_VARIABLE ||
+                type.kind() == Type.Kind.UNRESOLVED_TYPE_VARIABLE) {
+            // Resolve type variable to real variable.
+            //return resolveTypeVariable(annotationTarget, typeResolver, schema, pathEntry, fieldType);
+            return resolveTypeVariable(schema, type);
+        }
+
+        // Raw Collection
+        if (isA(type, COLLECTION_TYPE)) {
+            return ARRAY_TYPE_OBJECT;
+        }
+
+        // Raw Map
+        if (isA(type, MAP_TYPE)) {
+            return OBJECT_TYPE;
+        }
+
+        // Simple case: bare class or primitive type.
+        if (index.containsClass(type)) {
+            pushToStack(type);
+        } else {
+            // If the type is not in Jandex then we don't have easy access to it.
+            // Future work could consider separate code to traverse classes reachable from this classloader.
+//            LOG.debugv("Encountered type not in Jandex index that is not well-known type. " +
+//                    "Will not traverse it: {0}", type);
+        }
+
+        return type;
+    }
+
+    private Type readParameterizedType(ParameterizedType pType) {
+        //LOG.debugv("Processing parameterized type {0}", pType);
+
+        // If it's a collection, we should treat it as an array.
+        if (isA(pType, COLLECTION_TYPE)) { // TODO maybe also Iterable?
+            //LOG.debugv("Processing Java Collection. Will treat as an array.");
+            SchemaImpl arraySchema = new SchemaImpl();
+            schema.type(Schema.SchemaType.ARRAY);
+            schema.items(arraySchema);
+
+            // Should only have one arg for collection.
+            Type arg = pType.arguments().get(0);
+
+            if (isTerminalType(arg)) {
+                TypeUtil.TypeWithFormat terminalType = TypeUtil.getTypeFormat(arg);
+                arraySchema.type(terminalType.getSchemaType());
+                arraySchema.format(terminalType.getFormat().format());
+            } else {
+                resolveParameterizedType(arg, arraySchema);
+            }
+            return ARRAY_TYPE_OBJECT; // Representing collection as JSON array
+        } else if (isA(pType, MAP_TYPE)) {
+            //LOG.debugv("Processing Map. Will treat as an object.");
+            schema.type(Schema.SchemaType.OBJECT);
+
+            if (pType.arguments().size() == 2) {
+                Type valueType = pType.arguments().get(1);
+                SchemaImpl propsSchema = new SchemaImpl();
+                if (isTerminalType(valueType)) {
+                    TypeUtil.TypeWithFormat tf = TypeUtil.getTypeFormat(valueType);
+                    propsSchema.setType(tf.getSchemaType());
+                    propsSchema.setFormat(tf.getFormat().format());
+                } else {
+                    resolveParameterizedType(valueType, propsSchema);
+                }
+                // Add properties schema to field schema.
+                schema.additionalProperties(propsSchema);
+            }
+            return OBJECT_TYPE;
+        } else {
+            // This type will be resolved later, if necessary.
+            pushToStack(pType);
+            return pType;
+        }
+    }
+
+    private void resolveParameterizedType(Type valueType, SchemaImpl propsSchema) {
+        if (valueType.kind() == Type.Kind.TYPE_VARIABLE ||
+                valueType.kind() == Type.Kind.UNRESOLVED_TYPE_VARIABLE ||
+                valueType.kind() == Type.Kind.WILDCARD_TYPE) {
+            Type resolved = resolveTypeVariable(propsSchema, valueType);
+            if (index.containsClass(resolved)) {
+                propsSchema.type(Schema.SchemaType.OBJECT);
+            }
+        } else if (index.containsClass(valueType)) {
+            propsSchema.type(Schema.SchemaType.OBJECT);
+            pushToStack(valueType, propsSchema);
+        }
+    }
+
+    private Type resolveTypeVariable(Schema schema, Type fieldType) {
+        // Type variable (e.g. A in Foo<A>)
+        Type resolvedType = typeResolver.getResolvedType(fieldType);
+
+        //LOG.debugv("Resolved type {0} -> {1}", fieldType, resolvedType);
+        if (isTerminalType(resolvedType) || !index.containsClass(resolvedType)) {
+            //LOG.debugv("Is a terminal type {0}", resolvedType);
+            TypeUtil.TypeWithFormat replacement = TypeUtil.getTypeFormat(resolvedType);
+            schema.setType(replacement.getSchemaType());
+            schema.setFormat(replacement.getFormat().format());
+        } else {
+            //LOG.debugv("Attempting to do TYPE_VARIABLE substitution: {0} -> {1}", fieldType, resolvedType);
+            if (index.containsClass(resolvedType)) {
+                // Add resolved type to stack.
+                objectStack.push(annotationTarget, parentPathEntry, resolvedType, schema);
+            } else {
+                //LOG.debugv("Class for type {0} not available", resolvedType);
+            }
+        }
+        return resolvedType;
+    }
+
+    private void pushToStack(Type fieldType) {
+        objectStack.push(annotationTarget, parentPathEntry, fieldType, schema);
+    }
+
+    private void pushToStack(Type resolvedType, Schema schema) {
+        objectStack.push(annotationTarget, parentPathEntry, resolvedType, schema);
+    }
+
+    private boolean isA(Type testSubject, Type test) {
+        return TypeUtil.isA(index, testSubject, test);
+    }
+
+    private boolean isTerminalType(Type type) {
+        if (type.kind() == Type.Kind.TYPE_VARIABLE ||
+                type.kind() == Type.Kind.WILDCARD_TYPE ||
+                type.kind() == Type.Kind.ARRAY) {
+            return false;
+        }
+
+        if (type.kind() == Type.Kind.PRIMITIVE ||
+                type.kind() == Type.Kind.VOID) {
+            return true;
+        }
+
+        TypeUtil.TypeWithFormat tf = TypeUtil.getTypeFormat(type);
+        // If is known type.
+        return tf.getSchemaType() != Schema.SchemaType.OBJECT &&
+                tf.getSchemaType() != Schema.SchemaType.ARRAY;
+    }
+}

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -13,24 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.smallrye.openapi.runtime.scanner;
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import io.smallrye.openapi.runtime.util.TypeUtil;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.validation.constraints.NotNull;
-
-import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.FieldInfo;
-import org.jboss.jandex.IndexView;
-import org.jboss.jandex.ParameterizedType;
-import org.jboss.jandex.Type;
-import org.jboss.jandex.TypeVariable;
-
-import io.smallrye.openapi.runtime.util.TypeUtil;
 
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
@@ -76,7 +72,7 @@ public class TypeResolver {
         return current;
     }
 
-    public static Map<FieldInfo, TypeResolver> getAllFields(IndexView index, Type leaf, ClassInfo leafKlazz) {
+    public static Map<FieldInfo, TypeResolver> getAllFields(AugmentedIndexView index, Type leaf, ClassInfo leafKlazz) {
         Map<FieldInfo, TypeResolver> fields = new LinkedHashMap<>();
         Type currentType = leaf;
         ClassInfo currentClass = leafKlazz;
@@ -99,7 +95,7 @@ public class TypeResolver {
                 break;
             }
 
-            currentClass = getClassByName(index, currentType);
+            currentClass = index.getClass(currentType);
 
             if (currentClass == null) {
                 break;
@@ -126,10 +122,6 @@ public class TypeResolver {
         }
 
         return resolutionMap;
-    }
-
-    private  static ClassInfo getClassByName(IndexView index, @NotNull Type type) {
-        return index.getClassByName(TypeUtil.getName(type));
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -15,17 +15,10 @@
  */
 package io.smallrye.openapi.runtime.util;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import javax.validation.constraints.NotNull;
-
+import io.smallrye.openapi.api.OpenApiConstants;
 import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
@@ -34,7 +27,15 @@ import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.WildcardType;
 
-import io.smallrye.openapi.api.OpenApiConstants;
+import javax.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
@@ -214,7 +215,7 @@ public class TypeUtil {
         }
     }
 
-    public static Type resolveWildcard(WildcardType wildcardType) { // TODO move to typeutil?
+    public static Type resolveWildcard(WildcardType wildcardType) {
         return TypeUtil.getBound(wildcardType);
     }
 
@@ -223,6 +224,11 @@ public class TypeUtil {
             return type;
         }
         return TypeUtil.getBound(type.asWildcardType());
+    }
+
+
+    public static AnnotationInstance getSchemaAnnotation(AnnotationTarget annotationTarget) {
+        return getAnnotation(annotationTarget, OpenApiConstants.DOTNAME_SCHEMA);
     }
 
     public static AnnotationInstance getSchemaAnnotation(ClassInfo field) {
@@ -235,6 +241,32 @@ public class TypeUtil {
 
     public static AnnotationInstance getSchemaAnnotation(Type type) {
         return getAnnotation(type, OpenApiConstants.DOTNAME_SCHEMA);
+    }
+
+    public static AnnotationInstance getAnnotation(AnnotationTarget annotationTarget, DotName annotationName) {
+        if (annotationTarget == null) {
+            return null;
+        }
+        return getAnnotations(annotationTarget).stream()
+                .filter(annotation -> annotation.name().equals(annotationName))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static Collection<AnnotationInstance> getAnnotations(AnnotationTarget type) {
+        switch (type.kind()) {
+            case CLASS:
+                return type.asClass().classAnnotations();
+            case FIELD:
+                return type.asField().annotations();
+            case METHOD:
+                return type.asMethod().annotations();
+            case METHOD_PARAMETER:
+                break;
+            case TYPE:
+                break;
+        }
+        return Collections.emptyList();
     }
 
     public static AnnotationInstance getAnnotation(Type type, DotName annotationName) {

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
@@ -15,22 +15,20 @@
  */
 package io.smallrye.openapi.runtime.scanner;
 
-import static org.jboss.jandex.DotName.createSimple;
-
-import java.io.IOException;
-
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
-import org.junit.Ignore;
 import org.junit.Test;
-
 import test.io.smallrye.openapi.runtime.scanner.entities.Bar;
 import test.io.smallrye.openapi.runtime.scanner.entities.BuzzLinkedList;
 import test.io.smallrye.openapi.runtime.scanner.entities.EnumContainer;
 import test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer;
+
+import java.io.IOException;
+
+import static org.jboss.jandex.DotName.createSimple;
 
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
@@ -41,7 +39,6 @@ public class ExpectationTests extends OpenApiDataObjectScannerTestBase {
      * Unresolvable type parameter.
      */
     @Test
-    @Ignore
     public void testUnresolvable() throws IOException, JSONException {
         DotName bar = createSimple(Bar.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, ClassType.create(bar, Type.Kind.CLASS));

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner;
+
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Type;
+import org.json.JSONException;
+import org.junit.Test;
+import test.io.smallrye.openapi.runtime.scanner.entities.IgnoreTestContainer;
+import test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreOnFieldExample;
+import test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreTypeExample;
+
+import java.io.IOException;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class IgnoreTests extends OpenApiDataObjectScannerTestBase {
+
+    // Always ignore nominated properties when given class is used.
+    @Test
+    public void testIgnore_jsonIgnorePropertiesOnClass() throws IOException, JSONException {
+        String name = IgnoreTestContainer.class.getName();
+        Type type = getFieldFromKlazz(name, "jipOnClassTest").type();
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, type);
+
+        Schema result = scanner.process();
+
+        printToConsole(name, result);
+        assertJsonEquals(name, "ignore.jsonIgnorePropertiesOnClass.expected.json", result);
+    }
+
+    // Ignore nominated properties of the field in this instance only.
+    @Test
+    public void testIgnore_jsonIgnorePropertiesOnField() throws IOException, JSONException {
+        String name = IgnoreTestContainer.class.getName();
+        FieldInfo fieldInfo = getFieldFromKlazz(name, "jipOnFieldTest");
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, fieldInfo, fieldInfo.type());
+
+        Schema result = scanner.process();
+
+        printToConsole(name, result);
+        assertJsonEquals(name, "ignore.jsonIgnorePropertiesOnField.expected.json", result);
+    }
+
+    // Entirely ignore a single field once.
+    @Test
+    public void testIgnore_jsonIgnoreField() throws IOException, JSONException {
+        DotName name = DotName.createSimple(JsonIgnoreOnFieldExample.class.getName());
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+                ClassType.create(name, Type.Kind.CLASS));
+
+        Schema result = scanner.process();
+
+        printToConsole(name.local(), result);
+        assertJsonEquals(name.local(), "ignore.jsonIgnoreField.expected.json", result);
+    }
+
+    // Entirely ignore a single field once.
+    @Test
+    public void testIgnore_jsonIgnoreType() throws IOException, JSONException {
+        DotName name = DotName.createSimple(JsonIgnoreTypeExample.class.getName());
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+                ClassType.create(name, Type.Kind.CLASS));
+
+        Schema result = scanner.process();
+
+        printToConsole(name.local(), result);
+        assertJsonEquals(name.local(), "ignore.jsonIgnoreType.expected.json", result);
+    }
+
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/IgnoreTestContainer.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/IgnoreTestContainer.java
@@ -1,0 +1,14 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class IgnoreTestContainer {
+    // Should ignore @JsonIgnoreProperty nominated properties for this instance only.
+    @JsonIgnoreProperties({"aLongProperty"})
+    SimpleValues jipOnFieldTest;
+
+    JsonIgnorePropertiesOnClassExample jipOnClassTest;
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/IgnoreType.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/IgnoreType.java
@@ -1,0 +1,10 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+@JsonIgnoreType
+public class IgnoreType {
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JsonIgnoreOnFieldExample.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JsonIgnoreOnFieldExample.java
@@ -1,0 +1,15 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+
+public class JsonIgnoreOnFieldExample {
+    // Should be ignored by virtue of @JsonIgnore
+    @JsonIgnore
+    String jsonIgnoreThisField;
+
+    String thisFieldShouldAppear;
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JsonIgnorePropertiesOnClassExample.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JsonIgnorePropertiesOnClassExample.java
@@ -1,0 +1,18 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+@JsonIgnoreProperties({"jsonIgnoreProperties1", "jsonIgnoreProperties2"})
+public class JsonIgnorePropertiesOnClassExample {
+    // Should be ignored by virtue of @JsonIgnoreProperties on class
+    String jsonIgnoreProperties1;
+
+    // Should be ignored by virtue of @JsonIgnoreProperties on class
+    String jsonIgnoreProperties2;
+
+    // Should be present
+    String shouldBePresent;
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JsonIgnoreTypeExample.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JsonIgnoreTypeExample.java
@@ -1,0 +1,18 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class JsonIgnoreTypeExample {
+    // Should always be ignored by virtue of @JsonIgnoreType annotation
+    IgnoreThisType shouldBeIgnoredType;
+    IgnoreThisType shouldBeIgnoredType2;
+    int shouldBePresent;
+
+    @JsonIgnoreType
+    private static final class IgnoreThisType {
+        int foo;
+    }
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/SimpleValues.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/SimpleValues.java
@@ -1,0 +1,10 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class SimpleValues {
+    String aStringProperty;
+    Integer anIntegerProperty;
+    Long aLongProperty;
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnoreField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnoreField.expected.json
@@ -1,0 +1,13 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreOnFieldExample" : {
+        "properties" : {
+          "thisFieldShouldAppear" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnorePropertiesOnClass.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnorePropertiesOnClass.expected.json
@@ -1,0 +1,13 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.IgnoreTestContainer" : {
+        "properties" : {
+          "shouldBePresent" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnorePropertiesOnField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnorePropertiesOnField.expected.json
@@ -1,0 +1,17 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.IgnoreTestContainer" : {
+        "properties" : {
+          "aStringProperty" : {
+            "type" : "string"
+          },
+          "anIntegerProperty" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnoreType.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnoreType.expected.json
@@ -1,0 +1,14 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreTypeExample" : {
+        "properties" : {
+          "shouldBePresent" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/unresolvable.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/unresolvable.expected.json
@@ -1,16 +1,22 @@
 {
-  "components": {
-    "schemas": {
-      "test.io.smallrye.openapi.runtime.scanner.entities.Bar": {
-        "properties": {
-          "theQ": {
-            "type": "object"
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.Bar" : {
+        "properties" : {
+          "theQ" : {
+            "type" : "object"
           },
-          "theT": {
-            "type": "object"
+          "theT" : {
+            "type" : "object",
+            "properties" : {
+              "an_integer_value" : {
+                "format" : "int32",
+                "type" : "integer"
+              }
+            }
           },
-          "ultimateTShouldBeQ": {
-            "type": "object"
+          "ultimateTShouldBeQ" : {
+            "type" : "object"
           }
         }
       }


### PR DESCRIPTION
To facilitate this improvement cleanly, and make future changes and maintenance much easier, I did a substantial refactoring and modularisation of `OpenApiDataObjectScanner`.

`@JsonIgnore`, `@JsonIgnoreProperties`, and `@JsonIgnoreType` should all function now -- hopefully in the same way as in Jackson itself. 

I also took this opportunity to fix some bugs that were outstanding, such as cycle detection for certain nested generic types (cycle detection for nested generics was being skipped previously, but would break if it had been used).

I have a few small aspects to review with Eric before this is finalised.

Fixes #13 