### PR TITLE
Use Bean Validation constraints for schema parameters if not specified

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -70,6 +70,10 @@ public class SchemaRegistry {
         return current.get();
     }
 
+    public static void remove() {
+        current.remove();
+    }
+
     /**
      * Check if the entityType is eligible for registration using the
      * typeResolver. The eligible kinds of types are

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -116,6 +116,7 @@ public class AnnotationTargetProcessor {
             readSchemaAnnotatedField(propertyKey, schemaAnnotation);
         }
 
+        BeanValidationScanner.applyConstraints(annotationTarget, fieldSchema);
         fieldSchema = SchemaRegistry.checkRegistration(entityType, typeResolver, fieldSchema);
         parentPathEntry.getSchema().addProperty(propertyKey, fieldSchema);
         return fieldSchema;

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java
@@ -1,0 +1,456 @@
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import static io.smallrye.openapi.runtime.util.JandexUtil.booleanValue;
+import static io.smallrye.openapi.runtime.util.JandexUtil.intValue;
+import static io.smallrye.openapi.runtime.util.JandexUtil.stringValue;
+import static io.smallrye.openapi.runtime.util.TypeUtil.getAnnotation;
+import static org.jboss.jandex.DotName.createComponentized;
+
+import java.math.BigDecimal;
+
+import javax.validation.groups.Default;
+
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+import org.jboss.logging.Logger;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+public class BeanValidationScanner {
+
+    static final BeanValidationScanner INSTANCE = new BeanValidationScanner();
+
+    private final Logger LOG = Logger.getLogger(BeanValidationScanner.class);
+
+    static final BigDecimal NEGATIVE_ONE = BigDecimal.ZERO.subtract(BigDecimal.ONE);
+
+    static final DotName BV_JAVAX = createComponentized(null, "javax");
+    static final DotName BV_BASE = createComponentized(BV_JAVAX, "validation");
+
+    static final DotName BV_GROUPS = createComponentized(BV_BASE, "groups");
+    static final DotName BV_DEFAULT_GROUP = createComponentized(BV_GROUPS, "Default");
+
+    static final DotName BV_CONTRAINTS = createComponentized(BV_BASE, "constraints");
+
+    //static final DotName BV_ASSERT_TRUE = createComponentized(BV_CONTRAINTS, "AssertTrue");
+    //static final DotName BV_ASSERT_FALSE = createComponentized(BV_CONTRAINTS, "AssertFalse");
+    static final DotName BV_DECIMAL_MAX = createComponentized(BV_CONTRAINTS, "DecimalMax");
+    static final DotName BV_DECIMAL_MIN = createComponentized(BV_CONTRAINTS, "DecimalMin");
+    static final DotName BV_DIGITS = createComponentized(BV_CONTRAINTS, "Digits");
+    //static final DotName BV_EMAIL = createComponentized(BV_CONTRAINTS, "Email");
+    //static final DotName BV_FUTURE = createComponentized(BV_CONTRAINTS, "Future");
+    //static final DotName BV_FUTURE_OR_PRESENT = createComponentized(BV_CONTRAINTS, "FutureOrPresent");
+    static final DotName BV_MAX = createComponentized(BV_CONTRAINTS, "Max");
+    static final DotName BV_MIN = createComponentized(BV_CONTRAINTS, "Min");
+    static final DotName BV_NEGATIVE = createComponentized(BV_CONTRAINTS, "Negative");
+    static final DotName BV_NEGATIVE_OR_ZERO = createComponentized(BV_CONTRAINTS, "NegativeOrZero");
+    static final DotName BV_NOT_BLANK = createComponentized(BV_CONTRAINTS, "NotBlank");
+    static final DotName BV_NOT_EMPTY = createComponentized(BV_CONTRAINTS, "NotEmpty");
+    static final DotName BV_NOT_NULL = createComponentized(BV_CONTRAINTS, "NotNull");
+    //static final DotName BV_NULL = createComponentized(BV_CONTRAINTS, "Null");
+    //static final DotName BV_PAST = createComponentized(BV_CONTRAINTS, "Past");
+    //static final DotName BV_PAST_OR_PRESENT = createComponentized(BV_CONTRAINTS, "PastOrPresent");
+    //static final DotName BV_PATTERN = createComponentized(BV_CONTRAINTS, "Pattern");
+    static final DotName BV_POSITIVE = createComponentized(BV_CONTRAINTS, "Positive");
+    static final DotName BV_POSITIVE_OR_ZERO = createComponentized(BV_CONTRAINTS, "PositiveOrZero");
+    static final DotName BV_SIZE = createComponentized(BV_CONTRAINTS, "Size");
+
+    /**
+     * Determine if any Java Bean Validation constraint annotations are present
+     * on the {@link AnnotationTarget} that are applicable to the schema. This
+     * method will apply the constraints to the schema only if no value has
+     * previously been set.
+     *
+     * If the schema's type attribute has not been previously set or the schema
+     * contains a reference, this method will not apply any changes to the
+     * schema.
+     *
+     * Each of the constraints (defined in javax.validation.constraints)
+     * will apply to the schema based on the schema's type.
+     *
+     * @param target
+     *            the object from which to retrieve the constraint annotations
+     * @param schema
+     *            the schema to which the constraints will be applied
+     */
+    public static void applyConstraints(AnnotationTarget target, Schema schema) {
+        SchemaType schemaType = schema.getType();
+
+        /*
+         * The type be set. Attributes set in this function are not application
+         * to $ref type schemas.
+         */
+        if (schemaType == null || schema.getRef() != null) {
+            return;
+        }
+
+        switch (schemaType) {
+        case ARRAY:
+            INSTANCE.notNull(target, schema);
+            INSTANCE.sizeArray(target, schema);
+            INSTANCE.notEmptyArray(target, schema);
+            break;
+        case BOOLEAN:
+            INSTANCE.notNull(target, schema);
+            break;
+        case INTEGER:
+            INSTANCE.decimalMax(target, schema);
+            INSTANCE.decimalMin(target, schema);
+            INSTANCE.digits(target, schema);
+            INSTANCE.max(target, schema);
+            INSTANCE.min(target, schema);
+            INSTANCE.negative(target, schema);
+            INSTANCE.negativeOrZero(target, schema);
+            INSTANCE.notNull(target, schema);
+            INSTANCE.positive(target, schema);
+            INSTANCE.positiveOrZero(target, schema);
+            break;
+        case NUMBER:
+            INSTANCE.decimalMax(target, schema);
+            INSTANCE.decimalMin(target, schema);
+            INSTANCE.digits(target, schema);
+            INSTANCE.max(target, schema);
+            INSTANCE.min(target, schema);
+            INSTANCE.negative(target, schema);
+            INSTANCE.negativeOrZero(target, schema);
+            INSTANCE.notNull(target, schema);
+            INSTANCE.positive(target, schema);
+            INSTANCE.positiveOrZero(target, schema);
+            break;
+        case OBJECT:
+            INSTANCE.notNull(target, schema);
+            INSTANCE.sizeObject(target, schema);
+            INSTANCE.notEmptyObject(target, schema);
+            break;
+        case STRING:
+            INSTANCE.decimalMax(target, schema);
+            INSTANCE.decimalMin(target, schema);
+            INSTANCE.digits(target, schema);
+            INSTANCE.notBlank(target, schema);
+            INSTANCE.notNull(target, schema);
+            INSTANCE.sizeString(target, schema);
+            INSTANCE.notEmptyString(target, schema);
+            break;
+        }
+    }
+
+    void decimalMax(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_DECIMAL_MAX);
+
+        if (constraint != null && schema.getMaximum() == null) {
+            String decimalValue = stringValue(constraint, "value");
+            try {
+                BigDecimal decimal = new BigDecimal(decimalValue);
+                schema.setMaximum(decimal);
+
+                Boolean inclusive = booleanValue(constraint, "inclusive");
+
+                if (schema.getExclusiveMaximum() == null && inclusive != null && !inclusive) {
+                    schema.setExclusiveMaximum(Boolean.TRUE);
+                }
+            } catch (@SuppressWarnings("unused") NumberFormatException e) {
+                LOG.debugv("Annotation value has invalid format: {0}", decimalValue);
+            }
+        }
+    }
+
+    void decimalMin(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_DECIMAL_MIN);
+
+        if (constraint != null && schema.getMinimum() == null) {
+            String decimalValue = stringValue(constraint, "value");
+            try {
+                BigDecimal decimal = new BigDecimal(decimalValue);
+                schema.setMinimum(decimal);
+                Boolean inclusive = booleanValue(constraint, "inclusive");
+
+                if (schema.getExclusiveMinimum() == null && inclusive != null && !inclusive) {
+                    schema.setExclusiveMinimum(Boolean.TRUE);
+                }
+            } catch (@SuppressWarnings("unused") NumberFormatException e) {
+                LOG.debugv("Annotation value has invalid format: {0}", decimalValue);
+            }
+        }
+
+    }
+
+    void digits(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_DIGITS);
+
+        if (constraint != null && schema.getPattern() == null) {
+            // Both attributes are required - safe to use primitives.
+            final int integerPart = intValue(constraint, "integer");
+            final int fractionPart = intValue(constraint, "fraction");
+            final StringBuilder pattern = new StringBuilder(50);
+
+            pattern.append('^');
+
+            if (integerPart > 0) {
+                pattern.append("\\d");
+
+                if (integerPart > 1) {
+                    pattern.append("{1,").append(integerPart).append('}');
+                }
+            }
+
+            if (fractionPart > 0) {
+                pattern.append("([.]\\d");
+
+                if (fractionPart > 1) {
+                    pattern.append("{1,").append(fractionPart).append("}");
+                }
+
+                pattern.append(")?");
+            }
+
+            pattern.append('$');
+            schema.setPattern(pattern.toString());
+        }
+    }
+
+    void max(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_MAX);
+
+        if (constraint != null && schema.getMaximum() == null) {
+            AnnotationValue value = constraint.value("value");
+            schema.setMaximum(new BigDecimal(value.asLong()));
+        }
+    }
+
+    void min(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_MIN);
+
+        if (constraint != null && schema.getMinimum() == null) {
+            AnnotationValue value = constraint.value("value");
+            schema.setMinimum(new BigDecimal(value.asLong()));
+        }
+    }
+
+    void negative(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_NEGATIVE);
+
+        if (constraint != null && schema.getMaximum() == null) {
+            Boolean exclusive = schema.getExclusiveMaximum();
+
+            if (exclusive != null && exclusive) {
+                schema.setMaximum(BigDecimal.ZERO);
+            } else {
+                schema.setMaximum(NEGATIVE_ONE);
+            }
+        }
+    }
+
+    void negativeOrZero(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_NEGATIVE_OR_ZERO);
+
+        if (constraint != null && schema.getMaximum() == null) {
+            Boolean exclusive = schema.getExclusiveMaximum();
+
+            if (exclusive != null && exclusive) {
+                schema.setMaximum(BigDecimal.ONE);
+            } else {
+                schema.setMaximum(BigDecimal.ZERO);
+            }
+        }
+    }
+
+    void notBlank(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_NOT_BLANK);
+
+        if (constraint != null) {
+            if (schema.getNullable() == null) {
+                schema.setNullable(Boolean.FALSE);
+            }
+            if (schema.getPattern() == null) {
+                schema.setPattern("\\S");
+            }
+        }
+    }
+
+    void notEmptyArray(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_NOT_EMPTY);
+
+        if (constraint != null) {
+            if (schema.getMinItems() == null) {
+                schema.setMinItems(1);
+            }
+        }
+    }
+
+    void notEmptyObject(AnnotationTarget target, Schema schema) {
+        if (!allowsAdditionalProperties(schema)) {
+            return;
+        }
+
+        AnnotationInstance constraint = getConstraint(target, BV_NOT_EMPTY);
+
+        if (constraint != null) {
+            if (schema.getMinProperties() == null) {
+                schema.setMinProperties(1);
+            }
+        }
+    }
+
+    void notEmptyString(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_NOT_EMPTY);
+
+        if (constraint != null) {
+            if (schema.getNullable() == null) {
+                schema.setNullable(Boolean.FALSE);
+            }
+
+            if (schema.getMinLength() == null) {
+                schema.setMinLength(1);
+            }
+        }
+    }
+
+    void notNull(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_NOT_NULL);
+
+        if (constraint != null && schema.getNullable() == null) {
+            schema.setNullable(Boolean.FALSE);
+        }
+    }
+
+    void positive(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_POSITIVE);
+
+        if (constraint != null && schema.getMinimum() == null) {
+            Boolean exclusive = schema.getExclusiveMinimum();
+
+            if (exclusive != null && exclusive) {
+                schema.setMinimum(BigDecimal.ZERO);
+            } else {
+                schema.setMinimum(BigDecimal.ONE);
+            }
+        }
+    }
+
+    void positiveOrZero(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_POSITIVE_OR_ZERO);
+
+        if (constraint != null && schema.getMinimum() == null) {
+            Boolean exclusive = schema.getExclusiveMinimum();
+
+            if (exclusive != null && exclusive) {
+                schema.setMinimum(NEGATIVE_ONE);
+            } else {
+                schema.setMinimum(BigDecimal.ZERO);
+            }
+        }
+    }
+
+    void sizeArray(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_SIZE);
+
+        if (constraint != null) {
+            Integer min = intValue(constraint, "min");
+            Integer max = intValue(constraint, "max");
+
+            if (min != null && schema.getMinItems() == null) {
+                schema.setMinItems(min);
+            }
+
+            if (max != null && schema.getMaxItems() == null) {
+                schema.setMaxItems(max);
+            }
+        }
+    }
+
+    void sizeObject(AnnotationTarget target, Schema schema) {
+        if (!allowsAdditionalProperties(schema)) {
+            return;
+        }
+
+        AnnotationInstance constraint = getConstraint(target, BV_SIZE);
+
+        if (constraint != null) {
+            Integer min = intValue(constraint, "min");
+            Integer max = intValue(constraint, "max");
+
+            if (min != null && schema.getMinProperties() == null) {
+                schema.setMinProperties(min);
+            }
+
+            if (max != null && schema.getMaxProperties() == null) {
+                schema.setMaxProperties(max);
+            }
+        }
+    }
+
+    void sizeString(AnnotationTarget target, Schema schema) {
+        AnnotationInstance constraint = getConstraint(target, BV_SIZE);
+
+        if (constraint != null) {
+            Integer min = intValue(constraint, "min");
+            Integer max = intValue(constraint, "max");
+
+            if (min != null && schema.getMinLength() == null) {
+                schema.setMinLength(min);
+            }
+
+            if (max != null && schema.getMaxLength() == null) {
+                schema.setMaxLength(max);
+            }
+        }
+    }
+
+    boolean allowsAdditionalProperties(Schema schema) {
+        Boolean additionalProperties = schema.getAdditionalPropertiesBoolean();
+
+        if (additionalProperties != null) {
+            return additionalProperties;
+        }
+
+        return schema.getAdditionalPropertiesSchema() != null;
+    }
+
+    /**
+     * Retrieves a constraint {@link AnnotationInstance} from the current
+     * target. If the annotation is found and applies to multiple bean
+     * validation groups or to a single group other than the {@link Default},
+     * returns null.
+     *
+     * @param target
+     *            the object from which to retrieve the constraint annotation
+     * @param annotationName
+     *            name of the annotation
+     * @return the first occurrence of the named constraint if no groups or only
+     *         the {@link Default} group is specified, or null
+     */
+    AnnotationInstance getConstraint(AnnotationTarget target, DotName annotationName) {
+        AnnotationInstance constraint = getAnnotation(target, annotationName);
+
+        if (constraint != null) {
+            AnnotationValue groupValue = constraint.value("groups");
+
+            if (groupValue == null) {
+                return constraint;
+            }
+
+            Type[] groups = groupValue.asClassArray();
+
+            switch (groups.length) {
+            case 0:
+                return constraint;
+            case 1:
+                if (groups[0].name().equals(BV_DEFAULT_GROUP)) {
+                    return constraint;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IndexScannerTestBase.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IndexScannerTestBase.java
@@ -1,0 +1,178 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Indexer;
+import org.jboss.logging.Logger;
+import org.json.JSONException;
+import org.junit.After;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConfigImpl;
+import io.smallrye.openapi.api.OpenApiConstants;
+import io.smallrye.openapi.api.models.ComponentsImpl;
+import io.smallrye.openapi.api.models.OpenAPIImpl;
+import io.smallrye.openapi.runtime.io.OpenApiSerializer;
+
+public class IndexScannerTestBase {
+
+    private static final Logger LOG = Logger.getLogger(IndexScannerTestBase.class);
+
+    @After
+    public void removeSchemaRegistry() {
+        SchemaRegistry.remove();
+    }
+
+    protected static void indexDirectory(Indexer indexer, String baseDir) {
+        InputStream directoryStream = tcclGetResourceAsStream(baseDir);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(directoryStream));
+        reader.lines()
+                .filter(resName -> resName.endsWith(".class"))
+                .map(resName -> Paths.get(baseDir, resName)) // e.g. test/io/smallrye/openapi/runtime/scanner/entities/ + Bar.class
+                .forEach(path -> index(indexer, path.toString()));
+    }
+
+    private static InputStream tcclGetResourceAsStream(String path) {
+        return Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream(path);
+    }
+
+    protected static void index(Indexer indexer, String resName) {
+        try {
+            InputStream stream = tcclGetResourceAsStream(resName);
+            indexer.index(stream);
+        } catch (IOException ioe) {
+            throw new UncheckedIOException(ioe);
+        }
+    }
+
+    protected static DotName componentize(String className) {
+        boolean innerClass = className.contains("$");
+        DotName prefix = null;
+        String[] components = className.split("[\\.$]");
+        int lastIndex = components.length - 1;
+
+        for (int i = 0; i < components.length; i++) {
+            String localName = components[i];
+
+            if (i < lastIndex) {
+                prefix = DotName.createComponentized(prefix, localName);
+            } else {
+                prefix = DotName.createComponentized(prefix, localName, innerClass);
+            }
+        }
+
+        return prefix;
+    }
+
+    public static void printToConsole(String entityName, Schema schema) throws IOException {
+        // Remember to set debug level logging.
+        LOG.debug(schemaToString(entityName, schema));
+        System.out.println(schemaToString(entityName, schema));
+    }
+
+    public static void printToConsole(OpenAPI oai) throws IOException {
+        // Remember to set debug level logging.
+        LOG.debug(OpenApiSerializer.serialize(oai, OpenApiSerializer.Format.JSON));
+        System.out.println(OpenApiSerializer.serialize(oai, OpenApiSerializer.Format.JSON));
+    }
+
+    public static String schemaToString(String entityName, Schema schema) throws IOException {
+        Map<String, Schema> map = new HashMap<>();
+        map.put(entityName, schema);
+        OpenAPIImpl oai = new OpenAPIImpl();
+        ComponentsImpl comp = new ComponentsImpl();
+        comp.setSchemas(map);
+        oai.setComponents(comp);
+        return OpenApiSerializer.serialize(oai, OpenApiSerializer.Format.JSON);
+    }
+
+    public static void assertJsonEquals(String entityName, String expectedResource, Schema actual) throws JSONException, IOException {
+        URL resourceUrl = IndexScannerTestBase.class.getResource(expectedResource);
+        JSONAssert.assertEquals(loadResource(resourceUrl), schemaToString(entityName, actual),  true);
+    }
+
+    public static void assertJsonEquals(String expectedResource, OpenAPI actual) throws JSONException, IOException {
+        URL resourceUrl = IndexScannerTestBase.class.getResource(expectedResource);
+        JSONAssert.assertEquals(loadResource(resourceUrl), OpenApiSerializer.serialize(actual, OpenApiSerializer.Format.JSON),  true);
+    }
+
+    public static String loadResource(URL testResource) throws IOException {
+        return IOUtils.toString(testResource, "UTF-8");
+    }
+
+    public static OpenApiConfig emptyConfig() {
+        return new OpenApiConfigImpl(new Config() {
+            @Override
+            public <T> T getValue(String propertyName, Class<T> propertyType) {
+                return null;
+            }
+
+            @Override
+            public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Iterable<String> getPropertyNames() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Iterable<ConfigSource> getConfigSources() {
+                return Collections.emptyList();
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    public static OpenApiConfig nestingSupportConfig() {
+        return new OpenApiConfigImpl(new Config() {
+            @Override
+            public <T> T getValue(String propertyName, Class<T> propertyType) {
+                if (OpenApiConstants.SCHEMA_REFERENCES_ENABLE.equals(propertyName)) {
+                    return (T) Boolean.TRUE;
+                }
+                return null;
+            }
+
+            @Override
+            public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+                if (OpenApiConstants.SCHEMA_REFERENCES_ENABLE.equals(propertyName)) {
+                    return (Optional<T>) Optional.of(Boolean.TRUE);
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public Iterable<String> getPropertyNames() {
+                return Arrays.asList(OpenApiConstants.SCHEMA_REFERENCES_ENABLE);
+            }
+
+            @Override
+            public Iterable<ConfigSource> getConfigSources() {
+                // Not needed for this test case
+                return Collections.emptyList();
+            }
+        });
+    }
+}

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScannerTestBase.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScannerTestBase.java
@@ -15,47 +15,18 @@
  */
 package io.smallrye.openapi.runtime.scanner;
 
-import io.smallrye.openapi.api.OpenApiConfig;
-import io.smallrye.openapi.api.OpenApiConfigImpl;
-import io.smallrye.openapi.api.OpenApiConstants;
-import io.smallrye.openapi.api.models.ComponentsImpl;
-import io.smallrye.openapi.api.models.OpenAPIImpl;
-import io.smallrye.openapi.runtime.io.OpenApiSerializer;
-
-import org.apache.commons.io.IOUtils;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.spi.ConfigSource;
-import org.eclipse.microprofile.openapi.models.OpenAPI;
-import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
-import org.jboss.logging.Logger;
-import org.json.JSONException;
 import org.junit.BeforeClass;
-import org.skyscreamer.jsonassert.JSONAssert;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
-import java.net.URL;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
  */
-public class OpenApiDataObjectScannerTestBase {
+public class OpenApiDataObjectScannerTestBase extends IndexScannerTestBase {
 
-    private static final Logger LOG = Logger.getLogger(OpenApiDataObjectScannerTestBase.class);
     protected static Index index;
 
     @BeforeClass
@@ -82,133 +53,8 @@ public class OpenApiDataObjectScannerTestBase {
         index = indexer.complete();
     }
 
-    static DotName componentize(String className) {
-        DotName prefix = null;
-        for (String localName : className.split("\\.")) {
-            prefix = DotName.createComponentized(prefix, localName);
-        }
-        return prefix;
-    }
-
-    static void indexDirectory(Indexer indexer, String baseDir) {
-        InputStream directoryStream = tcclGetResourceAsStream(baseDir);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(directoryStream));
-        reader.lines()
-                .filter(resName -> resName.endsWith(".class"))
-                .map(resName -> Paths.get(baseDir, resName)) // e.g. test/io/smallrye/openapi/runtime/scanner/entities/ + Bar.class
-                .forEach(path -> index(indexer, path.toString()));
-    }
-
-    private static InputStream tcclGetResourceAsStream(String path) {
-        return Thread.currentThread()
-                .getContextClassLoader()
-                .getResourceAsStream(path);
-    }
-
-    static void index(Indexer indexer, String resName) {
-        try {
-            InputStream stream = tcclGetResourceAsStream(resName);
-            indexer.index(stream);
-        } catch (IOException ioe) {
-            throw new UncheckedIOException(ioe);
-        }
-    }
-
-    public static void printToConsole(String entityName, Schema schema) throws IOException {
-        // Remember to set debug level logging.
-        LOG.debug(schemaToString(entityName, schema));
-        System.out.println(schemaToString(entityName, schema));
-    }
-
-    public static void printToConsole(OpenAPI oai) throws IOException {
-        // Remember to set debug level logging.
-        LOG.debug(OpenApiSerializer.serialize(oai, OpenApiSerializer.Format.JSON));
-        System.out.println(OpenApiSerializer.serialize(oai, OpenApiSerializer.Format.JSON));
-    }
-
-    public static String schemaToString(String entityName, Schema schema) throws IOException {
-        Map<String, Schema> map = new HashMap<>();
-        map.put(entityName, schema);
-        OpenAPIImpl oai = new OpenAPIImpl();
-        ComponentsImpl comp = new ComponentsImpl();
-        comp.setSchemas(map);
-        oai.setComponents(comp);
-        return OpenApiSerializer.serialize(oai, OpenApiSerializer.Format.JSON);
-    }
-
-    public static void assertJsonEquals(String entityName, String expectedResource, Schema actual) throws JSONException, IOException {
-        URL resourceUrl = OpenApiDataObjectScannerTestBase.class.getResource(expectedResource);
-        JSONAssert.assertEquals(loadResource(resourceUrl), schemaToString(entityName, actual),  true);
-    }
-
-    public static void assertJsonEquals(String expectedResource, OpenAPI actual) throws JSONException, IOException {
-        URL resourceUrl = OpenApiDataObjectScannerTestBase.class.getResource(expectedResource);
-        JSONAssert.assertEquals(loadResource(resourceUrl), OpenApiSerializer.serialize(actual, OpenApiSerializer.Format.JSON),  true);
-    }
-
-    public static String loadResource(URL testResource) throws IOException {
-        return IOUtils.toString(testResource, "UTF-8");
-    }
-
     public FieldInfo getFieldFromKlazz(String containerName, String fieldName) {
         ClassInfo container = index.getClassByName(DotName.createSimple(containerName));
         return container.field(fieldName);
-    }
-
-    public static OpenApiConfig emptyConfig() {
-        return new OpenApiConfigImpl(new Config() {
-
-            @Override
-            public <T> T getValue(String propertyName, Class<T> propertyType) {
-                return null;
-            }
-
-            @Override
-            public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Iterable<String> getPropertyNames() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public Iterable<ConfigSource> getConfigSources() {
-                return Collections.emptyList();
-            }
-        });
-    }
-
-    @SuppressWarnings("unchecked")
-    public static OpenApiConfig nestingSupportConfig() {
-        return new OpenApiConfigImpl(new Config() {
-            @Override
-            public <T> T getValue(String propertyName, Class<T> propertyType) {
-                if (OpenApiConstants.SCHEMA_REFERENCES_ENABLE.equals(propertyName)) {
-                    return (T) Boolean.TRUE;
-                }
-                return null;
-            }
-
-            @Override
-            public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
-                if (OpenApiConstants.SCHEMA_REFERENCES_ENABLE.equals(propertyName)) {
-                    return (Optional<T>) Optional.of(Boolean.TRUE);
-                }
-                return Optional.empty();
-            }
-
-            @Override
-            public Iterable<String> getPropertyNames() {
-                return Arrays.asList(OpenApiConstants.SCHEMA_REFERENCES_ENABLE);
-            }
-
-            @Override
-            public Iterable<ConfigSource> getConfigSources() {
-                // Not needed for this test case
-                return Collections.emptyList();
-            }
-        });
     }
 }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
@@ -1,0 +1,103 @@
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+import javax.json.bind.annotation.JsonbProperty;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
+import io.smallrye.openapi.runtime.scanner.OpenApiAnnotationScanner;
+import io.smallrye.openapi.runtime.scanner.dataobject.BeanValidationScannerTest.BVTestContainer;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+public class BeanValidationResourceTest extends IndexScannerTestBase {
+
+    Index index;
+
+    @Before
+    public void beforeEach() {
+        Indexer indexer = new Indexer();
+        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest$BVTestContainer.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest$BVTestResource.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest$BVTestResourceEntity.class");
+
+        index = indexer.complete();
+    }
+
+    @Test
+    public void testBeanValidationDocument() throws IOException, JSONException {
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("dataobject/resource.testBeanValidationDocument.json", result);
+    }
+
+    /**********************************************************************/
+
+    @Path("/bv")
+    static class BVTestResource {
+        @SuppressWarnings("unused")
+        @Path("/test-container")
+        @POST
+        @Produces(MediaType.APPLICATION_JSON)
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Tag(name = "Test", description = "Testing the container")
+        public BVTestContainer getTestContainer(BVTestResourceEntity parameter) {
+            return new BVTestContainer();
+        }
+    }
+
+    static class BVTestResourceEntity {
+        @Size(min = 5, max = 100)
+        @NotNull
+        @Schema(minLength = 10, maxLength = 101, nullable = true, name = "string_no_bean_constraints")
+        @JsonbProperty("string_no_bean_constraints")
+        private String stringIgnoreBvContraints;
+
+        @Size(min = 1, max = 2000)
+        @Digits(integer = 100, fraction = 100)
+        @NotNull
+        @Schema(minimum = "101", maximum = "101.999", nullable = true, pattern = "^\\d{1,3}([.]\\d{1,3})?$", name = "big_int_no_bean_constraints")
+        @JsonbProperty("big_int_no_bean_constraints")
+        private BigInteger bIntegerIgnoreBvContraints;
+
+        @NotNull
+        @NotEmpty
+        @Size(max = 200)
+        @Schema(minItems = 0, maxItems = 100, nullable = true, name = "list_no_bean_constraints")
+        @JsonbProperty("list_no_bean_constraints")
+        private List<String> listIgnoreBvContraints;
+
+        @NotNull
+        @NotEmpty
+        @Size(max = 200)
+        @Schema(minProperties = 0, maxProperties = 100, nullable = true, name = "map_no_bean_constraints")
+        @JsonbProperty("map_no_bean_constraints")
+        private Map<String, String> mapIgnoreBvContraints;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.java
@@ -1,0 +1,509 @@
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
+import javax.validation.groups.Default;
+
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+public class BeanValidationScannerTest extends IndexScannerTestBase {
+
+    BeanValidationScanner testTarget;
+    Index index;
+    Set<String> methodsInvoked = new LinkedHashSet<>();
+    Schema schema;
+    ClassInfo targetClass;
+
+    @Before
+    public void beforeEach() {
+        testTarget = BeanValidationScanner.INSTANCE;
+
+        Indexer indexer = new Indexer();
+        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest$BVTestContainer.class");
+        index = indexer.complete();
+
+        methodsInvoked.clear();
+        schema = new SchemaImpl();
+        targetClass = index.getClassByName(componentize(BVTestContainer.class.getName()));
+    }
+
+    Schema proxySchema() {
+        Schema schemaProxy = (Schema) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
+                                                      new Class<?>[] { Schema.class },
+                                                      new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy,
+                                 Method method,
+                                 Object[] args) throws Throwable {
+                methodsInvoked.add(method.getName());
+                return method.invoke(schema, args);
+            }
+        });
+
+        return schemaProxy;
+    }
+
+    @Test
+    public void testNullSchemaIgnored() {
+        BeanValidationScanner.applyConstraints(targetClass, proxySchema());
+
+        assertArrayEquals("Unexpected methods were invoked",
+                          new String[] { "getType" },
+                          methodsInvoked.toArray());
+    }
+
+    @Test
+    public void testRefSchemaIgnored() {
+        schema.setType(SchemaType.OBJECT);
+        schema.setRef("#/components/schemas/Anything");
+        BeanValidationScanner.applyConstraints(targetClass, proxySchema());
+
+        assertArrayEquals("Unexpected methods were invoked",
+                          new String[] { "getType", "getRef" },
+                          methodsInvoked.toArray());
+    }
+
+    /**********************************************************************/
+
+    @Test
+    public void testArrayListNotNullAndNotEmptyAndMaxItems() {
+        FieldInfo targetField = targetClass.field("arrayListNotNullAndNotEmptyAndMaxItems");
+
+        testTarget.notNull(targetField, schema);
+        testTarget.sizeArray(targetField, schema);
+        testTarget.notEmptyArray(targetField, schema);
+
+        assertEquals(Boolean.FALSE, schema.getNullable());
+        assertEquals(Integer.valueOf(1), schema.getMinItems());
+        assertEquals(Integer.valueOf(20), schema.getMaxItems());
+    }
+
+    @Test
+    public void testArrayListNullableAndMinItemsAndMaxItems() {
+        FieldInfo targetField = targetClass.field("arrayListNullableAndMinItemsAndMaxItems");
+        testTarget.notNull(targetField, schema);
+        testTarget.sizeArray(targetField, schema);
+        testTarget.notEmptyArray(targetField, schema);
+
+        assertEquals(null, schema.getNullable());
+        assertEquals(Integer.valueOf(5), schema.getMinItems());
+        assertEquals(Integer.valueOf(20), schema.getMaxItems());
+    }
+
+    /**********************************************************************/
+
+    @Test
+    public void testMapObjectNotNullAndNotEmptyAndMaxProperties() {
+        schema.setAdditionalPropertiesBoolean(Boolean.TRUE);
+
+        FieldInfo targetField = targetClass.field("mapObjectNotNullAndNotEmptyAndMaxProperties");
+        testTarget.notNull(targetField, schema);
+        testTarget.sizeObject(targetField, schema);
+        testTarget.notEmptyObject(targetField, schema);
+
+        assertEquals(Boolean.FALSE, schema.getNullable());
+        assertEquals(Integer.valueOf(1), schema.getMinProperties());
+        assertEquals(Integer.valueOf(20), schema.getMaxProperties());
+    }
+
+    @Test
+    public void testMapObjectNullableAndMinPropertiesAndMaxProperties() {
+        schema.setAdditionalPropertiesBoolean(Boolean.TRUE);
+
+        FieldInfo targetField = targetClass.field("mapObjectNullableAndMinPropertiesAndMaxProperties");
+        testTarget.notNull(targetField, schema);
+        testTarget.sizeObject(targetField, schema);
+        testTarget.notEmptyObject(targetField, schema);
+
+        assertEquals(null, schema.getNullable());
+        assertEquals(Integer.valueOf(5), schema.getMinProperties());
+        assertEquals(Integer.valueOf(20), schema.getMaxProperties());
+    }
+
+    @Test
+    public void testMapObjectNullableNoAdditionalProperties() {
+        FieldInfo targetField = targetClass.field("mapObjectNullableAndMinPropertiesAndMaxProperties");
+        testTarget.notNull(targetField, schema);
+        testTarget.sizeObject(targetField, schema);
+        testTarget.notEmptyObject(targetField, schema);
+
+        assertEquals(null, schema.getNullable());
+        assertEquals(null, schema.getMinProperties());
+        assertEquals(null, schema.getMaxProperties());
+    }
+
+    /**********************************************************************/
+
+    @Test
+    public void testDecimalMaxPrimaryDigits() {
+        FieldInfo targetField = targetClass.field("decimalMaxBigDecimalPrimaryDigits");
+        testTarget.decimalMax(targetField, schema);
+        testTarget.digits(targetField, schema);
+
+        assertEquals(new BigDecimal("200.00"), schema.getMaximum());
+        assertEquals(null, schema.getExclusiveMaximum());
+        assertEquals("^\\d{1,3}([.]\\d{1,2})?$", schema.getPattern());
+    }
+
+    @Test
+    public void testDecimalMaxNoConstraint() {
+        testTarget.decimalMax(targetClass.field("decimalMaxBigDecimalNoConstraint"), schema);
+        assertEquals(null, schema.getMaximum());
+        assertEquals(null, schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testDecimalMaxInvalidValue() {
+        testTarget.decimalMax(targetClass.field("decimalMaxBigDecimalInvalidValue"), schema);
+        assertEquals(null, schema.getMaximum());
+        assertEquals(null, schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testDecimalMaxExclusiveDigits() {
+        FieldInfo targetField = targetClass.field("decimalMaxBigDecimalExclusiveDigits");
+        testTarget.decimalMax(targetField, schema);
+        testTarget.digits(targetField, schema);
+        assertEquals(new BigDecimal("201.0"), schema.getMaximum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMaximum());
+        assertEquals("^\\d{1,3}([.]\\d)?$", schema.getPattern());
+    }
+
+    @Test
+    public void testDecimalMaxInclusive() {
+        testTarget.decimalMax(targetClass.field("decimalMaxBigDecimalInclusive"), schema);
+        assertEquals(new BigDecimal("201.00"), schema.getMaximum());
+        assertEquals(null, schema.getExclusiveMaximum());
+    }
+
+    /**********************************************************************/
+
+    @Test
+    public void testDecimalMinPrimary() {
+        testTarget.decimalMin(targetClass.field("decimalMinBigDecimalPrimary"), schema);
+        assertEquals(new BigDecimal("10.0"), schema.getMinimum());
+        assertEquals(null, schema.getExclusiveMinimum());
+    }
+
+    @Test
+    public void testDecimalMinNoConstraint() {
+        testTarget.decimalMin(targetClass.field("decimalMinBigDecimalNoConstraint"), schema);
+        assertEquals(null, schema.getMinimum());
+        assertEquals(null, schema.getExclusiveMinimum());
+    }
+
+    @Test
+    public void testDecimalMinInvalidValue() {
+        testTarget.decimalMin(targetClass.field("decimalMinBigDecimalInvalidValue"), schema);
+        assertEquals(null, schema.getMinimum());
+        assertEquals(null, schema.getExclusiveMinimum());
+    }
+
+    @Test
+    public void testDecimalMinExclusiveDigits() {
+        FieldInfo targetField = targetClass.field("decimalMinBigDecimalExclusiveDigits");
+        testTarget.decimalMin(targetField, schema);
+        testTarget.digits(targetField, schema);
+
+        assertEquals(new BigDecimal("9.00"), schema.getMinimum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMinimum());
+        assertEquals("^\\d([.]\\d{1,2})?$", schema.getPattern());
+    }
+
+    @Test
+    public void testDecimalMinInclusive() {
+        testTarget.decimalMin(targetClass.field("decimalMinBigDecimalInclusive"), schema);
+        assertEquals(new BigDecimal("9.00"), schema.getMinimum());
+        assertEquals(null, schema.getExclusiveMinimum());
+    }
+
+    /**********************************************************************/
+
+    @Test
+    public void testIntegerPositiveNotZeroMaxValue() {
+        FieldInfo targetField = targetClass.field("integerPositiveNotZeroMaxValue");
+        testTarget.max(targetField, schema);
+        testTarget.positive(targetField, schema);
+
+        assertEquals(new BigDecimal("1"), schema.getMinimum());
+        assertEquals(null, schema.getExclusiveMinimum());
+        assertEquals(new BigDecimal("1000"), schema.getMaximum());
+        assertEquals(null, schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testIntegerPositiveNotZeroMaxValueExclusive() {
+        FieldInfo targetField = targetClass.field("integerPositiveNotZeroMaxValue");
+        schema.setExclusiveMaximum(Boolean.TRUE);
+        schema.setExclusiveMinimum(Boolean.TRUE);
+
+        testTarget.max(targetField, schema);
+        testTarget.positive(targetField, schema);
+
+        assertEquals(new BigDecimal("0"), schema.getMinimum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMinimum());
+        assertEquals(new BigDecimal("1000"), schema.getMaximum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testIntegerPositiveOrZeroMaxValue() {
+        FieldInfo targetField = targetClass.field("integerPositiveOrZeroMaxValue");
+        testTarget.max(targetField, schema);
+        testTarget.positiveOrZero(targetField, schema);
+
+        assertEquals(new BigDecimal("0"), schema.getMinimum());
+        assertEquals(null, schema.getExclusiveMinimum());
+        assertEquals(new BigDecimal("999"), schema.getMaximum());
+        assertEquals(null, schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testIntegerPositiveOrZeroMaxValueExclusive() {
+        FieldInfo targetField = targetClass.field("integerPositiveOrZeroMaxValue");
+        schema.setExclusiveMaximum(Boolean.TRUE);
+        schema.setExclusiveMinimum(Boolean.TRUE);
+
+        testTarget.max(targetField, schema);
+        testTarget.positiveOrZero(targetField, schema);
+
+        assertEquals(new BigDecimal("-1"), schema.getMinimum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMinimum());
+        assertEquals(new BigDecimal("999"), schema.getMaximum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMaximum());
+    }
+
+    /**********************************************************************/
+
+    @Test
+    public void testIntegerNegativeNotZeroMinValue() {
+        FieldInfo targetField = targetClass.field("integerNegativeNotZeroMinValue");
+        testTarget.min(targetField, schema);
+        testTarget.negative(targetField, schema);
+
+        assertEquals(new BigDecimal("-1"), schema.getMaximum());
+        assertEquals(null, schema.getExclusiveMaximum());
+        assertEquals(new BigDecimal("-1000000"), schema.getMinimum());
+        assertEquals(null, schema.getExclusiveMinimum());
+    }
+
+    @Test
+    public void testIntegerNegativeNotZeroMinValueExclusive() {
+        FieldInfo targetField = targetClass.field("integerNegativeNotZeroMinValue");
+        schema.setExclusiveMaximum(Boolean.TRUE);
+        schema.setExclusiveMinimum(Boolean.TRUE);
+
+        testTarget.min(targetField, schema);
+        testTarget.negative(targetField, schema);
+
+        assertEquals(new BigDecimal("0"), schema.getMaximum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMaximum());
+        assertEquals(new BigDecimal("-1000000"), schema.getMinimum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMinimum());
+    }
+
+    @Test
+    public void testIntegerNegativeOrZeroMinValue() {
+        FieldInfo targetField = targetClass.field("integerNegativeOrZeroMinValue");
+        testTarget.min(targetField, schema);
+        testTarget.negativeOrZero(targetField, schema);
+
+        assertEquals(new BigDecimal("0"), schema.getMaximum());
+        assertEquals(null, schema.getExclusiveMaximum());
+        assertEquals(new BigDecimal("-999"), schema.getMinimum());
+        assertEquals(null, schema.getExclusiveMinimum());
+    }
+
+    @Test
+    public void testIntegerNegativeOrZeroMinValueExclusive() {
+        FieldInfo targetField = targetClass.field("integerNegativeOrZeroMinValue");
+        schema.setExclusiveMaximum(Boolean.TRUE);
+        schema.setExclusiveMinimum(Boolean.TRUE);
+
+        testTarget.min(targetField, schema);
+        testTarget.negativeOrZero(targetField, schema);
+
+        assertEquals(new BigDecimal("1"), schema.getMaximum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMaximum());
+        assertEquals(new BigDecimal("-999"), schema.getMinimum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMinimum());
+    }
+
+    /**********************************************************************/
+
+    @Test
+    public void testStringNotBlankNotNull() {
+        FieldInfo targetField = targetClass.field("stringNotBlankNotNull");
+
+        testTarget.notBlank(targetField, schema);
+        testTarget.notNull(targetField, schema);
+
+        assertEquals("\\S", schema.getPattern());
+        assertEquals(Boolean.FALSE, schema.getNullable());
+    }
+
+    @Test
+    public void testStringNotBlankDigits() {
+        FieldInfo targetField = targetClass.field("stringNotBlankDigits");
+
+        testTarget.digits(targetField, schema);
+        testTarget.notBlank(targetField, schema);
+
+        assertEquals("^\\d{1,8}([.]\\d{1,10})?$", schema.getPattern());
+        assertEquals(Boolean.FALSE, schema.getNullable());
+    }
+
+    @Test
+    public void testStringNotEmptyMaxSize() {
+        FieldInfo targetField = targetClass.field("stringNotEmptyMaxSize");
+
+        testTarget.sizeString(targetField, schema);
+        testTarget.notEmptyString(targetField, schema);
+
+        assertEquals(Integer.valueOf(1), schema.getMinLength());
+        assertEquals(Integer.valueOf(2000), schema.getMaxLength());
+        assertEquals(Boolean.FALSE, schema.getNullable());
+    }
+
+    @Test
+    public void testStringNotEmptySizeRange() {
+        FieldInfo targetField = targetClass.field("stringNotEmptySizeRange");
+
+        testTarget.sizeString(targetField, schema);
+        testTarget.notEmptyString(targetField, schema);
+
+        assertEquals(Integer.valueOf(100), schema.getMinLength());
+        assertEquals(Integer.valueOf(2000), schema.getMaxLength());
+        assertEquals(Boolean.FALSE, schema.getNullable());
+    }
+
+    /**********************************************************************/
+
+    @SuppressWarnings("unused")
+    static class BVTestContainer {
+        @NotNull
+        @NotEmpty
+        @Size(max = 20)
+        List<String> arrayListNotNullAndNotEmptyAndMaxItems;
+
+        @NotEmpty
+        @Size(min = 5, max = 20)
+        List<String> arrayListNullableAndMinItemsAndMaxItems;
+
+        /**********************************************************************/
+
+        @NotNull
+        @NotEmpty
+        @Size(max = 20)
+        Map<String, String> mapObjectNotNullAndNotEmptyAndMaxProperties;
+
+        @NotEmpty
+        @Size(min = 5, max = 20)
+        Map<String, String> mapObjectNullableAndMinPropertiesAndMaxProperties;
+
+        /**********************************************************************/
+
+        @DecimalMax("200.00")
+        @Digits(integer = 3, fraction = 2)
+        private BigDecimal decimalMaxBigDecimalPrimaryDigits;
+        private BigDecimal decimalMaxBigDecimalNoConstraint;
+        @DecimalMax("Invalid BigDecimal value")
+        private BigDecimal decimalMaxBigDecimalInvalidValue;
+        @DecimalMax(value = "201.0", inclusive = false, groups = {})
+        @Digits(integer = 3, fraction = 1)
+        private BigDecimal decimalMaxBigDecimalExclusiveDigits;
+        @DecimalMax(value = "201.00", inclusive = true, groups = Default.class)
+        private BigDecimal decimalMaxBigDecimalInclusive;
+
+        /**********************************************************************/
+
+        @DecimalMin("10.0")
+        private BigDecimal decimalMinBigDecimalPrimary;
+        private BigDecimal decimalMinBigDecimalNoConstraint;
+        @DecimalMin("Invalid BigDecimal value")
+        private BigDecimal decimalMinBigDecimalInvalidValue;
+        @DecimalMin(value = "9.00", inclusive = false)
+        @Digits(integer = 1, fraction = 2)
+        private BigDecimal decimalMinBigDecimalExclusiveDigits;
+        @DecimalMin(value = "9.00", inclusive = true)
+        private BigDecimal decimalMinBigDecimalInclusive;
+
+        /**********************************************************************/
+
+        @Positive
+        @Max(1000)
+        private Long integerPositiveNotZeroMaxValue;
+
+        @PositiveOrZero
+        @Max(999)
+        private Integer integerPositiveOrZeroMaxValue;
+
+        @Negative
+        @Min(-1_000_000)
+        private Long integerNegativeNotZeroMinValue;
+
+        @NegativeOrZero
+        @Min(-999)
+        private Integer integerNegativeOrZeroMinValue;
+
+        /**********************************************************************/
+
+        @NotNull
+        @NotBlank
+        private String stringNotBlankNotNull;
+
+        @Digits(integer = 8, fraction = 10)
+        @NotBlank
+        private String stringNotBlankDigits;
+
+        @NotEmpty
+        @Size(max = 2000)
+        private String stringNotEmptyMaxSize;
+
+        @NotEmpty
+        @Size(min = 100, max = 2000)
+        private String stringNotEmptySizeRange;
+
+        /**********************************************************************/
+
+        @NotNull
+        private boolean booleanNotNull;
+    }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
@@ -1,0 +1,209 @@
+{
+  "openapi": "3.0.1",
+  "tags": [
+    {
+      "name": "Test",
+      "description": "Testing the container"
+    }
+  ],
+  "paths": {
+    "/bv/test-container": {
+      "post": {
+        "tags": [
+          "Test"
+        ],
+        "requestBody": {
+           "content": {
+           "application/json": {
+           "schema": {
+             "$ref": "#/components/schemas/BVTestResourceEntity"
+           }
+           }
+           }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BVTestContainer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BVTestResourceEntity": {
+        "type": "object",
+        "properties": {
+          "string_no_bean_constraints": {
+            "type": "string",
+            "minLength": 10,
+            "maxLength": 101,
+            "nullable": true
+          },
+          "big_int_no_bean_constraints": {
+            "type": "integer",
+            "minimum": 101,
+            "maximum": 101.999,
+            "nullable": true,
+            "pattern": "^\\d{1,3}([.]\\d{1,3})?$"
+          },
+          "list_no_bean_constraints": {
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 100,
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "map_no_bean_constraints": {
+            "type": "object",
+            "minProperties": 0,
+            "maxProperties": 100,
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "BVTestContainer": {
+        "type": "object",
+        "properties": {
+          "arrayListNotNullAndNotEmptyAndMaxItems": {
+            "type": "array",
+            "nullable": false,
+            "minItems": 1,
+            "maxItems": 20,
+            "items": {
+              "type": "string"
+            }
+          },
+          "arrayListNullableAndMinItemsAndMaxItems": {
+            "type": "array",
+            "minItems": 5,
+            "maxItems": 20,
+            "items": {
+              "type": "string"
+            }
+          },
+          "booleanNotNull": {
+            "type": "boolean",
+            "nullable": false
+          },
+          "decimalMaxBigDecimalExclusiveDigits": {
+            "type": "number",
+            "maximum": 201.0,
+            "exclusiveMaximum": true,
+            "pattern": "^\\d{1,3}([.]\\d)?$"
+          },
+          "decimalMaxBigDecimalInclusive": {
+            "type": "number",
+            "maximum": 201.0
+          },
+          "decimalMaxBigDecimalInvalidValue": {
+            "type": "number"
+          },
+          "decimalMaxBigDecimalNoConstraint": {
+            "type": "number"
+          },
+          "decimalMaxBigDecimalPrimaryDigits": {
+            "type": "number",
+            "maximum": 200.0,
+            "pattern": "^\\d{1,3}([.]\\d{1,2})?$"
+          },
+          "decimalMinBigDecimalExclusiveDigits": {
+            "type": "number",
+            "minimum": 9,
+            "exclusiveMinimum": true,
+            "pattern": "^\\d([.]\\d{1,2})?$"
+          },
+          "decimalMinBigDecimalInclusive": {
+            "type": "number",
+            "minimum": 9
+          },
+          "decimalMinBigDecimalInvalidValue": {
+            "type": "number"
+          },
+          "decimalMinBigDecimalNoConstraint": {
+            "type": "number"
+          },
+          "decimalMinBigDecimalPrimary": {
+            "type": "number",
+            "minimum": 10
+          },
+          "integerNegativeNotZeroMinValue": {
+            "type": "integer",
+            "format": "int64",
+            "maximum": -1,
+            "minimum": -1000000
+          },
+          "integerNegativeOrZeroMinValue": {
+            "type": "integer",
+            "format": "int32",
+            "maximum": 0,
+            "minimum": -999
+          },
+          "integerPositiveNotZeroMaxValue": {
+            "type": "integer",
+            "format": "int64",
+            "maximum": 1000,
+            "minimum": 1
+          },
+          "integerPositiveOrZeroMaxValue": {
+            "type": "integer",
+            "format": "int32",
+            "maximum": 999,
+            "minimum": 0
+          },
+          "mapObjectNotNullAndNotEmptyAndMaxProperties": {
+            "type": "object",
+            "nullable": false,
+            "minProperties": 1,
+            "maxProperties": 20,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "mapObjectNullableAndMinPropertiesAndMaxProperties": {
+            "type": "object",
+            "minProperties": 5,
+            "maxProperties": 20,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "stringNotBlankDigits": {
+            "type": "string",
+            "nullable": false,
+            "pattern": "^\\d{1,8}([.]\\d{1,10})?$"
+          },
+          "stringNotBlankNotNull": {
+            "type": "string",
+            "nullable": false,
+            "pattern": "\\S"
+          },
+          "stringNotEmptyMaxSize": {
+            "type": "string",
+            "nullable": false,
+            "minLength": 1,
+            "maxLength": 2000
+          },
+          "stringNotEmptySizeRange": {
+            "type": "string",
+            "nullable": false,
+            "minLength": 100,
+            "maxLength": 2000
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Changes for #103. 

Regarding the unit tests, I've been meaning to ask whether it's intended for the Surefire tests to be effectively disabled based on the 'includes' configuration.

*EDIT* Note that this functionality is enabled by default (no configuration).

*EDIT 2* Fixes #103 