### PR TITLE
Update 'version.eclipse.microprofile.openapi' to '1.1-RC1'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,19 +27,6 @@
         <version>1</version>
     </parent>
 
-    <repositories>
-        <repository>
-            <id>snapshots-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <artifactId>smallrye-open-api-parent</artifactId>
     <version>1.1.0-SNAPSHOT</version>
 
@@ -52,7 +39,7 @@
         <version.com.fasterxml.jackson.dataformat>2.9.2</version.com.fasterxml.jackson.dataformat>
         <version.commons-logging>1.2</version.commons-logging>
         <version.eclipse.microprofile.config>1.3</version.eclipse.microprofile.config>
-        <version.eclipse.microprofile.openapi>1.1-SNAPSHOT</version.eclipse.microprofile.openapi>
+        <version.eclipse.microprofile.openapi>1.1-RC1</version.eclipse.microprofile.openapi>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
         <version.javax.annotation-api>1.2</version.javax.annotation-api>
         <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>


### PR DESCRIPTION
[`1.1-RC1`](https://github.com/eclipse/microprofile-open-api/releases/tag/mp-openapi-1.1-RC1) is released. Use this version instead of `1.1-SNAPSHOT`