### PR TITLE
Ignore transient fields by default, unless explicitly unhidden with @Schema

### DIFF
--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
@@ -28,6 +28,7 @@ import test.io.smallrye.openapi.runtime.scanner.entities.IgnoreTestContainer;
 import test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreOnFieldExample;
 import test.io.smallrye.openapi.runtime.scanner.entities.JsonIgnoreTypeExample;
 import test.io.smallrye.openapi.runtime.scanner.entities.JsonbTransientOnFieldExample;
+import test.io.smallrye.openapi.runtime.scanner.entities.TransientFieldExample;
 
 import java.io.IOException;
 
@@ -114,4 +115,15 @@ public class IgnoreTests extends OpenApiDataObjectScannerTestBase {
         assertJsonEquals(name.local(), "ignore.schemaHiddenField.expected.json", result);
     }
 
+    @Test
+    public void testIgnore_transientField() throws IOException, JSONException {
+        DotName name = DotName.createSimple(TransientFieldExample.class.getName());
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+                ClassType.create(name, Type.Kind.CLASS));
+
+        Schema result = scanner.process();
+
+        printToConsole(name.local(), result);
+        assertJsonEquals(name.local(), "ignore.transientField.expected.json", result);
+    }
 }

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/TransientFieldExample.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/TransientFieldExample.java
@@ -1,0 +1,16 @@
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+
+public class TransientFieldExample {
+    // Transient field will be ignored by default
+    transient String ignoredTransientField;
+
+    // Transient field will be included if we explicitly 'unhide' it with a Schema annotation (and `hidden` is false)
+    @Schema(hidden = false)
+    transient String unhiddenTransientField;
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.transientField.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.transientField.expected.json
@@ -1,0 +1,14 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.TransientFieldExample" : {
+        "type" : "object",
+        "properties" : {
+          "unhiddenTransientField" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #115