### PR TITLE
Ignore hidden schema properties, add support for JSON-B name override

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -35,13 +35,13 @@
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
         </dependency>
-        
+
         <!-- MP Config Spec -->
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
-        
+
         <!-- Third Party Libraries -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -83,7 +83,7 @@
             <artifactId>validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- Test Only Dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -93,6 +93,11 @@
         <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.json.bind</groupId>
+            <artifactId>javax.json.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
@@ -249,6 +249,9 @@ public final class OpenApiConstants {
 
     public static final DotName COMPLETION_STAGE_NAME = DotName.createSimple(CompletionStage.class.getName());
 
+    public static final DotName DOTNAME_JSONB_PROPERTY = DotName.createSimple("javax.json.bind.annotation.JsonbProperty");
+    public static final DotName DOTNAME_JSONB_TRANSIENT = DotName.createSimple("javax.json.bind.annotation.JsonbTransient");
+
     public static final String[] DEFAULT_CONSUMES = new String[] {MIME_ANY};
     public static final String[] DEFAULT_PRODUCES = new String[] {MIME_ANY};
 

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
@@ -135,4 +135,15 @@ public class ExpectationTests extends OpenApiDataObjectScannerTestBase {
         assertJsonEquals(name, "generic.fields.expected.json", result);
     }
 
+    @Test
+    public void fieldNameOverrideTest() throws IOException, JSONException {
+        String name = GenericTypeTestContainer.class.getName();
+        Type pType = getFieldFromKlazz(name, "overriddenNames").type();
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+
+        Schema result = scanner.process();
+
+        printToConsole(name, result);
+        assertJsonEquals(name, "generic.fields.overriddenNames.expected.json", result);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
@@ -22,9 +22,12 @@ import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
 import org.junit.Test;
+
+import test.io.smallrye.openapi.runtime.scanner.entities.IgnoreSchemaOnFieldExample;
 import test.io.smallrye.openapi.runtime.scanner.entities.IgnoreTestContainer;
 import test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreOnFieldExample;
 import test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreTypeExample;
+import test.io.smallrye.openapi.runtime.scanner.entities.JsonbTransientOnFieldExample;
 
 import java.io.IOException;
 
@@ -83,6 +86,32 @@ public class IgnoreTests extends OpenApiDataObjectScannerTestBase {
 
         printToConsole(name.local(), result);
         assertJsonEquals(name.local(), "ignore.jsonIgnoreType.expected.json", result);
+    }
+
+    // Entirely ignore a single field once using JSON-B.
+    @Test
+    public void testIgnore_jsonbTransientField() throws IOException, JSONException {
+        DotName name = DotName.createSimple(JsonbTransientOnFieldExample.class.getName());
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+                ClassType.create(name, Type.Kind.CLASS));
+
+        Schema result = scanner.process();
+
+        printToConsole(name.local(), result);
+        assertJsonEquals(name.local(), "ignore.jsonbTransientField.expected.json", result);
+    }
+
+    // Entirely ignore a single field once using hidden attribute of Schema.
+    @Test
+    public void testIgnore_schemaHiddenField() throws IOException, JSONException {
+        DotName name = DotName.createSimple(IgnoreSchemaOnFieldExample.class.getName());
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+                ClassType.create(name, Type.Kind.CLASS));
+
+        Schema result = scanner.process();
+
+        printToConsole(name.local(), result);
+        assertJsonEquals(name.local(), "ignore.schemaHiddenField.expected.json", result);
     }
 
 }

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/FieldNameOverride.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/FieldNameOverride.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import javax.json.bind.annotation.JsonbProperty;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+public class FieldNameOverride {
+
+    @JsonbProperty("dasherized-name")
+    private String dasherizedName;
+
+    @JsonbProperty("dasherized-name-required")
+    @Schema(required = true)
+    private String dasherizedNameRequired;
+
+    @JsonbProperty("snake_case_name")
+    private String snakeCaseName;
+
+    @JsonbProperty("camelCaseNameCustom")
+    private String camelCaseName;
+
+    @JsonbProperty
+    private String camelCaseNameDefault1;
+
+    @SuppressWarnings("unused")
+    private String camelCaseNameDefault2;
+
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/GenericTypeTestContainer.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/GenericTypeTestContainer.java
@@ -36,4 +36,7 @@ public class GenericTypeTestContainer {
 
     // Type containing a variety of collections and maps.
     GenericFieldTestContainer<String, LocalDateTime> genericContainer;
+
+    // Type containing fields with overridden names.
+    FieldNameOverride overriddenNames;
 }

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/IgnoreSchemaOnFieldExample.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/IgnoreSchemaOnFieldExample.java
@@ -1,0 +1,21 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+
+public class IgnoreSchemaOnFieldExample {
+    @Schema(hidden = true)
+    String ignoredField;
+
+    @Schema(hidden = false, description = "This field is not hidden")
+    String serializedField1;
+
+    @Schema(description = "This field is not hidden either")
+    String serializedField2;
+
+    String serializedField3;
+
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JsonbTransientOnFieldExample.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JsonbTransientOnFieldExample.java
@@ -1,0 +1,15 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import javax.json.bind.annotation.JsonbTransient;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+
+public class JsonbTransientOnFieldExample {
+
+    @JsonbTransient
+    String ignoredField;
+
+    String serializedField;
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.fields.overriddenNames.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.fields.overriddenNames.expected.json
@@ -1,0 +1,31 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer" : {
+        "required" : [
+          "dasherized-name-required"
+        ],
+        "properties" : {
+          "dasherized-name" : {
+            "type" : "string"
+          },
+          "dasherized-name-required" : {
+            "type" : "string"
+          },
+          "snake_case_name" : {
+            "type" : "string"
+          },
+          "camelCaseNameCustom" : {
+            "type" : "string"
+          },
+          "camelCaseNameDefault1" : {
+            "type" : "string"
+          },
+          "camelCaseNameDefault2" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonbTransientField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonbTransientField.expected.json
@@ -1,0 +1,13 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.JsonbTransientOnFieldExample" : {
+        "properties" : {
+          "serializedField" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.schemaHiddenField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.schemaHiddenField.expected.json
@@ -1,0 +1,21 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.IgnoreSchemaOnFieldExample" : {
+        "properties" : {
+          "serializedField1" : {
+            "type" : "string",
+            "description" : "This field is not hidden"
+          },
+          "serializedField2" : {
+            "type" : "string",
+            "description" : "This field is not hidden either"
+          },
+          "serializedField3" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <version.javax.javaee-api>7.0</version.javax.javaee-api>
         <version.javax.enterprise.cdi-api>2.0</version.javax.enterprise.cdi-api>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
+        <version.javax.json.bind-api>1.0</version.javax.json.bind-api>
         <version.junit>4.12</version.junit>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
@@ -127,6 +128,11 @@
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${version.javax.validation}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.json.bind</groupId>
+                <artifactId>javax.json.bind-api</artifactId>
+                <version>${version.javax.json.bind-api}</version>
             </dependency>
 
             <!-- Third Party Libraries -->


### PR DESCRIPTION
This addresses #89 and also adds support for overriding property names by considering the value of @JsonbProperty annotations. I'm not sure if that has specification impacts, but I at least wanted to get that discussion started here.

* Add support for properties to be hidden using @Schema or @JsonbTransient
* Add support for property key names to consider value of @JsonbProperty value attribute
* Test cases