### PR TITLE
Ensure JAX-RS Request Body is properly handled when non JAX-RS annotations present

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -44,6 +44,8 @@ import static java.util.stream.Collectors.toList;
  */
 public class JandexUtil {
 
+    private static final String JAXRS_PACKAGE = "javax.ws.rs";
+
     /**
      * Simple enum to indicate the type of a $ref being read/written.
      * @author eric.wittmann@gmail.com
@@ -407,11 +409,21 @@ public class JandexUtil {
             return null;
         }
         for (short i = 0; i < methodParams.size(); i++) {
-            if (JandexUtil.getParameterAnnotations(method, i).isEmpty()) {
+            List<AnnotationInstance> parameterAnnotations = JandexUtil.getParameterAnnotations(method, i);
+            if (parameterAnnotations.isEmpty() || !containsJaxRsAnnotations(parameterAnnotations)) {
                 return methodParams.get(i);
             }
         }
         return null;
+    }
+
+    private static boolean containsJaxRsAnnotations(List<AnnotationInstance> instances) {
+        for (AnnotationInstance instance : instances) {
+            if (instance.name().toString().startsWith(JAXRS_PACKAGE)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Prior to this fix, the implementation would disregard a proper JAX-RS
request body parameter if it was annotated with any annotation, like for
example `javax.validation.Valid`

Relates to: https://github.com/quarkusio/quarkus/issues/2339

cc @kenfinnigan 