### PR TITLE
Issue #116 - do not generate schema when @RequestBody is a reference

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -610,7 +610,7 @@ public class OpenApiAnnotationScanner {
             RequestBody requestBody = readRequestBody(annotation);
             // TODO if the method argument type is Request, don't generate a Schema!
 
-            // Only generate the request body schema is the @RequestBody is not a reference and no schema is yet specified
+            // Only generate the request body schema if the @RequestBody is not a reference and no schema is yet specified
             if (requestBody.getRef() == null && !ModelUtil.requestBodyHasSchema(requestBody)) {
                 Type requestBodyType = null;
                 if (annotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -609,7 +609,9 @@ public class OpenApiAnnotationScanner {
         for (AnnotationInstance annotation : requestBodyAnnotations) {
             RequestBody requestBody = readRequestBody(annotation);
             // TODO if the method argument type is Request, don't generate a Schema!
-            if (!ModelUtil.requestBodyHasSchema(requestBody)) {
+
+            // Only generate the request body schema is the @RequestBody is not a reference and no schema is yet specified
+            if (requestBody.getRef() == null && !ModelUtil.requestBodyHasSchema(requestBody)) {
                 Type requestBodyType = null;
                 if (annotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
                     requestBodyType = JandexUtil.getMethodParameterType(method, annotation.target().asMethodParameter().position());

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScannerTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScannerTest.java
@@ -83,4 +83,22 @@ public class OpenApiAnnotationScannerTest extends OpenApiDataObjectScannerTestBa
         printToConsole(result);
         assertJsonEquals("resource.testHiddenOperationPathNotPresent.json", result);
     }
+
+    @Test
+    public void testRequestBodyComponentGeneration() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+
+        // Test samples
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/RequestBodyTestApplication.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/RequestBodyTestApplication$SomeObject.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/RequestBodyTestApplication$DifferentObject.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/RequestBodyTestApplication$RequestBodyResource.class");
+
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), indexer.complete());
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("resource.testRequestBodyComponentGeneration.json", result);
+    }
 }

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/RequestBodyTestApplication.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/RequestBodyTestApplication.java
@@ -1,0 +1,62 @@
+package test.io.smallrye.openapi.runtime.scanner.resources;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.Components;
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+
+import test.io.smallrye.openapi.runtime.scanner.resources.RequestBodyTestApplication.DifferentObject;
+
+/**
+ * Test case for smallrye-open-api issue #116
+ * https://github.com/smallrye/smallrye-open-api/issues/116
+ *
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+@OpenAPIDefinition(
+        info = @Info(title = "Test Request Body", version = "1.0"),
+        components = @Components(
+                requestBodies = @RequestBody(
+                        name = "test",
+                        content = @Content(
+                                mediaType = MediaType.APPLICATION_JSON,
+                                schema = @Schema(implementation = DifferentObject.class)),
+                        required = true)))
+public class RequestBodyTestApplication extends Application {
+
+    public static class SomeObject {
+        public String someName;
+    }
+
+    public static class DifferentObject {
+        public String differentName;
+    }
+
+    @SuppressWarnings("unused")
+    @Path("requestbodies")
+    public static class RequestBodyResource {
+
+        @POST
+        @Path("impl")
+        public void testImpl(@RequestBody(
+                content = @Content(
+                        mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(implementation = DifferentObject.class)),
+                required = true) SomeObject body) {
+            return;
+        }
+
+        @POST
+        @Path("ref")
+        public void testRef(@RequestBody(ref = "test") SomeObject body) {
+            return;
+        }
+    }
+}

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/RequestBodyTestApplication.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/RequestBodyTestApplication.java
@@ -1,5 +1,6 @@
 package test.io.smallrye.openapi.runtime.scanner.resources;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
@@ -56,6 +57,13 @@ public class RequestBodyTestApplication extends Application {
         @POST
         @Path("ref")
         public void testRef(@RequestBody(ref = "test") SomeObject body) {
+            return;
+        }
+
+        @POST
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Path("defaults")
+        public void testDefaults(@RequestBody(required = true) SomeObject body) {
             return;
         }
     }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testRequestBodyComponentGeneration.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testRequestBodyComponentGeneration.json
@@ -35,6 +35,25 @@
           }
         }
       }
+    },
+    "/requestbodies/defaults": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SomeObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -43,6 +62,14 @@
         "type": "object",
         "properties": {
           "differentName": {
+            "type": "string"
+          }
+        }
+      },
+      "SomeObject": {
+        "type": "object",
+        "properties": {
+          "someName": {
             "type": "string"
           }
         }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testRequestBodyComponentGeneration.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testRequestBodyComponentGeneration.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test Request Body",
+    "version": "1.0"
+  },
+  "paths": {
+    "/requestbodies/impl": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DifferentObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    },
+    "/requestbodies/ref": {
+      "post": {
+        "requestBody": {
+          "$ref": "#/components/requestBodies/test"
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DifferentObject": {
+        "type": "object",
+        "properties": {
+          "differentName": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "requestBodies": {
+      "test": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DifferentObject"
+            }
+          }
+        },
+        "required": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Prevent auto-generation of a `Schema` when a `@RequestBody` annotation contains a reference. 