### PR TITLE
Added support for CompletionStage and extensions

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
@@ -16,6 +16,8 @@
 
 package io.smallrye.openapi.api;
 
+import java.util.concurrent.CompletionStage;
+
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
@@ -243,6 +245,8 @@ public final class OpenApiConstants {
     public static final DotName DOTNAME_PATCH = DotName.createSimple(PATCH.class.getName());
 
     public static final DotName DOTNAME_RESPONSE = DotName.createSimple(Response.class.getName());
+
+    public static final DotName COMPLETION_STAGE_NAME = DotName.createSimple(CompletionStage.class.getName());
 
     public static final String[] DEFAULT_CONSUMES = new String[] {MIME_ANY};
     public static final String[] DEFAULT_PRODUCES = new String[] {MIME_ANY};

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
@@ -1,0 +1,55 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
+
+import io.smallrye.openapi.runtime.util.JandexUtil.JaxRsParameterInfo;
+
+/**
+ * Extension point for supporting extensions to JAX-RS.
+ */
+public class AnnotationScannerExtension {
+
+    /**
+     * Determines where an @Parameter can be found (examples include Query,
+     * Path, Header, Cookie, etc).
+     * 
+     * @param paramInfo
+     * @return the parameter location, or null if unknown
+     */
+    public In parameterIn(MethodParameterInfo paramInfo) {
+        return null;
+    }
+
+    /**
+     * Returns jax-rs info about the parameter at the given index. If the index
+     * is invalid or does not refer to a jax-rs parameter then this should
+     * return null. Otherwise it will return a {@link JaxRsParameterInfo} object
+     * with the name and type of the param.
+     * 
+     * @param method
+     *            MethodInfo
+     * @param idx
+     *            index of parameter
+     * @return JaxRsParameterInfo or null if unknown.
+     */
+    public JaxRsParameterInfo getMethodParameterJaxRsInfo(MethodInfo method, int idx) {
+        return null;
+    }
+
+    /**
+     * Unwraps an asynchronous type such as
+     * <code>CompletionStage&lt;X&gt;</code> into its resolved type
+     * <code>X</code>
+     * 
+     * @param type
+     *            the type to unwrap if it is a supported async type
+     * @return the resolved type or null if not supported
+     */
+    public Type resolveAsyncType(Type type) {
+        return null;
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
@@ -1,6 +1,9 @@
 package io.smallrye.openapi.runtime.scanner;
 
+import java.util.Collection;
+
 import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.Type;
@@ -50,6 +53,14 @@ public class AnnotationScannerExtension {
      */
     public Type resolveAsyncType(Type type) {
         return null;
+    }
+
+    /**
+     * Gives a chance to extensions to process the set of jax-rs application classes.
+     * @param scanner the scanner used for application scanning
+     * @param applications the set of jax-rs application classes
+     */
+    public void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications) {
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
@@ -13,7 +13,7 @@ import io.smallrye.openapi.runtime.util.JandexUtil.JaxRsParameterInfo;
 /**
  * Extension point for supporting extensions to JAX-RS.
  */
-public class AnnotationScannerExtension {
+public interface AnnotationScannerExtension {
 
     /**
      * Determines where an @Parameter can be found (examples include Query,
@@ -22,7 +22,7 @@ public class AnnotationScannerExtension {
      * @param paramInfo
      * @return the parameter location, or null if unknown
      */
-    public In parameterIn(MethodParameterInfo paramInfo) {
+    public default In parameterIn(MethodParameterInfo paramInfo) {
         return null;
     }
 
@@ -38,7 +38,7 @@ public class AnnotationScannerExtension {
      *            index of parameter
      * @return JaxRsParameterInfo or null if unknown.
      */
-    public JaxRsParameterInfo getMethodParameterJaxRsInfo(MethodInfo method, int idx) {
+    public default JaxRsParameterInfo getMethodParameterJaxRsInfo(MethodInfo method, int idx) {
         return null;
     }
 
@@ -51,7 +51,7 @@ public class AnnotationScannerExtension {
      *            the type to unwrap if it is a supported async type
      * @return the resolved type or null if not supported
      */
-    public Type resolveAsyncType(Type type) {
+    public default Type resolveAsyncType(Type type) {
         return null;
     }
 
@@ -60,7 +60,7 @@ public class AnnotationScannerExtension {
      * @param scanner the scanner used for application scanning
      * @param applications the set of jax-rs application classes
      */
-    public void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications) {
+    public default void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications) {
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/DefaultAnnotationScannerExtension.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/DefaultAnnotationScannerExtension.java
@@ -11,11 +11,9 @@ import org.jboss.jandex.Type;
 import io.smallrye.openapi.runtime.util.JandexUtil.JaxRsParameterInfo;
 
 /**
- * Extension point for supporting extensions to JAX-RS. Implement this directly or extend {@link DefaultAnnotationScannerExtension}.
- * 
- * @see DefaultAnnotationScannerExtension
+ * Default extension point for supporting extensions to JAX-RS.
  */
-public interface AnnotationScannerExtension {
+public class DefaultAnnotationScannerExtension implements AnnotationScannerExtension {
 
     /**
      * Determines where an @Parameter can be found (examples include Query,
@@ -24,7 +22,9 @@ public interface AnnotationScannerExtension {
      * @param paramInfo
      * @return the parameter location, or null if unknown
      */
-    public In parameterIn(MethodParameterInfo paramInfo);
+    public In parameterIn(MethodParameterInfo paramInfo) {
+        return null;
+    }
 
     /**
      * Returns jax-rs info about the parameter at the given index. If the index
@@ -38,7 +38,9 @@ public interface AnnotationScannerExtension {
      *            index of parameter
      * @return JaxRsParameterInfo or null if unknown.
      */
-    public JaxRsParameterInfo getMethodParameterJaxRsInfo(MethodInfo method, int idx);
+    public JaxRsParameterInfo getMethodParameterJaxRsInfo(MethodInfo method, int idx) {
+        return null;
+    }
 
     /**
      * Unwraps an asynchronous type such as
@@ -49,13 +51,16 @@ public interface AnnotationScannerExtension {
      *            the type to unwrap if it is a supported async type
      * @return the resolved type or null if not supported
      */
-    public Type resolveAsyncType(Type type);
+    public Type resolveAsyncType(Type type) {
+        return null;
+    }
 
     /**
      * Gives a chance to extensions to process the set of jax-rs application classes.
      * @param scanner the scanner used for application scanning
      * @param applications the set of jax-rs application classes
      */
-    public void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications);
+    public void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications) {
+    }
 
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.core.Application;
 
@@ -130,8 +129,6 @@ import io.smallrye.openapi.runtime.util.ModelUtil;
  * @author eric.wittmann@gmail.com
  */
 public class OpenApiAnnotationScanner {
-
-    private static final DotName COMPLETION_STAGE_NAME = DotName.createSimple(CompletionStage.class.getName());
 
     private static Logger LOG = Logger.getLogger(OpenApiAnnotationScanner.class);
 
@@ -783,7 +780,7 @@ public class OpenApiAnnotationScanner {
     private Type resolveAsyncType(Type type) {
         if(type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
             ParameterizedType pType = type.asParameterizedType();
-            if(pType.name().equals(COMPLETION_STAGE_NAME)
+            if(pType.name().equals(OpenApiConstants.COMPLETION_STAGE_NAME)
                     && pType.arguments().size() == 1)
                 return pType.arguments().get(0);
         }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -182,6 +182,10 @@ public class OpenApiAnnotationScanner {
         for (ClassInfo classInfo : applications) {
             oai = MergeUtil.merge(oai, jaxRsApplicationToOpenApi(classInfo));
         }
+        // this can be a useful extension point to set/override the application path
+        for (AnnotationScannerExtension extension : extensions) {
+            extension.processJaxRsApplications(this, applications);
+        }
 
         // TODO find all OpenAPIDefinition annotations at the package level
 
@@ -2005,6 +2009,10 @@ public class OpenApiAnnotationScanner {
         public boolean has(ClassType instanceClass) {
             return registry.containsKey(instanceClass.name());
         }
+    }
+
+    public void setCurrentAppPath(String path) {
+        this.currentAppPath = path;
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -467,7 +467,7 @@ public class JandexUtil {
      * @param parameterIndex
      * @param annotationName
      */
-    private static AnnotationInstance getMethodParameterAnnotation(MethodInfo method, int parameterIndex,
+    public static AnnotationInstance getMethodParameterAnnotation(MethodInfo method, int parameterIndex,
             DotName annotationName) {
         for (AnnotationInstance annotation : method.annotations()) {
             if (annotation.target().kind() == Kind.METHOD_PARAMETER &&

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.jboss.arquillian>1.1.13.Final</version.org.jboss.arquillian>
         <version.org.jboss.arquillian.container.weld-embedded>2.0.0.Final</version.org.jboss.arquillian.container.weld-embedded>
-        <version.org.jboss.jandex>2.0.5.Final</version.org.jboss.jandex>
+        <version.org.jboss.jandex>2.1.0.Beta3</version.org.jboss.jandex>
         <version.org.jboss.logging>3.3.2.Final</version.org.jboss.logging>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>


### PR DESCRIPTION
This is a preview PR for #46

Don't merge it until https://github.com/wildfly/jandex/pull/43 is merged and jandex is released. However, this should support:

- the JAX-RS 2.1 return type of `CompletionStage`
- the ability to register extensions to the scanning process for:
    - custom types such as RESTEasy `@*Param` that use the method parameter name
    - custom async return types such as RESTEasy support for RxJava 1&2 `Single`

Please review so we can get this merged ASAP when Jandex is released. Thanks.