### PR TITLE
Read static openapi.yaml from WEB-INF

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/util/ArchiveUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/util/ArchiveUtil.java
@@ -83,7 +83,7 @@ public class ArchiveUtil {
         // Check for the file in both META-INF and WEB-INF/classes/META-INF
         Node node = archive.get("/META-INF/openapi.yaml");
         if (node == null) {
-            node = archive.get("/WEB-INF/classes/META-INF/openapi.yml");
+            node = archive.get("/WEB-INF/classes/META-INF/openapi.yaml");
         }
         if (node == null) {
             node = archive.get("/META-INF/openapi.yml");


### PR DESCRIPTION
Fixed the code part reading static OpenApi documents.
It tries to get openapi.yaml, openapi.yml or openapi.json from META-INF or WEB-INF directories.
By a mistake it tried to read openapi.yml from WEB-INF twice, instead of reading openapi.yaml first.