### PR TITLE
Use @Schema 'name' for props and schema refs; Fix #25

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/models/media/SchemaImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/models/media/SchemaImpl.java
@@ -39,6 +39,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema, ModelI
 
     private String $ref;
     private String format;
+    private String name;
     private String title;
     private String description;
     private Object defaultValue;
@@ -126,6 +127,14 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema, ModelI
     public Schema discriminator(Discriminator discriminator) {
         this.discriminator = discriminator;
         return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -1,25 +1,36 @@
 package io.smallrye.openapi.runtime.scanner;
 
+import static io.smallrye.openapi.runtime.util.TypeUtil.getSchemaAnnotation;
+
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
+import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.WildcardType;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.api.models.media.SchemaImpl;
 import io.smallrye.openapi.runtime.scanner.dataobject.TypeResolver;
+import io.smallrye.openapi.runtime.util.JandexUtil;
 import io.smallrye.openapi.runtime.util.ModelUtil;
 
 /**
  * A simple registry used to track schemas that have been generated and inserted
  * into the #/components section of the
+ *
  * @author eric.wittmann@gmail.com
  */
 public class SchemaRegistry {
@@ -27,18 +38,70 @@ public class SchemaRegistry {
     // Initial value is null
     private static ThreadLocal<SchemaRegistry> current = new ThreadLocal<>();
 
-    public static SchemaRegistry newInstance(OpenApiConfig config, OpenAPI oai) {
-        SchemaRegistry registry = new SchemaRegistry(config, oai);
+    /**
+     * Create a new instance of a {@link SchemaRegistry} on this thread. The
+     * registry returned by this method may also be obtained by subsequent calls
+     * to {@link #currentInstance()}. Additional calls of this method will
+     * replace the registry in the current thread context with a new instance.
+     *
+     * @param config
+     *            current runtime configuration
+     * @param oai
+     *            the OpenAPI being constructed by the scan
+     * @param index
+     *            indexed class information
+     * @return the registry
+     */
+    public static SchemaRegistry newInstance(OpenApiConfig config, OpenAPI oai, IndexView index) {
+        SchemaRegistry registry = new SchemaRegistry(config, oai, index);
         current.set(registry);
         return registry;
     }
 
+    /**
+     * Retrieve the {@link SchemaRegistry} previously created by
+     * {@link SchemaRegistry#newInstance(OpenApiConfig, OpenAPI, IndexView)
+     * newInstance} for the current thread, or <code>null</code> if none has yet
+     * been created.
+     *
+     * @return a {@link SchemaRegistry} instance or null
+     */
     public static SchemaRegistry currentInstance() {
         return current.get();
     }
 
-    public static Schema checkRegistration(IndexView index, Type entityType, TypeResolver typeResolver, Schema schema) {
-        Type resolvedType = typeResolver.getResolvedType(entityType);
+    /**
+     * Check if the entityType is eligible for registration using the
+     * typeResolver. The eligible kinds of types are
+     *
+     * <ul>
+     * <li>{@link org.jboss.jandex.Type.Kind#CLASS CLASS}
+     * <li>{@link org.jboss.jandex.Type.Kind#PARAMETERIZED_TYPE
+     * PARAMETERIZED_TYPE}
+     * <li>{@link org.jboss.jandex.Type.Kind#TYPE_VARIABLE TYPE_VARIABLE}
+     * <li>{@link org.jboss.jandex.Type.Kind#WILDCARD_TYPE WILDCARD_TYPE}
+     * </ul>
+     *
+     * If eligible, schema references are enabled by MP Config property
+     * <code>mp.openapi.extensions.schema-references.enable</code>, and the
+     * resolved type is available in the registry's {@link IndexView} then the
+     * schema can be registered.
+     *
+     * Only if the type has not already been registered earlier will it be
+     * added.
+     *
+     * @param type
+     *            the {@link Type} the {@link Schema} applies to
+     * @param resolver
+     *            a {@link TypeResolver} that will be used to resolve
+     *            parameterized and wildcard types
+     * @param schema
+     *            {@link Schema} to add to the registry
+     * @return the same schema if not eligible for registration, or a reference
+     *         to the schema registered for the give Type
+     */
+    public static Schema checkRegistration(Type type, TypeResolver resolver, Schema schema) {
+        Type resolvedType = resolver.getResolvedType(type);
 
         switch (resolvedType.kind()) {
         case CLASS:
@@ -56,10 +119,16 @@ public class SchemaRegistry {
             return schema;
         }
 
-        if (registry.has(resolvedType)) {
-            schema = registry.lookupRef(resolvedType);
-        } else if (index.getClassByName(resolvedType.name()) != null) {
-            schema = registry.register(resolvedType, schema);
+        if (registry.index.getClassByName(resolvedType.name()) == null) {
+            return schema;
+        }
+
+        TypeKey key = new TypeKey(resolvedType);
+
+        if (registry.has(key)) {
+            schema = registry.lookupRef(key);
+        } else {
+            schema = registry.register(key, schema);
         }
 
         return schema;
@@ -67,98 +136,265 @@ public class SchemaRegistry {
 
     /**
      * Information about a single generated schema.
+     *
      * @author eric.wittmann@gmail.com
      */
     static class GeneratedSchemaInfo {
-        @SuppressWarnings("unused")
-        public String name;
-        public Schema schema;
-        public String $ref;
+        public final String name;
+        public final Schema schema;
+        public final Schema schemaRef;
+
+        GeneratedSchemaInfo(String name, Schema schema, Schema schemaRef) {
+            this.name = name;
+            this.schema = schema;
+            this.schemaRef = schemaRef;
+        }
     }
 
     private final OpenApiConfig config;
     private final OpenAPI oai;
-    //private Map<DotName, GeneratedSchemaInfo> registry = new HashMap<>();
-    private Map<Type, GeneratedSchemaInfo> registry = new LinkedHashMap<>();
-    private Set<String> names = new LinkedHashSet<>();
+    private final IndexView index;
 
-    private SchemaRegistry(OpenApiConfig config, OpenAPI oai) {
+    private final Map<TypeKey, GeneratedSchemaInfo> registry = new LinkedHashMap<>();
+    private final Set<String> names = new LinkedHashSet<>();
+
+    private SchemaRegistry(OpenApiConfig config, OpenAPI oai, IndexView index) {
         this.config = config;
         this.oai = oai;
+        this.index = index;
+
+        /*
+         * If anything has been added in the component scan, add the names here
+         * to prevent a collision.
+         */
+        Components components = oai.getComponents();
+
+        if (components != null) {
+            Map<String, Schema> schemas = components.getSchemas();
+            if (schemas != null) {
+                this.names.addAll(schemas.keySet());
+            }
+        }
     }
 
+    /**
+     * Register the provided {@link Schema} for the provided {@link Type}. If an
+     * existing schema has already been registered for the type, it will be
+     * replaced by the schema given in this method.
+     *
+     * @param entityType
+     *            the type the {@link Schema} applies to
+     * @param schema
+     *            {@link Schema} to add to the registry
+     * @return a reference to the newly registered {@link Schema}
+     */
     public Schema register(Type entityType, Schema schema) {
-        if (has(entityType)) {
+        TypeKey key = new TypeKey(entityType);
+
+        if (has(key)) {
             // This is a replacement registration
-            remove(entityType);
+            remove(key);
         }
 
-        String localName = entityType.name().local();
-        String name = localName;
+        return register(key, schema);
+    }
+
+    /**
+     * Derive the schema's display name and add to both the registry and the
+     * OpenAPI document's schema map, contained in components. If a type is
+     * registered using a name that already exists in the registry, a sequential
+     * number will be appended to the schemas display name prior to adding.
+     *
+     * Note, this method does NOT merge schemas found during the scanning of the
+     * {@link org.eclipse.microprofile.openapi.annotations.Components}
+     * annotation with those found during the model scan.
+     *
+     * @param key
+     *            a value to be used for referencing the schema in the registry
+     * @param schema
+     *            {@link Schema} to add to the registry
+     * @return a reference to the newly registered {@link Schema}
+     */
+    private Schema register(TypeKey key, Schema schema) {
+        /*
+         * We cannot use the 'name' on the SchemaImpl because it may be a
+         * property name rather then a schema name.
+         */
+        AnnotationTarget targetSchema = index.getClassByName(key.type.name());
+        AnnotationInstance schemaAnnotation = getSchemaAnnotation(targetSchema);
+        String schemaName = null;
+
+        if (schemaAnnotation != null) {
+            schemaName = JandexUtil.stringValue(schemaAnnotation, OpenApiConstants.PROP_NAME);
+        }
+
+        String nameBase = schemaName != null ? schemaName : key.type.name().local();
+        String name = nameBase;
         int idx = 1;
         while (this.names.contains(name)) {
-            name = localName + idx++;
+            name = nameBase + idx++;
         }
-        GeneratedSchemaInfo info = new GeneratedSchemaInfo();
-        info.schema = schema;
-        info.name = name;
-        info.$ref = OpenApiConstants.REF_PREFIX_SCHEMA + name;
 
-        //registry.put(entityType.name(), info);
-        registry.put(entityType, info);
+        Schema schemaRef = new SchemaImpl();
+        schemaRef.setRef(OpenApiConstants.REF_PREFIX_SCHEMA + name);
+
+        registry.put(key, new GeneratedSchemaInfo(name, schema, schemaRef));
         names.add(name);
 
         ModelUtil.components(oai).addSchema(name, schema);
 
-        Schema rval = new SchemaImpl();
-        rval.setRef(info.$ref);
-        return rval;
-    }
-
-    public Schema lookup(Type instanceType) {
-        //GeneratedSchemaInfo info = registry.get(instanceType.name());
-        GeneratedSchemaInfo info = registry.get(instanceType);
-
-        if (info == null) {
-            throw new NoSuchElementException("Class schema not registered: " + instanceType.name());
-        }
-
-        return info.schema;
+        return schemaRef;
     }
 
     public Schema lookupRef(Type instanceType) {
-        //GeneratedSchemaInfo info = registry.get(instanceType.name());
-        GeneratedSchemaInfo info = registry.get(instanceType);
-
-        if (info == null) {
-            throw new NoSuchElementException("Class schema not registered: " + instanceType.name());
-        }
-
-        Schema rval = new SchemaImpl();
-        rval.setRef(info.$ref);
-        return rval;
+        return lookupRef(new TypeKey(instanceType));
     }
 
     public boolean has(Type instanceType) {
-        //return registry.containsKey(instanceType.name());
-        return registry.containsKey(instanceType);
-    }
-
-    /*
-     * public Map<DotName, GeneratedSchemaInfo> getSchemas() { return
-     * this.registry; }
-     */
-
-    public Map<Type, GeneratedSchemaInfo> getSchemas() {
-        return this.registry;
+        return has(new TypeKey(instanceType));
     }
 
     public boolean schemaReferenceSupported() {
         return config != null && config.schemaReferencesEnable();
     }
 
-    private void remove(Type entityType) {
-        this.registry.remove(entityType);
-        this.names.remove(entityType.name().local());
+    private Schema lookupRef(TypeKey key) {
+        GeneratedSchemaInfo info = registry.get(key);
+
+        if (info == null) {
+            throw new NoSuchElementException("Class schema not registered: " + key.type.name());
+        }
+
+        return info.schemaRef;
+    }
+
+    private boolean has(TypeKey key) {
+        return registry.containsKey(key);
+    }
+
+    private void remove(TypeKey key) {
+        GeneratedSchemaInfo info = this.registry.remove(key);
+        this.names.remove(info.name);
+    }
+
+    /************************************************************************/
+
+    /**
+     * This class is used as the key when storing {@link Schema}s in the
+     * registry. The purpose is to replicate the same behavior as the
+     * {@link Type} classes <code>equals</code> and <code>hashCode</code>
+     * functions, with the exception that the {@link Type}'s annotations are not
+     * considered in these versions of the methods.
+     *
+     *
+     * @author Michael Edgar {@literal <michael@xlate.io>}
+     */
+    static class TypeKey {
+        private final Type type;
+        private int hash = 0;
+
+        TypeKey(Type type) {
+            this.type = type;
+        }
+
+        /**
+         * Determine if the two {@link Type}s are equal.
+         *
+         * @see Type#equals
+         * @see ParameterizedType#equals
+         * @see TypeVariable#equals
+         * @see WildcardType#equals
+         */
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || this.getClass() != o.getClass()) {
+                return false;
+            }
+
+            TypeKey other = (TypeKey) o;
+
+            if (type == other.type) {
+                return true;
+            }
+
+            if (type == null || type.getClass() != other.type.getClass()) {
+                return false;
+            }
+
+            if (!type.name().equals(other.type.name())) {
+                return false;
+            }
+
+            if (type instanceof ParameterizedType) {
+                ParameterizedType paramType = (ParameterizedType) type;
+                ParameterizedType otherType = (ParameterizedType) other.type;
+                Type typeOwner = paramType.owner();
+                Type otherOwner = otherType.owner();
+
+                return (typeOwner == otherOwner || (typeOwner != null && typeOwner.equals(otherOwner)))
+                        && Objects.equals(paramType.arguments(), otherType.arguments());
+            }
+
+            if (type instanceof TypeVariable) {
+                TypeVariable varType = (TypeVariable) type;
+                TypeVariable otherType = (TypeVariable) other.type;
+
+                String id = varType.identifier();
+                String otherId = otherType.identifier();
+
+                return id.equals(otherId) && Objects.equals(varType.bounds(), otherType.bounds());
+            }
+
+            if (type instanceof WildcardType) {
+                WildcardType wildType = (WildcardType) type;
+                WildcardType otherType = (WildcardType) other.type;
+
+                return Objects.equals(wildType.extendsBound(), otherType.extendsBound()) &&
+                        Objects.equals(wildType.superBound(), otherType.superBound());
+            }
+
+            return true;
+        }
+
+        /**
+         * @see Type#equals
+         * @see ParameterizedType#equals
+         * @see TypeVariable#equals
+         * @see WildcardType#equals
+         */
+        @Override
+        public int hashCode() {
+            int hash = this.hash;
+
+            if (hash != 0) {
+                return hash;
+            }
+
+            hash = type.name().hashCode();
+
+            if (type instanceof ParameterizedType) {
+                ParameterizedType paramType = (ParameterizedType) type;
+                Type owner = paramType.owner();
+                hash = 31 * hash + Objects.hashCode(paramType.arguments());
+                hash = 31 * hash + (owner != null ? owner.hashCode() : 0);
+            }
+
+            if (type instanceof TypeVariable) {
+                TypeVariable varType = (TypeVariable) type;
+                hash = 31 * hash + varType.identifier().hashCode();
+                hash = 31 * hash + Objects.hashCode(varType.bounds());
+            }
+
+            if (type instanceof WildcardType) {
+                WildcardType wildType = (WildcardType) type;
+                hash = 31 * hash + Objects.hash(wildType.extendsBound(), wildType.superBound());
+            }
+
+            return this.hash = hash;
+        }
     }
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
@@ -101,7 +101,7 @@ public class TypeProcessor {
                 pushToStack(type, arrSchema);
             }
 
-            arrSchema = SchemaRegistry.checkRegistration(index, arrayType.component(), typeResolver, arrSchema);
+            arrSchema = SchemaRegistry.checkRegistration(arrayType.component(), typeResolver, arrSchema);
 
             schema.items(arrSchema);
 
@@ -213,12 +213,12 @@ public class TypeProcessor {
             Type resolved = resolveTypeVariable(propsSchema, valueType);
             if (index.containsClass(resolved)) {
                 propsSchema.type(Schema.SchemaType.OBJECT);
-                propsSchema = SchemaRegistry.checkRegistration(index, valueType, typeResolver, propsSchema);
+                propsSchema = SchemaRegistry.checkRegistration(valueType, typeResolver, propsSchema);
             }
         } else if (index.containsClass(valueType)) {
             propsSchema.type(Schema.SchemaType.OBJECT);
             pushToStack(valueType, propsSchema);
-            propsSchema = SchemaRegistry.checkRegistration(index, valueType, typeResolver, propsSchema);
+            propsSchema = SchemaRegistry.checkRegistration(valueType, typeResolver, propsSchema);
         }
 
         return propsSchema;

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
@@ -42,7 +42,7 @@ public class ExpectationWithRefsTests extends OpenApiDataObjectScannerTestBase {
     @Before
     public void setupRegistry() {
         oai = new OpenAPIImpl();
-        registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai);
+        registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai, index);
     }
 
     private void testAssertion(Class<?> target, String expectedResourceName) throws IOException, JSONException {

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
@@ -74,7 +74,7 @@ public class KitchenSinkTest extends OpenApiDataObjectScannerTestBase {
         Type type = ClassType.create(name, Type.Kind.CLASS);
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, type);
         OpenAPIImpl oai = new OpenAPIImpl();
-        SchemaRegistry registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai);
+        SchemaRegistry registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai, index);
 
         Schema result = scanner.process();
         registry.register(type, result);

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
@@ -39,7 +39,7 @@ public class NestedSchemaReferenceTests extends OpenApiDataObjectScannerTestBase
         DotName parentName = componentize(NestedSchemaParent.class.getName());
         Type parentType = ClassType.create(parentName, Type.Kind.CLASS);
         OpenAPIImpl oai = new OpenAPIImpl();
-        SchemaRegistry registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai);
+        SchemaRegistry registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai, index);
 
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, parentType);
 
@@ -58,6 +58,7 @@ public class NestedSchemaReferenceTests extends OpenApiDataObjectScannerTestBase
         index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.class");
         index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource$NestedParameterTestParent.class");
         index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource$NestedParameterTestChild.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource$AnotherNestedChildWithSchemaName.class");
 
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), indexer.complete());
 

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.runtime.scanner;
+
+import java.io.IOException;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Indexer;
+import org.json.JSONException;
+import org.junit.Test;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+public class ResourceParameterTests extends OpenApiDataObjectScannerTestBase {
+
+    /*
+     * Test cast derived from original example in Smallrye OpenAPI issue #25.
+     *
+     * https://github.com/smallrye/smallrye-open-api/issues/25
+     *
+     */
+    @Test
+    public void testParameterResource() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+
+        // Test samples
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/ParameterResource.class");
+
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), indexer.complete());
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("resource.parameters.simpleSchema.json", result);
+    }
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/FooResource.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/FooResource.java
@@ -3,6 +3,7 @@ package test.io.smallrye.openapi.runtime.scanner.resources;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+@SuppressWarnings("unused")
 @Path("foo")
 public class FooResource {
 

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.java
@@ -3,6 +3,8 @@ package test.io.smallrye.openapi.runtime.scanner.resources;
 import java.util.List;
 import java.util.Map;
 
+import javax.enterprise.context.Dependent;
+import javax.json.bind.annotation.JsonbProperty;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -27,6 +29,10 @@ public class NestedSchemaOnParameterResource {
         @Schema(required = true)
         NestedParameterTestChild nested;
 
+        @JsonbProperty("will_not_be_used")
+        @Schema(name = "another_child", description = "This schema and description will be replaced with a $ref to 'another_nested', but the name will be used for the property")
+        AnotherNestedChildWithSchemaName another;
+
         List<NestedParameterTestChild> childList;
 
         Map<String, NestedParameterTestChild> childMap;
@@ -36,6 +42,15 @@ public class NestedSchemaOnParameterResource {
     public static class NestedParameterTestChild {
         @Schema(required = true)
         String id;
+        String name;
+    }
+
+    @Dependent
+    @Schema(name = "another_nested", description = "The name of this child is not 'AnotherNestedChildWithSchemaName'")
+    public static class AnotherNestedChildWithSchemaName {
+        @Schema(required = true)
+        String id;
+        @Schema(name = "name_", title = "This property's 'name' has been overridden using the @Schema")
         String name;
     }
 

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/ParameterResource.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/ParameterResource.java
@@ -1,0 +1,47 @@
+package test.io.smallrye.openapi.runtime.scanner.resources;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+/**
+ * Test case for smallrye-open-api issue #25
+ * https://github.com/smallrye/smallrye-open-api/issues/25
+ *
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+@SuppressWarnings("unused")
+@Path("params/{taskId}")
+public class ParameterResource {
+
+    @DELETE
+    @Path("/unnamed")
+    @APIResponse(responseCode = "204", description = "No content")
+    public Response deleteTaskWithoutParamName(@Parameter(
+            description = "The id of the task",
+            example = "e1cb23d0-6cbe-4a29",
+            schema = @Schema(
+                    type = SchemaType.STRING)) @PathParam("taskId") String taskId,
+                                               @QueryParam("nextTask") String nextTaskId) {
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Path("/named")
+    @APIResponse(responseCode = "204", description = "No content")
+    public Response deleteTaskWithParamName(@Parameter(
+            description = "The id of the task",
+            name = "notTaskId",
+            example = "e1cb23d0-6cbe-4a29",
+            schema = @Schema(
+                    type = SchemaType.STRING)) @PathParam("taskId") String taskId) {
+        return Response.noContent().build();
+    }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.testNestedSchemaOnParameter.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.testNestedSchemaOnParameter.json
@@ -44,6 +44,9 @@
           "nested": {
             "$ref": "#/components/schemas/NestedParameterTestChild"
           },
+          "another_child": {
+            "$ref": "#/components/schemas/another_nested"
+          },
           "childList": {
             "type": "array",
             "items": {
@@ -70,6 +73,22 @@
           },
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "another_nested": {
+        "type": "object",
+        "description": "The name of this child is not 'AnotherNestedChildWithSchemaName'",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name_": {
+            "type": "string",
+            "title": "This property's 'name' has been overridden using the @Schema"
           }
         }
       }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.simpleSchema.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.simpleSchema.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/params/{taskId}/unnamed": {
+      "delete": {
+        "parameters": [{
+          "name": "taskId",
+          "in": "path",
+          "required": true,
+          "description": "The id of the task",
+          "schema": {
+            "type": "string"
+          },
+          "example": "e1cb23d0-6cbe-4a29"
+        }, {
+          "name": "nextTask",
+          "in": "query",
+          "schema": {
+            "type": "string"
+          }
+        }],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    },
+    "/params/{taskId}/named": {
+      "delete": {
+        "parameters": [{
+          "name": "notTaskId",
+          "in": "path",
+          "required": true,
+          "description": "The id of the task",
+          "schema": {
+            "type": "string"
+          },
+          "example": "e1cb23d0-6cbe-4a29"
+        }],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is what I have for the change to use the @Schema name (and issue #25). Most of the real change is in the schema registry, but I also consolidated some duplicate functions and moved some that seemed better placed in the SchemaFactory than in the main scanner. As noted in the code comments, this does not handle merging Schema information found in @Components with information found directly on the models. 

I think we might need to have a bigger discussion around how best to merge/resolve things within the scanning phase (not to mention the higher-level phases) and whether or not warnings should be logged if the user codes annotations that are not valid or have undefined behavior. For example, a @Schema with a ref that also includes other properties - a good case to issue warning messages? I like the idea of being told that something in an annotation will be ignored/discarded or is otherwise not valid.

* Consolidate duplicate Schema utility functions into SchemaFactory
* Construct SchemaRegistry with the IndexView
* Use custom key to store schemas in registry for added control of the equals/hashCode methods
* Update JAX-RS annotation scanning to address issue #25