### PR TITLE
addAPIResponse() should not call remove for null values

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/models/responses/APIResponsesImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/models/responses/APIResponsesImpl.java
@@ -77,11 +77,7 @@ public class APIResponsesImpl extends LinkedHashMap<String, APIResponse> impleme
      */
     @Override
     public APIResponses addAPIResponse(String name, APIResponse apiResponse) {
-        if (apiResponse == null) {
-            this.removeAPIResponse(name);
-        } else {
-            this.put(name, apiResponse);
-        }
+        this.put(name, apiResponse);
         return this;
     }
 
@@ -117,7 +113,11 @@ public class APIResponsesImpl extends LinkedHashMap<String, APIResponse> impleme
      */
     @Override
     public void setDefaultValue(APIResponse defaultValue) {
-        addAPIResponse(DEFAULT, defaultValue);
+        if (defaultValue == null) {
+            removeAPIResponse(DEFAULT);
+        } else {
+            addAPIResponse(DEFAULT, defaultValue);
+        }
     }
 
     /**
@@ -125,7 +125,11 @@ public class APIResponsesImpl extends LinkedHashMap<String, APIResponse> impleme
      */
     @Override
     public APIResponses defaultValue(APIResponse defaultValue) {
-        addAPIResponse(DEFAULT, defaultValue);
+        if (defaultValue == null) {
+            removeAPIResponse(DEFAULT);
+        } else {
+            addAPIResponse(DEFAULT, defaultValue);
+        }
         return this;
     }
 


### PR DESCRIPTION
As discussed by @EricWittmann in https://github.com/eclipse/microprofile-open-api/issues/323#issuecomment-450882166:

>  I don't think the `addX` methods should be able to remove items.