### PR TITLE
Run TCK on random free port.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <properties>
         <version.asciidoctor.plugin>1.5.7.1</version.asciidoctor.plugin>
+        <version.buildhelper.plugin>3.0.0</version.buildhelper.plugin>
         <version.com.fasterxml.jackson>2.9.8</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.dataformat>2.9.8</version.com.fasterxml.jackson.dataformat>
         <version.commons-io>2.6</version.commons-io>
@@ -283,6 +284,11 @@
                             <organization>${project.organization.name}</organization>
                         </attributes>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>{version.buildhelper.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -85,6 +85,27 @@
 
     <build>
         <plugins>
+            <!-- Reserve random free port for TCK -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${version.buildhelper.plugin}</version>
+                <executions>
+                    <execution>
+                        <id>reserve-network-port</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <portNames>
+                                <portName>smallrye.openapi.server.port</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Export the reserved port from above as a system property (code will use a default port if port unset) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -95,6 +116,11 @@
                         <version>${version.surefire.plugin}</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <systemPropertyVariables>
+                        <smallrye.openapi.server.port>${smallrye.openapi.server.port}</smallrye.openapi.server.port>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Use builder-helper-maven-plugin's reserve-network-port to reserve a
random free port and export to a Maven Property. Maven-surefire-plugin
exports this to the Java System Property `smallrye.openapi.server.port`.

If `smallrye.openapi.server.port` is unset or empty, the test port will
default to 8080.

Fixes #57

Signed-off-by: Marc Savy <marc@rhymewithgravy.com>