### PR TITLE
Do not set null/empty enumeration from annotation on schema

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/SchemaFactory.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/SchemaFactory.java
@@ -111,12 +111,16 @@ public class SchemaFactory {
         schema.setExternalDocs(readExternalDocs(annotation.value(OpenApiConstants.PROP_EXTERNAL_DOCS)));
         schema.setDeprecated((Boolean) overrides.getOrDefault(OpenApiConstants.PROP_DEPRECATED, JandexUtil.booleanValue(annotation, OpenApiConstants.PROP_DEPRECATED)));
         schema.setType((Schema.SchemaType) overrides.getOrDefault(OpenApiConstants.PROP_TYPE, JandexUtil.enumValue(annotation, OpenApiConstants.PROP_TYPE, Schema.SchemaType.class)));
-        schema.setEnumeration((List<Object>) overrides.getOrDefault(OpenApiConstants.PROP_ENUMERATION, JandexUtil.stringListValue(annotation, OpenApiConstants.PROP_ENUMERATION)));
         schema.setDefaultValue(overrides.getOrDefault(OpenApiConstants.PROP_DEFAULT_VALUE, JandexUtil.stringValue(annotation, OpenApiConstants.PROP_DEFAULT_VALUE)));
         schema.setDiscriminator(readDiscriminatorMappings(annotation.value(OpenApiConstants.PROP_DISCRIMINATOR_MAPPING)));
         schema.setMaxItems((Integer) overrides.getOrDefault(OpenApiConstants.PROP_MAX_ITEMS, JandexUtil.intValue(annotation, OpenApiConstants.PROP_MAX_ITEMS)));
         schema.setMinItems((Integer) overrides.getOrDefault(OpenApiConstants.PROP_MIN_ITEMS, JandexUtil.intValue(annotation, OpenApiConstants.PROP_MIN_ITEMS)));
         schema.setUniqueItems((Boolean) overrides.getOrDefault(OpenApiConstants.PROP_UNIQUE_ITEMS, JandexUtil.booleanValue(annotation, OpenApiConstants.PROP_UNIQUE_ITEMS)));
+
+        List<Object> enumeration = (List<Object>) overrides.getOrDefault(OpenApiConstants.PROP_ENUMERATION, JandexUtil.stringListValue(annotation, OpenApiConstants.PROP_ENUMERATION));
+        if (enumeration != null && !enumeration.isEmpty()) {
+            schema.setEnumeration(enumeration);
+        }
 
         if (schema instanceof SchemaImpl) {
             ((SchemaImpl) schema).setName((String) overrides.getOrDefault(OpenApiConstants.PROP_NAME, JandexUtil.stringValue(annotation, OpenApiConstants.PROP_NAME)));

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import test.io.smallrye.openapi.runtime.scanner.entities.Bar;
 import test.io.smallrye.openapi.runtime.scanner.entities.BuzzLinkedList;
 import test.io.smallrye.openapi.runtime.scanner.entities.EnumContainer;
+import test.io.smallrye.openapi.runtime.scanner.entities.EnumRequiredContainer;
 import test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer;
 
 import java.io.IOException;
@@ -72,6 +73,17 @@ public class ExpectationTests extends OpenApiDataObjectScannerTestBase {
 
         printToConsole(baz.local(), result);
         assertJsonEquals(baz.local(), "enum.expected.json", result);
+    }
+
+    @Test
+    public void testRequiredEnum() throws IOException, JSONException {
+        DotName baz = createSimple(EnumRequiredContainer.class.getName());
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, ClassType.create(baz, Type.Kind.CLASS));
+
+        Schema result = scanner.process();
+
+        printToConsole(baz.local(), result);
+        assertJsonEquals(baz.local(), "enumRequired.expected.json", result);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
@@ -29,6 +29,7 @@ import io.smallrye.openapi.api.models.OpenAPIImpl;
 import test.io.smallrye.openapi.runtime.scanner.entities.Bar;
 import test.io.smallrye.openapi.runtime.scanner.entities.BuzzLinkedList;
 import test.io.smallrye.openapi.runtime.scanner.entities.EnumContainer;
+import test.io.smallrye.openapi.runtime.scanner.entities.EnumRequiredContainer;
 import test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContainer;
 
 /**
@@ -92,6 +93,11 @@ public class ExpectationWithRefsTests extends OpenApiDataObjectScannerTestBase {
     @Test
     public void testBareEnumWithRef() throws IOException, JSONException {
         testAssertion(EnumContainer.class, "refsEnabled.enum.expected.json");
+    }
+
+    @Test
+    public void testRequiredEnumWithRef() throws IOException, JSONException {
+        testAssertion(EnumRequiredContainer.class, "refsEnabled.enumRequired.expected.json");
     }
 
     @Test

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/EnumRequiredContainer.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/EnumRequiredContainer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.io.smallrye.openapi.runtime.scanner.entities;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class EnumRequiredContainer {
+    @Schema(required = true)
+    BazEnum bazEnum;
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/enumRequired.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/enumRequired.expected.json
@@ -1,0 +1,16 @@
+{
+  "components" : {
+    "schemas" : {
+      "test.io.smallrye.openapi.runtime.scanner.entities.EnumRequiredContainer" : {
+        "required": [ "bazEnum" ],
+        "type": "object",
+        "properties" : {
+          "bazEnum" : {
+            "enum" : [ "Gold", "Green", "Orange" ],
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.enumRequired.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.enumRequired.expected.json
@@ -1,0 +1,23 @@
+{
+  "components": {
+    "schemas": {
+      "BazEnum": {
+        "type": "string",
+        "enum": [
+          "Gold",
+          "Green",
+          "Orange"
+        ]
+      },
+      "EnumRequiredContainer": {
+        "required": [ "bazEnum" ],
+        "type": "object",
+        "properties": {
+          "bazEnum": {
+            "$ref": "#/components/schemas/BazEnum"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This set of changes prevents the generated/scanned `Enum` value list from being overwritten by an undefined or empty `enumeration` in an `@Schema` annotation.

Fixes #110 
