### PR TITLE
Paths are duplicated if @ApplicationPath contains more than "/"

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -134,7 +134,6 @@ public class OpenApiAnnotationScanner {
 
     private OpenAPIImpl oai;
 
-    private String currentAppPath = "";
     private String currentResourcePath = "";
     private String[] currentConsumes;
     private String[] currentProduces;
@@ -203,18 +202,6 @@ public class OpenApiAnnotationScanner {
     private OpenAPIImpl jaxRsApplicationToOpenApi(ClassInfo applicationClass) {
         OpenAPIImpl oai = new OpenAPIImpl();
         oai.setOpenapi(OpenApiConstants.OPEN_API_VERSION);
-
-        // Get the @ApplicationPath info and save it for later (also support @Path which seems nonstandard but common).
-        ////////////////////////////////////////
-        AnnotationInstance appPathAnno = JandexUtil.getClassAnnotation(applicationClass, OpenApiConstants.DOTNAME_APPLICATION_PATH);
-        if (appPathAnno == null) {
-            appPathAnno = JandexUtil.getClassAnnotation(applicationClass, OpenApiConstants.DOTNAME_PATH);
-        }
-        if (appPathAnno != null) {
-            this.currentAppPath = appPathAnno.value().asString();
-        } else {
-            this.currentAppPath = "/";
-        }
 
         // Get the @OpenAPIDefinition annotation and process it.
         ////////////////////////////////////////
@@ -366,14 +353,14 @@ public class OpenApiAnnotationScanner {
 
         LOG.debugf("Processing jax-rs method: {0}", method.toString());
 
-        // Figure out the path for the operation.  This is a combination of the App, Resource, and Method @Path annotations
+        // Figure out the path for the operation.  This is a combination of Resource and Method @Path annotations
         String path;
         if (method.hasAnnotation(OpenApiConstants.DOTNAME_PATH)) {
             AnnotationInstance pathAnno = method.annotation(OpenApiConstants.DOTNAME_PATH);
             String methodPath = pathAnno.value().asString();
-            path = makePath(this.currentAppPath, this.currentResourcePath, methodPath);
+            path = makePath(this.currentResourcePath, methodPath);
         } else {
-            path = makePath(this.currentAppPath, this.currentResourcePath);
+            path = makePath(this.currentResourcePath);
         }
 
         // Get or create a PathItem to hold the operation

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScannerTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScannerTest.java
@@ -38,12 +38,6 @@ public class OpenApiAnnotationScannerTest {
         path = OpenApiAnnotationScanner.makePath("", "/bookings");
         Assert.assertEquals("/bookings", path);
 
-        path = OpenApiAnnotationScanner.makePath("/api", "/bookings");
-        Assert.assertEquals("/api/bookings", path);
-
-        path = OpenApiAnnotationScanner.makePath("api", "bookings");
-        Assert.assertEquals("/api/bookings", path);
-
         path = OpenApiAnnotationScanner.makePath("/", "/bookings", "{id}");
         Assert.assertEquals("/bookings/{id}", path);
     }


### PR DESCRIPTION
With a static file like 

```yaml
openapi: 3.0.1
servers:
- url: http://localhost:8080/api
paths:
  /customers:
```
and a JAXRS Application like 
```java
@ApplicationPath("/api")
public class RestApplication extends Application { 
}
```
The generated document at `/openapi` contains 

```yaml
---
openapi: 3.0.1
servers:
- url: http://localhost:8080/api
paths:
  /customers:
    get:
      ...
  /api/customers:
    get:
      ...
```
This is because the `OpenApiAnnotationScanner` uses the value of `@ApplicationPath` for creating the paths in the OpenAPI document. 
This PR fixes this by ignoring the application path completely during annotation scanning.
