### PR TITLE
[#73, #96] Nested schema references w/configuration; default object type

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -51,4 +51,5 @@ public interface OpenApiConfig {
 
     public Set<String> scanDependenciesJars();
 
+    public boolean schemaReferencesEnable();
 }

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -42,6 +42,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     private Set<String> servers;
     private Boolean scanDependenciesDisable;
     private Set<String> scanDependenciesJars;
+    private Boolean schemaReferencesEnable;
 
     /**
      * Constructor.
@@ -193,6 +194,13 @@ public class OpenApiConfigImpl implements OpenApiConfig {
         return scanDependenciesJars;
     }
 
+    @Override
+    public boolean schemaReferencesEnable() {
+        if (schemaReferencesEnable == null) {
+            schemaReferencesEnable = getConfig().getOptionalValue(OpenApiConstants.SCHEMA_REFERENCES_ENABLE, Boolean.class).orElse(false);
+        }
+        return schemaReferencesEnable;
+    }
 
     private static Set<String> asCsvSet(String items) {
         Set<String> rval = new HashSet<>();

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
@@ -70,6 +70,7 @@ public final class OpenApiConstants {
 
     public static final String SCAN_DEPENDENCIES_DISABLE = "mp.openapi.extensions.scan-dependencies.disable";
     public static final String SCAN_DEPENDENCIES_JARS = "mp.openapi.extensions.scan-dependencies.jars";
+    public static final String SCHEMA_REFERENCES_ENABLE = "mp.openapi.extensions.schema-references.enable";
 
     public static final String CLASS_SUFFIX = ".class";
     public static final String JAR_SUFFIX = ".jar";

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -23,6 +23,7 @@ import io.smallrye.openapi.runtime.scanner.dataobject.TypeResolver;
 import io.smallrye.openapi.runtime.scanner.dataobject.AugmentedIndexView;
 import io.smallrye.openapi.runtime.util.SchemaFactory;
 import io.smallrye.openapi.runtime.util.TypeUtil;
+
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -118,7 +119,7 @@ public class OpenApiDataObjectScanner {
         this.rootClassInfo = initialType(classType);
     }
 
-    public OpenApiDataObjectScanner(IndexView _index, AnnotationTarget annotationTarget, Type classType) {
+    OpenApiDataObjectScanner(IndexView _index, AnnotationTarget annotationTarget, Type classType) {
         this.index = new AugmentedIndexView(_index);
         this.objectStack = new DataObjectDeque(index);
         this.ignoreResolver = new IgnoreResolver(index);
@@ -159,7 +160,7 @@ public class OpenApiDataObjectScanner {
      *
      * @return the OAI schema
      */
-    public Schema process() {
+    Schema process() {
         LOG.debugv("Starting processing with root: {0}", rootClassType.name());
 
         // If top level item is simple
@@ -203,6 +204,11 @@ public class OpenApiDataObjectScanner {
 
             // First, handle class annotations.
             currentPathEntry.setSchema(readKlass(currentClass, currentSchema));
+
+            if (currentSchema.getType() == null) {
+                // If not schema has yet been set, consider this an "object"
+                currentSchema.setType(Schema.SchemaType.OBJECT);
+            }
 
             LOG.debugv("Getting all fields for: {0} in class: {1}", currentType, currentClass);
 

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -1,0 +1,164 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConstants;
+import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.runtime.scanner.dataobject.TypeResolver;
+import io.smallrye.openapi.runtime.util.ModelUtil;
+
+/**
+ * A simple registry used to track schemas that have been generated and inserted
+ * into the #/components section of the
+ * @author eric.wittmann@gmail.com
+ */
+public class SchemaRegistry {
+
+    // Initial value is null
+    private static ThreadLocal<SchemaRegistry> current = new ThreadLocal<>();
+
+    public static SchemaRegistry newInstance(OpenApiConfig config, OpenAPI oai) {
+        SchemaRegistry registry = new SchemaRegistry(config, oai);
+        current.set(registry);
+        return registry;
+    }
+
+    public static SchemaRegistry currentInstance() {
+        return current.get();
+    }
+
+    public static Schema checkRegistration(IndexView index, Type entityType, TypeResolver typeResolver, Schema schema) {
+        Type resolvedType = typeResolver.getResolvedType(entityType);
+
+        switch (resolvedType.kind()) {
+        case CLASS:
+        case PARAMETERIZED_TYPE:
+        case TYPE_VARIABLE:
+        case WILDCARD_TYPE:
+            break;
+        default:
+            return schema;
+        }
+
+        SchemaRegistry registry = currentInstance();
+
+        if (registry == null || !registry.schemaReferenceSupported()) {
+            return schema;
+        }
+
+        if (registry.has(resolvedType)) {
+            schema = registry.lookupRef(resolvedType);
+        } else if (index.getClassByName(resolvedType.name()) != null) {
+            schema = registry.register(resolvedType, schema);
+        }
+
+        return schema;
+    }
+
+    /**
+     * Information about a single generated schema.
+     * @author eric.wittmann@gmail.com
+     */
+    static class GeneratedSchemaInfo {
+        @SuppressWarnings("unused")
+        public String name;
+        public Schema schema;
+        public String $ref;
+    }
+
+    private final OpenApiConfig config;
+    private final OpenAPI oai;
+    //private Map<DotName, GeneratedSchemaInfo> registry = new HashMap<>();
+    private Map<Type, GeneratedSchemaInfo> registry = new LinkedHashMap<>();
+    private Set<String> names = new LinkedHashSet<>();
+
+    private SchemaRegistry(OpenApiConfig config, OpenAPI oai) {
+        this.config = config;
+        this.oai = oai;
+    }
+
+    public Schema register(Type entityType, Schema schema) {
+        if (has(entityType)) {
+            // This is a replacement registration
+            remove(entityType);
+        }
+
+        String localName = entityType.name().local();
+        String name = localName;
+        int idx = 1;
+        while (this.names.contains(name)) {
+            name = localName + idx++;
+        }
+        GeneratedSchemaInfo info = new GeneratedSchemaInfo();
+        info.schema = schema;
+        info.name = name;
+        info.$ref = OpenApiConstants.REF_PREFIX_SCHEMA + name;
+
+        //registry.put(entityType.name(), info);
+        registry.put(entityType, info);
+        names.add(name);
+
+        ModelUtil.components(oai).addSchema(name, schema);
+
+        Schema rval = new SchemaImpl();
+        rval.setRef(info.$ref);
+        return rval;
+    }
+
+    public Schema lookup(Type instanceType) {
+        //GeneratedSchemaInfo info = registry.get(instanceType.name());
+        GeneratedSchemaInfo info = registry.get(instanceType);
+
+        if (info == null) {
+            throw new NoSuchElementException("Class schema not registered: " + instanceType.name());
+        }
+
+        return info.schema;
+    }
+
+    public Schema lookupRef(Type instanceType) {
+        //GeneratedSchemaInfo info = registry.get(instanceType.name());
+        GeneratedSchemaInfo info = registry.get(instanceType);
+
+        if (info == null) {
+            throw new NoSuchElementException("Class schema not registered: " + instanceType.name());
+        }
+
+        Schema rval = new SchemaImpl();
+        rval.setRef(info.$ref);
+        return rval;
+    }
+
+    public boolean has(Type instanceType) {
+        //return registry.containsKey(instanceType.name());
+        return registry.containsKey(instanceType);
+    }
+
+    /*
+     * public Map<DotName, GeneratedSchemaInfo> getSchemas() { return
+     * this.registry; }
+     */
+
+    public Map<Type, GeneratedSchemaInfo> getSchemas() {
+        return this.registry;
+    }
+
+    public boolean schemaReferenceSupported() {
+        return config != null && config.schemaReferencesEnable();
+    }
+
+    private void remove(Type entityType) {
+        this.registry.remove(entityType);
+        this.names.remove(entityType.name().local());
+    }
+}

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -17,6 +17,7 @@ package io.smallrye.openapi.runtime.scanner.dataobject;
 
 import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.runtime.scanner.SchemaRegistry;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 import io.smallrye.openapi.runtime.util.SchemaFactory;
 import io.smallrye.openapi.runtime.util.TypeUtil;
@@ -102,7 +103,7 @@ public class AnnotationTargetProcessor {
         return fp.processField();
     }
 
-    public Schema processField() {
+    Schema processField() {
         AnnotationInstance schemaAnnotation = TypeUtil.getSchemaAnnotation(annotationTarget);
 
         final String propertyKey = readPropertyKey();
@@ -114,6 +115,8 @@ public class AnnotationTargetProcessor {
             // Handle field annotated with @Schema.
             readSchemaAnnotatedField(propertyKey, schemaAnnotation);
         }
+
+        fieldSchema = SchemaRegistry.checkRegistration(index, entityType, typeResolver, fieldSchema);
         parentPathEntry.getSchema().addProperty(propertyKey, fieldSchema);
         return fieldSchema;
     }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner;
+
+import java.io.IOException;
+
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.openapi.api.models.OpenAPIImpl;
+import test.io.smallrye.openapi.runtime.scanner.entities.Bar;
+import test.io.smallrye.openapi.runtime.scanner.entities.BuzzLinkedList;
+import test.io.smallrye.openapi.runtime.scanner.entities.EnumContainer;
+import test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+public class ExpectationWithRefsTests extends OpenApiDataObjectScannerTestBase {
+
+    OpenAPIImpl oai;
+    SchemaRegistry registry;
+
+    @Before
+    public void setupRegistry() {
+        oai = new OpenAPIImpl();
+        registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai);
+    }
+
+    private void testAssertion(Class<?> target, String expectedResourceName) throws IOException, JSONException {
+        DotName name = componentize(target.getName());
+        Type type = ClassType.create(name, Type.Kind.CLASS);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, type);
+
+        Schema result = scanner.process();
+        registry.register(type, result);
+
+        printToConsole(oai);
+        assertJsonEquals(expectedResourceName, oai);
+    }
+
+    private void testAssertion(Class<?> containerClass,
+                               String targetField,
+                               String expectedResourceName) throws IOException, JSONException {
+
+        String containerName = containerClass.getName();
+        Type parentType = getFieldFromKlazz(containerName, targetField).type();
+
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, parentType);
+
+        Schema result = scanner.process();
+        registry.register(parentType, result);
+
+        printToConsole(oai);
+        assertJsonEquals(expectedResourceName, oai);
+    }
+
+    /**
+     * Unresolvable type parameter.
+     */
+    @Test
+    public void testUnresolvableWithRefs() throws IOException, JSONException {
+        testAssertion(Bar.class, "refsEnabled.unresolvable.expected.json");
+    }
+
+    /**
+     * Cyclic reference.
+     */
+    @Test
+    public void testCycleWithRef() throws IOException, JSONException {
+        testAssertion(BuzzLinkedList.class, "refsEnabled.cycle.expected.json");
+    }
+
+    @Test
+    public void testBareEnumWithRef() throws IOException, JSONException {
+        testAssertion(EnumContainer.class, "refsEnabled.enum.expected.json");
+    }
+
+    @Test
+    public void testNestedGenericsWithRefs() throws IOException, JSONException {
+        testAssertion(GenericTypeTestContainer.class, "nesting", "refsEnabled.generic.nested.expected.json");
+    }
+
+    @Test
+    public void testComplexNestedGenericsWithRefs() throws IOException, JSONException {
+        testAssertion(GenericTypeTestContainer.class, "complexNesting", "refsEnabled.generic.complexNesting.expected.json");
+    }
+
+    @Test
+    public void testComplexInheritanceGenericsWithRefs() throws IOException, JSONException {
+        testAssertion(GenericTypeTestContainer.class, "complexInheritance", "refsEnabled.generic.complexInheritance.expected.json");
+    }
+
+    @Test
+    public void testGenericsWithBoundsWithRef() throws IOException, JSONException {
+        testAssertion(GenericTypeTestContainer.class, "genericWithBounds", "refsEnabled.generic.withBounds.expected.json");
+    }
+
+    @Test
+    public void genericFieldWithRefTest() throws IOException, JSONException {
+        testAssertion(GenericTypeTestContainer.class, "genericContainer", "refsEnabled.generic.fields.expected.json");
+    }
+
+    @Test
+    public void fieldNameOverrideWithRefTest() throws IOException, JSONException {
+        testAssertion(GenericTypeTestContainer.class, "overriddenNames", "refsEnabled.generic.fields.overriddenNames.expected.json");
+    }
+}

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
@@ -17,12 +17,15 @@ package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
+import org.json.JSONException;
 import org.junit.Test;
 
+import io.smallrye.openapi.api.models.OpenAPIImpl;
 import test.io.smallrye.openapi.runtime.scanner.entities.KitchenSink;
 
 /**
@@ -65,4 +68,18 @@ public class KitchenSinkTest extends OpenApiDataObjectScannerTestBase {
         printToConsole("KustomPair", scanner.process());
     }
 
+    @Test
+    public void testKitchenSinkWithRefs() throws IOException, JSONException {
+        DotName name = componentize(KitchenSink.class.getName());
+        Type type = ClassType.create(name, Type.Kind.CLASS);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, type);
+        OpenAPIImpl oai = new OpenAPIImpl();
+        SchemaRegistry registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai);
+
+        Schema result = scanner.process();
+        registry.register(type, result);
+
+        printToConsole(oai);
+        assertJsonEquals("refsEnabled.kitchenSink.expected.json", oai);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner;
+
+import java.io.IOException;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.Type;
+import org.json.JSONException;
+import org.junit.Test;
+
+import io.smallrye.openapi.api.models.OpenAPIImpl;
+import test.io.smallrye.openapi.runtime.scanner.entities.NestedSchemaParent;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+public class NestedSchemaReferenceTests extends OpenApiDataObjectScannerTestBase {
+
+    @Test
+    public void testNestedSchemasAddedToRegistry() throws IOException, JSONException {
+        DotName parentName = componentize(NestedSchemaParent.class.getName());
+        Type parentType = ClassType.create(parentName, Type.Kind.CLASS);
+        OpenAPIImpl oai = new OpenAPIImpl();
+        SchemaRegistry registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai);
+
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, parentType);
+
+        Schema result = scanner.process();
+        registry.register(parentType, result);
+
+        printToConsole(oai);
+        assertJsonEquals("refsEnabled.nested.schema.family.expected.json", oai);
+    }
+
+    @Test
+    public void testNestedSchemaOnParameter() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+
+        // Test samples
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource$NestedParameterTestParent.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource$NestedParameterTestChild.class");
+
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), indexer.complete());
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("refsEnabled.resource.testNestedSchemaOnParameter.json", result);
+    }
+
+    /*
+     * Test cast derived from original example in Smallrye OpenAPI issue #73.
+     *
+     * https://github.com/smallrye/smallrye-open-api/issues/73
+     *
+     */
+    @Test
+    public void testSimpleNestedSchemaOnParameter() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+
+        // Test samples
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/FooResource.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/FooResource$Foo.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/FooResource$Bar.class");
+
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), indexer.complete());
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("refsEnabled.resource.simple.expected.json", result);
+    }
+}

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScannerTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScannerTest.java
@@ -58,15 +58,15 @@ public class OpenApiAnnotationScannerTest extends OpenApiDataObjectScannerTestBa
         Indexer indexer = new Indexer();
 
         // Test samples
-        indexDirectory(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/HiddenOperationResource.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/VisibleOperationResource.class");
 
-        String name = "testHiddenOperationNotPresent";
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), indexer.complete());
 
         OpenAPI result = scanner.scan();
 
-        printToConsole(name, result);
-        assertJsonEquals(name, "resource.testHiddenOperationNotPresent.json", result);
+        printToConsole(result);
+        assertJsonEquals("resource.testHiddenOperationNotPresent.json", result);
     }
 
     @Test
@@ -76,12 +76,11 @@ public class OpenApiAnnotationScannerTest extends OpenApiDataObjectScannerTestBa
         // Test samples
         index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/HiddenOperationResource.class");
 
-        String name = "testHiddenOperationPathNotPresent";
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), indexer.complete());
 
         OpenAPI result = scanner.scan();
 
-        printToConsole(name, result);
-        assertJsonEquals(name, "resource.testHiddenOperationPathNotPresent.json", result);
+        printToConsole(result);
+        assertJsonEquals("resource.testHiddenOperationPathNotPresent.json", result);
     }
 }

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/NestedSchemaParent.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/NestedSchemaParent.java
@@ -1,0 +1,17 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+
+public class NestedSchemaParent {
+
+    NestedSchemaSiblingA child1;
+
+    @Schema(type = SchemaType.OBJECT)
+    NestedSchemaSiblingB child2;
+
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/NestedSchemaSiblingA.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/NestedSchemaSiblingA.java
@@ -1,0 +1,12 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+
+public class NestedSchemaSiblingA {
+
+    String name;
+
+    String title;
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/NestedSchemaSiblingB.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/NestedSchemaSiblingB.java
@@ -1,0 +1,13 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+
+public class NestedSchemaSiblingB {
+
+    String name;
+
+    long favoriteNumber;
+
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/FooResource.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/FooResource.java
@@ -1,0 +1,26 @@
+package test.io.smallrye.openapi.runtime.scanner.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("foo")
+public class FooResource {
+
+    public static class Foo {
+        private String name;
+        private Bar bar;
+
+        //... getters/setters
+    }
+
+    public static class Bar {
+        private String note;
+
+        //...getter/setter
+    }
+
+    @GET
+    public Foo getFoo() {
+        return new Foo();
+    }
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.java
@@ -1,0 +1,51 @@
+package test.io.smallrye.openapi.runtime.scanner.resources;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+@Path("/nested")
+public class NestedSchemaOnParameterResource {
+
+    public static class NestedParameterTestParent {
+        @Schema(required = true)
+        String id;
+        @Schema(required = true)
+        String name;
+        @Schema(required = true)
+        NestedParameterTestChild nested;
+
+        List<NestedParameterTestChild> childList;
+
+        Map<String, NestedParameterTestChild> childMap;
+    }
+
+    @Schema(description = "The description of the child")
+    public static class NestedParameterTestChild {
+        @Schema(required = true)
+        String id;
+        String name;
+    }
+
+    @SuppressWarnings("unused")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @APIResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = NestedParameterTestParent.class)))
+    public NestedParameterTestParent getHiddenResponse(@Parameter(name = "arg") NestedParameterTestParent request) {
+        return new NestedParameterTestParent();
+    }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/cycle.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/cycle.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.BuzzLinkedList" : {
+        "type": "object",
         "properties" : {
           "next" : {
             "description" : "Cyclic reference to test.io.smallrye.openapi.runtime.scanner.entities.BuzzLinkedList",

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/enum.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/enum.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.EnumContainer" : {
+        "type": "object",
         "properties" : {
           "bazEnum" : {
             "enum" : [ "Gold", "Green", "Orange" ],

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.complexInheritance.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.complexInheritance.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer" : {
+        "type": "object",
         "properties" : {
           "theQ" : {
             "type" : "string"

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.complexNesting.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.complexNesting.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer" : {
+        "type": "object",
         "properties" : {
           "qAgain" : {
             "format" : "double",

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.fields.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.fields.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer" : {
+        "type": "object",
         "properties" : {
           "arrayListOfV" : {
             "type" : "array",

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.nested.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.nested.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer" : {
+        "type": "object",
         "required" : [ "bar", "foo" ],
         "properties" : {
           "bar" : {

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.withBounds.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/generic.withBounds.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer" : {
+        "type": "object",
         "required" : [ "bar", "foo" ],
         "properties" : {
           "bar" : {

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnoreField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnoreField.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreOnFieldExample" : {
+        "type": "object",
         "properties" : {
           "thisFieldShouldAppear" : {
             "type" : "string"

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnorePropertiesOnClass.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnorePropertiesOnClass.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.IgnoreTestContainer" : {
+        "type": "object",
         "properties" : {
           "shouldBePresent" : {
             "type" : "string"

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnorePropertiesOnField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonIgnorePropertiesOnField.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.IgnoreTestContainer" : {
+        "type": "object",
         "properties" : {
           "aStringProperty" : {
             "type" : "string"

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonbTransientField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.jsonbTransientField.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.JsonbTransientOnFieldExample" : {
+        "type": "object",
         "properties" : {
           "serializedField" : {
             "type" : "string"

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.schemaHiddenField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.schemaHiddenField.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.IgnoreSchemaOnFieldExample" : {
+        "type": "object",
         "properties" : {
           "serializedField1" : {
             "type" : "string",

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.cycle.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.cycle.expected.json
@@ -1,0 +1,14 @@
+{
+  "components" : {
+    "schemas" : {
+      "BuzzLinkedList" : {
+        "type": "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/BuzzLinkedList"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.enum.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.enum.expected.json
@@ -1,0 +1,22 @@
+{
+  "components": {
+    "schemas": {
+      "BazEnum": {
+        "type": "string",
+        "enum": [
+          "Gold",
+          "Green",
+          "Orange"
+        ]
+      },
+      "EnumContainer": {
+        "type": "object",
+        "properties": {
+          "bazEnum": {
+            "$ref": "#/components/schemas/BazEnum"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexInheritance.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexInheritance.expected.json
@@ -1,0 +1,32 @@
+{
+  "components": {
+    "schemas": {
+      "Bazzy": {
+        "type": "object",
+        "properties": {
+          "hellofrombazzy": {
+            "type": "string"
+          },
+          "an_integer_value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "theQ": {
+            "type": "string"
+          },
+          "theT": {
+            "$ref": "#/components/schemas/Bazzy"
+          },
+          "ultimateTShouldBeQ": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
@@ -1,0 +1,76 @@
+{
+  "components": {
+    "schemas": {
+      "KustomPair": {
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "type": "object",
+        "properties": {
+          "bar": {
+            "type": "object"
+          },
+          "foo": {
+            "$ref": "#/components/schemas/Fuzz"
+          }
+        }
+      },
+      "Fuzz": {
+        "maxLength": 123456,
+        "type": "object",
+        "properties": {
+          "qAgain": {
+            "format": "date",
+            "type": "string"
+          },
+          "qAgain3": {
+            "format": "date",
+            "type": "string"
+          },
+          "qValue": {
+            "format": "date",
+            "description": "Ah, Q, my favourite variable!",
+            "type": "string"
+          },
+          "tAgain2": {
+            "type": "string"
+          },
+          "tAgain4": {
+            "type": "string"
+          },
+          "tValue": {
+            "type": "string"
+          }
+        }
+      },
+      "Fuzz1": {
+        "type": "object",
+        "properties": {
+          "qAgain": {
+            "format": "double",
+            "type": "number"
+          },
+          "qAgain3": {
+            "format": "double",
+            "type": "number"
+          },
+          "qValue": {
+            "format": "double",
+            "description": "Ah, Q, my favourite variable!",
+            "type": "number"
+          },
+          "tAgain2": {
+            "$ref": "#/components/schemas/KustomPair"
+          },
+          "tAgain4": {
+            "$ref": "#/components/schemas/KustomPair"
+          },
+          "tValue": {
+            "$ref": "#/components/schemas/KustomPair"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.fields.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.fields.expected.json
@@ -1,0 +1,61 @@
+{
+  "components": {
+    "schemas": {
+      "Bazzy": {
+        "type": "object",
+        "properties": {
+          "hellofrombazzy": {
+            "type": "string"
+          },
+          "an_integer_value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "theQ": {
+            "type": "string"
+          },
+          "theT": {
+            "$ref": "#/components/schemas/Bazzy"
+          },
+          "ultimateTShouldBeQ": {
+            "type": "string"
+          }
+        }
+      },
+      "GenericFieldTestContainer": {
+        "type": "object",
+        "properties": {
+          "arrayListOfV": {
+            "type": "array",
+            "items": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "genericFieldK": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "mapOfKToFoo": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Foo"
+            }
+          },
+          "mapOfKV": {
+            "type": "object",
+            "additionalProperties": {
+              "format": "date-time",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.fields.overriddenNames.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.fields.overriddenNames.expected.json
@@ -1,7 +1,7 @@
 {
   "components" : {
     "schemas" : {
-      "test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer" : {
+      "FieldNameOverride" : {
         "type": "object",
         "required" : [
           "dasherized-name-required"

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
@@ -1,0 +1,39 @@
+{
+  "components": {
+    "schemas": {
+      "KustomPair": {
+        "maxLength": 123456,
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "type": "object",
+        "properties": {
+          "bar": {
+            "type": "string"
+          },
+          "foo": {
+            "maxLength": 123456,
+            "type": "string"
+          }
+        }
+      },
+      "KustomPair1": {
+        "type": "object",
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "properties": {
+          "bar": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "foo": {
+            "$ref": "#/components/schemas/KustomPair"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.withBounds.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.withBounds.expected.json
@@ -1,11 +1,16 @@
 {
   "components" : {
     "schemas" : {
-      "test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreTypeExample" : {
+      "KustomPair" : {
         "type": "object",
+        "required" : [ "bar", "foo" ],
         "properties" : {
-          "shouldBePresent" : {
+          "bar" : {
+            "type" : "object"
+          },
+          "foo" : {
             "format" : "int32",
+            "maxLength" : 123456,
             "type" : "integer"
           }
         }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
@@ -1,0 +1,459 @@
+{
+  "components" : {
+    "schemas" : {
+      "BazEnum": {
+        "type" : "object",
+              "properties" : {
+                "z" : {
+                  "format" : "int32",
+                  "type" : "integer"
+                }
+              }
+      },
+      "Baz": {
+                  "type" : "object",
+                  "properties" : {
+                    "an_integer_value" : {
+                      "format" : "int32",
+                      "type" : "integer"
+                    }
+                  }
+      },
+      "Bar": {
+        "type" : "object",
+              "properties" : {
+                "theQ" : {
+                  "type" : "object"
+                },
+                "theT" : {
+                  "$ref": "#/components/schemas/Baz"
+                },
+                "ultimateTShouldBeQ" : {
+                  "type" : "object"
+                }
+              }
+      },
+      "Airline": {
+                    "required" : [ "contactPhone", "name" ],
+                    "type" : "object",
+                    "properties" : {
+                      "contactPhone" : {
+                        "type" : "string",
+                        "example" : "1-888-1234-567"
+                      },
+                      "name" : {
+                        "type" : "string",
+                        "example" : "Acme Air"
+                      }
+                    }
+      },
+      "Flight": {
+                "required" : [ "airline", "airportFrom", "airportTo", "dateTime", "number", "price", "status" ],
+                "type" : "object",
+                "properties" : {
+                  "airline" : {
+                    "$ref": "#/components/schemas/Airline"
+                  },
+                  "airportFrom" : {
+                    "type" : "string",
+                    "example" : "YYZ"
+                  },
+                  "airportTo" : {
+                    "type" : "string",
+                    "example" : "LAX"
+                  },
+                  "dateTime" : {
+                    "pattern" : "dateTime",
+                    "type" : "string",
+                    "example" : "2016-03-05 18:00"
+                  },
+                  "number" : {
+                    "type" : "string",
+                    "example" : "AC190"
+                  },
+                  "price" : {
+                    "type" : "string",
+                    "example" : "US$350"
+                  },
+                  "status" : {
+                    "type" : "string",
+                    "example" : "On Schedule"
+                  }
+                }
+      },
+      "CreditCard": {
+                "required" : [ "cardNumber", "cardholderName", "cvv", "expiryDate", "issuer" ],
+                "type" : "object",
+                "properties" : {
+                  "cardNumber" : {
+                    "type" : "string",
+                    "example" : "**********1234"
+                  },
+                  "cardholderName" : {
+                    "type" : "string",
+                    "example" : "Joe Smith"
+                  },
+                  "cvv" : {
+                    "type" : "string",
+                    "example" : "0322"
+                  },
+                  "expiryDate" : {
+                    "type" : "string",
+                    "example" : "04/19"
+                  },
+                  "issuer" : {
+                    "type" : "string",
+                    "example" : "VISA"
+                  }
+                }
+      },
+      "Booking": {
+            "required" : [ "airMiles", "creditCard", "departtureFlight", "returningFlight", "seatPreference" ],
+            "type" : "object",
+            "properties" : {
+              "airMiles" : {
+                "type" : "string",
+                "example" : "32126319"
+              },
+              "creditCard" : {
+                "$ref": "#/components/schemas/CreditCard"
+              },
+              "departtureFlight" : {
+                "$ref": "#/components/schemas/Flight"
+              },
+              "returningFlight" : {
+                "$ref": "#/components/schemas/Flight"
+              },
+              "seatPreference" : {
+                "type" : "string",
+                "example" : "window"
+              }
+            }
+      },
+      "Bazzy": {
+                "type" : "object",
+                "properties" : {
+                  "hellofrombazzy" : {
+                    "type" : "string"
+                  },
+                  "an_integer_value" : {
+                    "format" : "int32",
+                    "type" : "integer"
+                  }
+                }
+      },
+      "Foo": {
+            "type" : "object",
+            "properties" : {
+              "theQ" : {
+                "type" : "string"
+              },
+              "theT" : {
+                "$ref": "#/components/schemas/Bazzy"
+              },
+              "ultimateTShouldBeQ" : {
+                "type" : "string"
+              }
+            }
+      },
+      "Fuzz2": {
+                    "maxLength" : 123456,
+                    "type" : "object",
+                    "properties" : {
+                      "qAgain" : {
+                        "type" : "object"
+                      },
+                      "qAgain3" : {
+                        "type" : "object"
+                      },
+                      "qValue" : {
+                        "description" : "Ah, Q, my favourite variable!",
+                        "type" : "object"
+                      },
+                      "tAgain2" : {
+                        "type" : "string"
+                      },
+                      "tAgain4" : {
+                        "type" : "string"
+                      },
+                      "tValue" : {
+                        "type" : "string"
+                      }
+                    }
+      },
+      "KustomPair4": {
+                "required" : [ "bar", "foo" ],
+                "type" : "object",
+                "properties" : {
+                  "bar" : {
+                    "format" : "int32",
+                    "type" : "integer"
+                  },
+                  "foo" : {
+                    "$ref": "#/components/schemas/Fuzz2"
+                  }
+                }
+      },
+      "Fuzz": {
+            "type" : "object",
+            "properties" : {
+              "qAgain" : {
+                "format" : "double",
+                "type" : "number"
+              },
+              "qAgain3" : {
+                "format" : "double",
+                "type" : "number"
+              },
+              "qValue" : {
+                "format" : "double",
+                "description" : "Ah, Q, my favourite variable!",
+                "type" : "number"
+              },
+              "tAgain2" : {
+                "$ref": "#/components/schemas/KustomPair4"
+              },
+              "tAgain4" : {
+                "$ref": "#/components/schemas/KustomPair4"
+              },
+              "tValue" : {
+                "$ref": "#/components/schemas/KustomPair4"
+              }
+        }
+      },
+      "Foo1": {
+            "type" : "object",
+            "properties" : {
+              "theQ" : {
+                "type" : "string"
+              },
+              "theT" : {
+                "$ref": "#/components/schemas/Bazzy"
+              },
+              "ultimateTShouldBeQ" : {
+                "type" : "string"
+              }
+            }
+      },
+      "Fuzz1": {
+            "type" : "object",
+            "properties" : {
+              "qAgain" : {
+                "$ref": "#/components/schemas/Foo1"
+              },
+              "qAgain3" : {
+                "$ref": "#/components/schemas/Foo1"
+              },
+              "qValue" : {
+                "$ref": "#/components/schemas/Foo1"
+              },
+              "tAgain2" : {
+                "type" : "string"
+              },
+              "tAgain4" : {
+                "type" : "string"
+              },
+              "tValue" : {
+                "type" : "string"
+              }
+            }
+      },
+      "KustomPair": {
+            "required" : [ "bar", "foo" ],
+            "type" : "object",
+            "properties" : {
+              "bar" : {
+                "type" : "object"
+              },
+              "foo" : {
+                "maxLength" : 123456,
+                "type" : "string"
+              }
+            }
+      },
+      "KustomPair1": {
+            "required" : [ "bar", "foo" ],
+            "type" : "object",
+            "properties" : {
+              "bar" : {
+                "format" : "int32",
+                "type" : "integer"
+              },
+              "foo" : {
+                "$ref": "#/components/schemas/KustomPair3"
+              }
+            }
+      },
+      "KustomPair3": {
+                "maxLength" : 123456,
+                "required" : [ "bar", "foo" ],
+                "type" : "object",
+                "properties" : {
+                  "bar" : {
+                    "type" : "string"
+                  },
+                  "foo" : {
+                    "maxLength" : 123456,
+                    "type" : "string"
+                  }
+                }
+      },
+      "BuzzLinkedList": {
+            "type" : "object",
+            "properties" : {
+              "next" : {
+                "$ref": "#/components/schemas/BuzzLinkedList"
+              }
+            }
+      },
+      "KustomPair2": {
+            "required" : [ "bar", "foo" ],
+            "type" : "object",
+            "properties" : {
+              "bar" : {
+                "format" : "int32",
+                "type" : "integer"
+              },
+              "foo" : {
+                "maxLength" : 123456,
+                "type" : "string"
+              }
+            }
+      },
+      "KitchenSink" : {
+        "description" : "This is the kitchen sink description!",
+        "required" : [ "booking", "ccList", "creditCardMap", "fooArray", "fuzzListWildcard", "seatPreference", "unsafeList" ],
+        "type" : "object",
+        "properties" : {
+          "array" : {
+            "type" : "array",
+            "items" : {
+              "format" : "int32",
+              "type" : "integer"
+            }
+          },
+          "awkwardMap" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "awkwardMap2" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref": "#/components/schemas/BazEnum"
+            }
+          },
+          "barExtends" : {
+            "type" : "array",
+            "items" : {
+              "$ref": "#/components/schemas/Bar"
+            }
+          },
+          "barSuper" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object"
+            }
+          },
+          "bareCollection" : {
+            "type" : "array"
+          },
+          "bareEnum" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object"
+            }
+          },
+          "blahMap" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "object"
+            }
+          },
+          "booking" : {
+            "$ref": "#/components/schemas/Booking"
+          },
+          "ccList" : {
+            "type" : "array",
+            "items" : {
+              "$ref": "#/components/schemas/CreditCard"
+            }
+          },
+          "complexNesting" : {
+            "$ref": "#/components/schemas/Fuzz"
+          },
+          "creditCardMap" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref": "#/components/schemas/CreditCard"
+            }
+          },
+          "customTypeExtendsSuper" : {
+            "$ref": "#/components/schemas/KustomPair"
+          },
+          "foo" : {
+            "$ref": "#/components/schemas/Foo"
+          },
+          "fooArray" : {
+            "type" : "array",
+            "items" : {
+              "$ref": "#/components/schemas/Bar"
+            }
+          },
+          "fuzzListWildcard" : {
+            "$ref": "#/components/schemas/Fuzz1"
+          },
+          "longArray" : {
+            "type" : "array",
+            "items" : {
+              "format" : "int64",
+              "type" : "integer"
+            }
+          },
+          "nesting" : {
+            "$ref": "#/components/schemas/KustomPair1"
+          },
+          "password" : {
+            "type" : "string"
+          },
+          "primitiveFoo" : {
+            "format" : "int32",
+            "maximum" : 9001,
+            "type" : "integer"
+          },
+          "rawArray" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object"
+            }
+          },
+          "rootNode" : {
+            "$ref": "#/components/schemas/BuzzLinkedList"
+          },
+          "seatPreference" : {
+            "maxLength" : 999,
+            "type" : "string",
+            "example" : "window"
+          },
+          "simpleParameterizedType" : {
+            "$ref": "#/components/schemas/KustomPair2"
+          },
+          "unsafeList" : {
+            "type" : "array"
+          },
+          "voidField" : {
+            "type" : "object"
+          },
+          "writeOnlyInteger" : {
+            "format" : "int32",
+            "type" : "integer",
+            "writeOnly" : true
+          }
+        },
+        "example" : "This is the KitchenSink example field in Schema",
+        "deprecated" : true
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.nested.schema.family.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.nested.schema.family.expected.json
@@ -1,0 +1,40 @@
+{
+  "components" : {
+    "schemas" : {
+      "NestedSchemaParent" : {
+        "type": "object",
+        "properties" : {
+          "child1" : {
+            "$ref": "#/components/schemas/NestedSchemaSiblingA"
+          },
+          "child2" : {
+            "$ref": "#/components/schemas/NestedSchemaSiblingB"
+          }
+        }
+      },
+      "NestedSchemaSiblingA" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type": "string"
+          },
+          "title" : {
+            "type": "string"
+          }
+        }
+      },
+      "NestedSchemaSiblingB" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type": "string"
+          },
+          "favoriteNumber" : {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.simple.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.simple.expected.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/foo": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Foo"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "bar": {
+            "$ref": "#/components/schemas/Bar"
+          }
+        }
+      },
+      "Bar": {
+        "type": "object",
+        "properties": {
+          "note": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.testNestedSchemaOnParameter.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.testNestedSchemaOnParameter.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/nested": {
+      "post": {
+        "parameters": [
+          {
+            "name": "arg",
+            "schema": {
+              "$ref": "#/components/schemas/NestedParameterTestParent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NestedParameterTestParent"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NestedParameterTestParent": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "nested"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nested": {
+            "$ref": "#/components/schemas/NestedParameterTestChild"
+          },
+          "childList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NestedParameterTestChild"
+            }
+          },
+          "childMap": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/NestedParameterTestChild"
+            }
+          }
+        }
+      },
+      "NestedParameterTestChild": {
+        "type": "object",
+        "description": "The description of the child",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.unresolvable.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.unresolvable.expected.json
@@ -1,0 +1,29 @@
+{
+  "components": {
+    "schemas": {
+      "Baz": {
+        "type": "object",
+        "properties": {
+          "an_integer_value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "Bar": {
+        "type": "object",
+        "properties": {
+          "theQ": {
+            "type": "object"
+          },
+          "theT": {
+            "$ref": "#/components/schemas/Baz"
+          },
+          "ultimateTShouldBeQ": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/unresolvable.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/unresolvable.expected.json
@@ -2,6 +2,7 @@
   "components" : {
     "schemas" : {
       "test.io.smallrye.openapi.runtime.scanner.entities.Bar" : {
+        "type": "object",
         "properties" : {
           "theQ" : {
             "type" : "object"


### PR DESCRIPTION
Addresses issues #73 and #96. Criticism/feedback is welcome.

The approach to enable schema references uses a configuration extension property, `mp.openapi.extensions.schema-references.enable`. This is handled using the `SchemaRegistry` class which has been extracted to a top-level class outside of the scanner. I implemented this using `ThreadLocal` to avoid changing a larger number of method signatures. This could certainly be re-factored to be cleaner at some point, but I think any negative impact is low because the scanning process is not currently multi-threaded.

The changes include replicating a good number of the test cases to verify those scenarios still function when schema references are enabled.

* Default type attribute on generated schemas to "object"
* Extract `SchemaRegistry` to top-level class
* Update existing test cases for defaulted "object" schema type
* Add and clone test cases for schema reference support
* Make several public methods used only for unit tests package private