### PR TITLE
Use type params in generated schema names; process enum as map value

### DIFF
--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
@@ -1,0 +1,163 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.Type;
+import org.json.JSONException;
+import org.junit.Test;
+
+import io.smallrye.openapi.api.models.OpenAPIImpl;
+import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.runtime.util.ModelUtil;
+
+/**
+ *
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ *
+ */
+public class SchemaRegistryTests extends IndexScannerTestBase {
+
+    SchemaRegistry registry;
+
+    @Test
+    public void testParameterizedNameCollisionsUseSequence() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
+        Index index = indexer.complete();
+
+        OpenAPIImpl oai = new OpenAPIImpl();
+        SchemaRegistry registry = SchemaRegistry.newInstance(emptyConfig(), oai, index);
+
+        DotName cName = componentize(Container.class.getName());
+        ClassInfo cInfo = index.getClassByName(cName);
+
+        FieldInfo n1 = cInfo.field("n1");
+        FieldInfo n2 = cInfo.field("n2");
+        FieldInfo n3 = cInfo.field("n3");
+
+        Schema s1 = registry.register(n1.type(), new SchemaImpl());
+        Schema s2 = registry.register(n2.type(), new SchemaImpl());
+        Schema s3 = registry.register(n3.type(), new SchemaImpl());
+
+        assertEquals("#/components/schemas/NestableStringNestable", s1.getRef());
+        assertEquals("#/components/schemas/NestableStringNestable1", s2.getRef());
+        assertEquals("#/components/schemas/NestableStringNestable2", s3.getRef());
+    }
+
+    @Test
+    public void testWildcardLowerBoundName() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
+        Index index = indexer.complete();
+
+        OpenAPIImpl oai = new OpenAPIImpl();
+        SchemaRegistry registry = SchemaRegistry.newInstance(emptyConfig(), oai, index);
+
+        DotName cName = componentize(Container.class.getName());
+        ClassInfo cInfo = index.getClassByName(cName);
+
+        FieldInfo n4 = cInfo.field("n4");
+        Schema s4 = registry.register(n4.type(), new SchemaImpl());
+        assertEquals("#/components/schemas/NestableStringSuperInteger", s4.getRef());
+    }
+
+    @Test
+    public void testWildcardUpperBoundName() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
+        Index index = indexer.complete();
+
+        OpenAPIImpl oai = new OpenAPIImpl();
+        SchemaRegistry registry = SchemaRegistry.newInstance(emptyConfig(), oai, index);
+
+        DotName cName = componentize(Container.class.getName());
+        ClassInfo cInfo = index.getClassByName(cName);
+
+        FieldInfo n5 = cInfo.field("n5");
+        Schema s5 = registry.register(n5.type(), new SchemaImpl());
+        assertEquals("#/components/schemas/NestableExtendsCharSequenceExtendsNumber", s5.getRef());
+    }
+
+    @Test
+    public void testWildcardWithGivenName() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$NamedNestable.class");
+        Index index = indexer.complete();
+
+        OpenAPIImpl oai = new OpenAPIImpl();
+        SchemaRegistry registry = SchemaRegistry.newInstance(emptyConfig(), oai, index);
+
+        DotName cName = componentize(Container.class.getName());
+        ClassInfo cInfo = index.getClassByName(cName);
+
+        FieldInfo n6 = cInfo.field("n6");
+        Schema s6 = registry.register(n6.type(), new SchemaImpl());
+        assertEquals("#/components/schemas/n6", s6.getRef());
+    }
+
+    @Test
+    public void testNestedGenericWildcard() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
+        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$NamedNestable.class");
+        Index index = indexer.complete();
+
+        OpenAPIImpl oai = new OpenAPIImpl();
+        SchemaRegistry registry = SchemaRegistry.newInstance(nestingSupportConfig(), oai, index);
+
+        DotName cName = componentize(Container.class.getName());
+        ClassInfo cInfo = index.getClassByName(cName);
+
+        Type n6Type = cInfo.field("n6").type();
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, n6Type);
+
+        Schema result = scanner.process();
+        registry.register(n6Type, result);
+        printToConsole(oai);
+
+        String field3SchemaName = ModelUtil.nameFromRef(result.getProperties().get("field3").getRef());
+        String field2SchemaName = oai.getComponents()
+                                     .getSchemas()
+                                     .get(field3SchemaName)
+                                     .getProperties()
+                                     .get("field2")
+                                     .getRef();
+
+        assertEquals("#/components/schemas/NestableExtendsNestable", field2SchemaName);
+    }
+
+    public static class Container {
+        Nestable<String, Nestable<String, String>> n1;
+        Nestable<String, Nestable<String, Object>> n2;
+        Nestable<String, Nestable<String, Nestable<String, Object>>> n3;
+        Nestable<String, ? super Integer> n4;
+        Nestable<? extends CharSequence, ? extends Number> n5;
+        NamedNestable<? extends CharSequence, ? extends Number> n6;
+    }
+
+    public static class Nestable<T1, T2> {
+        T1 field1;
+        T2 field2;
+    }
+
+    @org.eclipse.microprofile.openapi.annotations.media.Schema(name = "n6")
+    public static class NamedNestable<T1, T2> {
+        T1 field1;
+        T2 field2;
+        Nestable<String, ? extends Nestable<T1, T2>> field3;
+    }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "schemas": {
-      "KustomPair": {
+      "KustomPairFuzzObject": {
         "required": [
           "bar",
           "foo"
@@ -12,11 +12,11 @@
             "type": "object"
           },
           "foo": {
-            "$ref": "#/components/schemas/Fuzz"
+            "$ref": "#/components/schemas/FuzzStringDate"
           }
         }
       },
-      "Fuzz": {
+      "FuzzStringDate": {
         "maxLength": 123456,
         "type": "object",
         "properties": {
@@ -44,7 +44,7 @@
           }
         }
       },
-      "Fuzz1": {
+      "FuzzKustomPairDouble": {
         "type": "object",
         "properties": {
           "qAgain": {
@@ -61,13 +61,13 @@
             "type": "number"
           },
           "tAgain2": {
-            "$ref": "#/components/schemas/KustomPair"
+            "$ref": "#/components/schemas/KustomPairFuzzObject"
           },
           "tAgain4": {
-            "$ref": "#/components/schemas/KustomPair"
+            "$ref": "#/components/schemas/KustomPairFuzzObject"
           },
           "tValue": {
-            "$ref": "#/components/schemas/KustomPair"
+            "$ref": "#/components/schemas/KustomPairFuzzObject"
           }
         }
       }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.fields.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.fields.expected.json
@@ -27,7 +27,7 @@
           }
         }
       },
-      "GenericFieldTestContainer": {
+      "GenericFieldTestContainerStringLocalDateTime": {
         "type": "object",
         "properties": {
           "arrayListOfV": {

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "schemas": {
-      "KustomPair": {
+      "KustomPairStringString": {
         "maxLength": 123456,
         "required": [
           "bar",
@@ -18,7 +18,7 @@
           }
         }
       },
-      "KustomPair1": {
+      "KustomPairKustomPairInteger": {
         "type": "object",
         "required": [
           "bar",
@@ -30,7 +30,7 @@
             "type": "integer"
           },
           "foo": {
-            "$ref": "#/components/schemas/KustomPair"
+            "$ref": "#/components/schemas/KustomPairStringString"
           }
         }
       }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.withBounds.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.withBounds.expected.json
@@ -1,7 +1,7 @@
 {
   "components" : {
     "schemas" : {
-      "KustomPair" : {
+      "KustomPairExtendsIntegerSuperInteger" : {
         "type": "object",
         "required" : [ "bar", "foo" ],
         "properties" : {

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
@@ -1,458 +1,509 @@
 {
-  "components" : {
-    "schemas" : {
+  "components": {
+    "schemas": {
       "BazEnum": {
-        "type" : "object",
-              "properties" : {
-                "z" : {
-                  "format" : "int32",
-                  "type" : "integer"
-                }
-              }
-      },
-      "Baz": {
-                  "type" : "object",
-                  "properties" : {
-                    "an_integer_value" : {
-                      "format" : "int32",
-                      "type" : "integer"
-                    }
-                  }
-      },
-      "Bar": {
-        "type" : "object",
-              "properties" : {
-                "theQ" : {
-                  "type" : "object"
-                },
-                "theT" : {
-                  "$ref": "#/components/schemas/Baz"
-                },
-                "ultimateTShouldBeQ" : {
-                  "type" : "object"
-                }
-              }
-      },
-      "Airline": {
-                    "required" : [ "contactPhone", "name" ],
-                    "type" : "object",
-                    "properties" : {
-                      "contactPhone" : {
-                        "type" : "string",
-                        "example" : "1-888-1234-567"
-                      },
-                      "name" : {
-                        "type" : "string",
-                        "example" : "Acme Air"
-                      }
-                    }
-      },
-      "Flight": {
-                "required" : [ "airline", "airportFrom", "airportTo", "dateTime", "number", "price", "status" ],
-                "type" : "object",
-                "properties" : {
-                  "airline" : {
-                    "$ref": "#/components/schemas/Airline"
-                  },
-                  "airportFrom" : {
-                    "type" : "string",
-                    "example" : "YYZ"
-                  },
-                  "airportTo" : {
-                    "type" : "string",
-                    "example" : "LAX"
-                  },
-                  "dateTime" : {
-                    "pattern" : "dateTime",
-                    "type" : "string",
-                    "example" : "2016-03-05 18:00"
-                  },
-                  "number" : {
-                    "type" : "string",
-                    "example" : "AC190"
-                  },
-                  "price" : {
-                    "type" : "string",
-                    "example" : "US$350"
-                  },
-                  "status" : {
-                    "type" : "string",
-                    "example" : "On Schedule"
-                  }
-                }
-      },
-      "CreditCard": {
-                "required" : [ "cardNumber", "cardholderName", "cvv", "expiryDate", "issuer" ],
-                "type" : "object",
-                "properties" : {
-                  "cardNumber" : {
-                    "type" : "string",
-                    "example" : "**********1234"
-                  },
-                  "cardholderName" : {
-                    "type" : "string",
-                    "example" : "Joe Smith"
-                  },
-                  "cvv" : {
-                    "type" : "string",
-                    "example" : "0322"
-                  },
-                  "expiryDate" : {
-                    "type" : "string",
-                    "example" : "04/19"
-                  },
-                  "issuer" : {
-                    "type" : "string",
-                    "example" : "VISA"
-                  }
-                }
-      },
-      "Booking": {
-            "required" : [ "airMiles", "creditCard", "departtureFlight", "returningFlight", "seatPreference" ],
-            "type" : "object",
-            "properties" : {
-              "airMiles" : {
-                "type" : "string",
-                "example" : "32126319"
-              },
-              "creditCard" : {
-                "$ref": "#/components/schemas/CreditCard"
-              },
-              "departtureFlight" : {
-                "$ref": "#/components/schemas/Flight"
-              },
-              "returningFlight" : {
-                "$ref": "#/components/schemas/Flight"
-              },
-              "seatPreference" : {
-                "type" : "string",
-                "example" : "window"
-              }
-            }
-      },
-      "Bazzy": {
-                "type" : "object",
-                "properties" : {
-                  "hellofrombazzy" : {
-                    "type" : "string"
-                  },
-                  "an_integer_value" : {
-                    "format" : "int32",
-                    "type" : "integer"
-                  }
-                }
-      },
-      "Foo": {
-            "type" : "object",
-            "properties" : {
-              "theQ" : {
-                "type" : "string"
-              },
-              "theT" : {
-                "$ref": "#/components/schemas/Bazzy"
-              },
-              "ultimateTShouldBeQ" : {
-                "type" : "string"
-              }
-            }
-      },
-      "Fuzz2": {
-                    "maxLength" : 123456,
-                    "type" : "object",
-                    "properties" : {
-                      "qAgain" : {
-                        "type" : "object"
-                      },
-                      "qAgain3" : {
-                        "type" : "object"
-                      },
-                      "qValue" : {
-                        "description" : "Ah, Q, my favourite variable!",
-                        "type" : "object"
-                      },
-                      "tAgain2" : {
-                        "type" : "string"
-                      },
-                      "tAgain4" : {
-                        "type" : "string"
-                      },
-                      "tValue" : {
-                        "type" : "string"
-                      }
-                    }
-      },
-      "KustomPair4": {
-                "required" : [ "bar", "foo" ],
-                "type" : "object",
-                "properties" : {
-                  "bar" : {
-                    "format" : "int32",
-                    "type" : "integer"
-                  },
-                  "foo" : {
-                    "$ref": "#/components/schemas/Fuzz2"
-                  }
-                }
-      },
-      "Fuzz": {
-            "type" : "object",
-            "properties" : {
-              "qAgain" : {
-                "format" : "double",
-                "type" : "number"
-              },
-              "qAgain3" : {
-                "format" : "double",
-                "type" : "number"
-              },
-              "qValue" : {
-                "format" : "double",
-                "description" : "Ah, Q, my favourite variable!",
-                "type" : "number"
-              },
-              "tAgain2" : {
-                "$ref": "#/components/schemas/KustomPair4"
-              },
-              "tAgain4" : {
-                "$ref": "#/components/schemas/KustomPair4"
-              },
-              "tValue" : {
-                "$ref": "#/components/schemas/KustomPair4"
-              }
+        "type": "string",
+        "enum": [
+          "Gold",
+          "Green",
+          "Orange"
+        ],
+        "properties": {
+          "z": {
+            "format": "int32",
+            "type": "integer"
+          }
         }
       },
-      "Foo1": {
-            "type" : "object",
-            "properties" : {
-              "theQ" : {
-                "type" : "string"
-              },
-              "theT" : {
-                "$ref": "#/components/schemas/Bazzy"
-              },
-              "ultimateTShouldBeQ" : {
-                "type" : "string"
-              }
-            }
+      "Baz": {
+        "type": "object",
+        "properties": {
+          "an_integer_value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
       },
-      "Fuzz1": {
-            "type" : "object",
-            "properties" : {
-              "qAgain" : {
-                "$ref": "#/components/schemas/Foo1"
-              },
-              "qAgain3" : {
-                "$ref": "#/components/schemas/Foo1"
-              },
-              "qValue" : {
-                "$ref": "#/components/schemas/Foo1"
-              },
-              "tAgain2" : {
-                "type" : "string"
-              },
-              "tAgain4" : {
-                "type" : "string"
-              },
-              "tValue" : {
-                "type" : "string"
-              }
-            }
+      "Bar": {
+        "type": "object",
+        "properties": {
+          "theQ": {
+            "type": "object"
+          },
+          "theT": {
+            "$ref": "#/components/schemas/Baz"
+          },
+          "ultimateTShouldBeQ": {
+            "type": "object"
+          }
+        }
       },
-      "KustomPair": {
-            "required" : [ "bar", "foo" ],
-            "type" : "object",
-            "properties" : {
-              "bar" : {
-                "type" : "object"
-              },
-              "foo" : {
-                "maxLength" : 123456,
-                "type" : "string"
-              }
-            }
+      "Airline": {
+        "required": [
+          "contactPhone",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "contactPhone": {
+            "type": "string",
+            "example": "1-888-1234-567"
+          },
+          "name": {
+            "type": "string",
+            "example": "Acme Air"
+          }
+        }
       },
-      "KustomPair1": {
-            "required" : [ "bar", "foo" ],
-            "type" : "object",
-            "properties" : {
-              "bar" : {
-                "format" : "int32",
-                "type" : "integer"
-              },
-              "foo" : {
-                "$ref": "#/components/schemas/KustomPair3"
-              }
-            }
+      "Flight": {
+        "required": [
+          "airline",
+          "airportFrom",
+          "airportTo",
+          "dateTime",
+          "number",
+          "price",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "airline": {
+            "$ref": "#/components/schemas/Airline"
+          },
+          "airportFrom": {
+            "type": "string",
+            "example": "YYZ"
+          },
+          "airportTo": {
+            "type": "string",
+            "example": "LAX"
+          },
+          "dateTime": {
+            "pattern": "dateTime",
+            "type": "string",
+            "example": "2016-03-05 18:00"
+          },
+          "number": {
+            "type": "string",
+            "example": "AC190"
+          },
+          "price": {
+            "type": "string",
+            "example": "US$350"
+          },
+          "status": {
+            "type": "string",
+            "example": "On Schedule"
+          }
+        }
       },
-      "KustomPair3": {
-                "maxLength" : 123456,
-                "required" : [ "bar", "foo" ],
-                "type" : "object",
-                "properties" : {
-                  "bar" : {
-                    "type" : "string"
-                  },
-                  "foo" : {
-                    "maxLength" : 123456,
-                    "type" : "string"
-                  }
-                }
+      "CreditCard": {
+        "required": [
+          "cardNumber",
+          "cardholderName",
+          "cvv",
+          "expiryDate",
+          "issuer"
+        ],
+        "type": "object",
+        "properties": {
+          "cardNumber": {
+            "type": "string",
+            "example": "**********1234"
+          },
+          "cardholderName": {
+            "type": "string",
+            "example": "Joe Smith"
+          },
+          "cvv": {
+            "type": "string",
+            "example": "0322"
+          },
+          "expiryDate": {
+            "type": "string",
+            "example": "04/19"
+          },
+          "issuer": {
+            "type": "string",
+            "example": "VISA"
+          }
+        }
+      },
+      "Booking": {
+        "required": [
+          "airMiles",
+          "creditCard",
+          "departtureFlight",
+          "returningFlight",
+          "seatPreference"
+        ],
+        "type": "object",
+        "properties": {
+          "airMiles": {
+            "type": "string",
+            "example": "32126319"
+          },
+          "creditCard": {
+            "$ref": "#/components/schemas/CreditCard"
+          },
+          "departtureFlight": {
+            "$ref": "#/components/schemas/Flight"
+          },
+          "returningFlight": {
+            "$ref": "#/components/schemas/Flight"
+          },
+          "seatPreference": {
+            "type": "string",
+            "example": "window"
+          }
+        }
+      },
+      "Bazzy": {
+        "type": "object",
+        "properties": {
+          "hellofrombazzy": {
+            "type": "string"
+          },
+          "an_integer_value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "theQ": {
+            "type": "string"
+          },
+          "theT": {
+            "$ref": "#/components/schemas/Bazzy"
+          },
+          "ultimateTShouldBeQ": {
+            "type": "string"
+          }
+        }
+      },
+      "FuzzStringObject": {
+        "maxLength": 123456,
+        "type": "object",
+        "properties": {
+          "qAgain": {
+            "type": "object"
+          },
+          "qAgain3": {
+            "type": "object"
+          },
+          "qValue": {
+            "description": "Ah, Q, my favourite variable!",
+            "type": "object"
+          },
+          "tAgain2": {
+            "type": "string"
+          },
+          "tAgain4": {
+            "type": "string"
+          },
+          "tValue": {
+            "type": "string"
+          }
+        }
+      },
+      "KustomPairFuzzInteger": {
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "type": "object",
+        "properties": {
+          "bar": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "foo": {
+            "$ref": "#/components/schemas/FuzzStringObject"
+          }
+        }
+      },
+      "FuzzKustomPairDouble": {
+        "type": "object",
+        "properties": {
+          "qAgain": {
+            "format": "double",
+            "type": "number"
+          },
+          "qAgain3": {
+            "format": "double",
+            "type": "number"
+          },
+          "qValue": {
+            "format": "double",
+            "description": "Ah, Q, my favourite variable!",
+            "type": "number"
+          },
+          "tAgain2": {
+            "$ref": "#/components/schemas/KustomPairFuzzInteger"
+          },
+          "tAgain4": {
+            "$ref": "#/components/schemas/KustomPairFuzzInteger"
+          },
+          "tValue": {
+            "$ref": "#/components/schemas/KustomPairFuzzInteger"
+          }
+        }
+      },
+      "FooExtendsFoo": {
+        "type": "object",
+        "properties": {
+          "theQ": {
+            "type": "string"
+          },
+          "theT": {
+            "$ref": "#/components/schemas/Bazzy"
+          },
+          "ultimateTShouldBeQ": {
+            "type": "string"
+          }
+        }
+      },
+      "FuzzStringExtendsFoo": {
+        "type": "object",
+        "properties": {
+          "qAgain": {
+            "$ref": "#/components/schemas/FooExtendsFoo"
+          },
+          "qAgain3": {
+            "$ref": "#/components/schemas/FooExtendsFoo"
+          },
+          "qValue": {
+            "$ref": "#/components/schemas/FooExtendsFoo"
+          },
+          "tAgain2": {
+            "type": "string"
+          },
+          "tAgain4": {
+            "type": "string"
+          },
+          "tValue": {
+            "type": "string"
+          }
+        }
+      },
+      "KustomPairExtendsStringSuperString": {
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "type": "object",
+        "properties": {
+          "bar": {
+            "type": "object"
+          },
+          "foo": {
+            "maxLength": 123456,
+            "type": "string"
+          }
+        }
+      },
+      "KustomPairKustomPairInteger": {
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "type": "object",
+        "properties": {
+          "bar": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "foo": {
+            "$ref": "#/components/schemas/KustomPairStringString"
+          }
+        }
+      },
+      "KustomPairStringString": {
+        "maxLength": 123456,
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "type": "object",
+        "properties": {
+          "bar": {
+            "type": "string"
+          },
+          "foo": {
+            "maxLength": 123456,
+            "type": "string"
+          }
+        }
       },
       "BuzzLinkedList": {
-            "type" : "object",
-            "properties" : {
-              "next" : {
-                "$ref": "#/components/schemas/BuzzLinkedList"
-              }
-            }
+        "type": "object",
+        "properties": {
+          "next": {
+            "$ref": "#/components/schemas/BuzzLinkedList"
+          }
+        }
       },
-      "KustomPair2": {
-            "required" : [ "bar", "foo" ],
-            "type" : "object",
-            "properties" : {
-              "bar" : {
-                "format" : "int32",
-                "type" : "integer"
-              },
-              "foo" : {
-                "maxLength" : 123456,
-                "type" : "string"
-              }
-            }
+      "KustomPairStringInteger": {
+        "required": [
+          "bar",
+          "foo"
+        ],
+        "type": "object",
+        "properties": {
+          "bar": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "foo": {
+            "maxLength": 123456,
+            "type": "string"
+          }
+        }
       },
-      "KitchenSink" : {
-        "description" : "This is the kitchen sink description!",
-        "required" : [ "booking", "ccList", "creditCardMap", "fooArray", "fuzzListWildcard", "seatPreference", "unsafeList" ],
-        "type" : "object",
-        "properties" : {
-          "array" : {
-            "type" : "array",
-            "items" : {
-              "format" : "int32",
-              "type" : "integer"
+      "KitchenSink": {
+        "description": "This is the kitchen sink description!",
+        "required": [
+          "booking",
+          "ccList",
+          "creditCardMap",
+          "fooArray",
+          "fuzzListWildcard",
+          "seatPreference",
+          "unsafeList"
+        ],
+        "type": "object",
+        "properties": {
+          "array": {
+            "type": "array",
+            "items": {
+              "format": "int32",
+              "type": "integer"
             }
           },
-          "awkwardMap" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "string"
+          "awkwardMap": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
             }
           },
-          "awkwardMap2" : {
-            "type" : "object",
-            "additionalProperties" : {
+          "awkwardMap2": {
+            "type": "object",
+            "additionalProperties": {
               "$ref": "#/components/schemas/BazEnum"
             }
           },
-          "barExtends" : {
-            "type" : "array",
-            "items" : {
+          "barExtends": {
+            "type": "array",
+            "items": {
               "$ref": "#/components/schemas/Bar"
             }
           },
-          "barSuper" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object"
+          "barSuper": {
+            "type": "array",
+            "items": {
+              "type": "object"
             }
           },
-          "bareCollection" : {
-            "type" : "array"
+          "bareCollection": {
+            "type": "array"
           },
-          "bareEnum" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object"
+          "bareEnum": {
+            "type": "array",
+            "items": {
+              "type": "object"
             }
           },
-          "blahMap" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "object"
+          "blahMap": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
             }
           },
-          "booking" : {
+          "booking": {
             "$ref": "#/components/schemas/Booking"
           },
-          "ccList" : {
-            "type" : "array",
-            "items" : {
+          "ccList": {
+            "type": "array",
+            "items": {
               "$ref": "#/components/schemas/CreditCard"
             }
           },
-          "complexNesting" : {
-            "$ref": "#/components/schemas/Fuzz"
+          "complexNesting": {
+            "$ref": "#/components/schemas/FuzzKustomPairDouble"
           },
-          "creditCardMap" : {
-            "type" : "object",
-            "additionalProperties" : {
+          "creditCardMap": {
+            "type": "object",
+            "additionalProperties": {
               "$ref": "#/components/schemas/CreditCard"
             }
           },
-          "customTypeExtendsSuper" : {
-            "$ref": "#/components/schemas/KustomPair"
+          "customTypeExtendsSuper": {
+            "$ref": "#/components/schemas/KustomPairExtendsStringSuperString"
           },
-          "foo" : {
+          "foo": {
             "$ref": "#/components/schemas/Foo"
           },
-          "fooArray" : {
-            "type" : "array",
-            "items" : {
+          "fooArray": {
+            "type": "array",
+            "items": {
               "$ref": "#/components/schemas/Bar"
             }
           },
-          "fuzzListWildcard" : {
-            "$ref": "#/components/schemas/Fuzz1"
+          "fuzzListWildcard": {
+            "$ref": "#/components/schemas/FuzzStringExtendsFoo"
           },
-          "longArray" : {
-            "type" : "array",
-            "items" : {
-              "format" : "int64",
-              "type" : "integer"
+          "longArray": {
+            "type": "array",
+            "items": {
+              "format": "int64",
+              "type": "integer"
             }
           },
-          "nesting" : {
-            "$ref": "#/components/schemas/KustomPair1"
+          "nesting": {
+            "$ref": "#/components/schemas/KustomPairKustomPairInteger"
           },
-          "password" : {
-            "type" : "string"
+          "password": {
+            "type": "string"
           },
-          "primitiveFoo" : {
-            "format" : "int32",
-            "maximum" : 9001,
-            "type" : "integer"
+          "primitiveFoo": {
+            "format": "int32",
+            "maximum": 9001,
+            "type": "integer"
           },
-          "rawArray" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object"
+          "rawArray": {
+            "type": "array",
+            "items": {
+              "type": "object"
             }
           },
-          "rootNode" : {
+          "rootNode": {
             "$ref": "#/components/schemas/BuzzLinkedList"
           },
-          "seatPreference" : {
-            "maxLength" : 999,
-            "type" : "string",
-            "example" : "window"
+          "seatPreference": {
+            "maxLength": 999,
+            "type": "string",
+            "example": "window"
           },
-          "simpleParameterizedType" : {
-            "$ref": "#/components/schemas/KustomPair2"
+          "simpleParameterizedType": {
+            "$ref": "#/components/schemas/KustomPairStringInteger"
           },
-          "unsafeList" : {
-            "type" : "array"
+          "unsafeList": {
+            "type": "array"
           },
-          "voidField" : {
-            "type" : "object"
+          "voidField": {
+            "type": "object"
           },
-          "writeOnlyInteger" : {
-            "format" : "int32",
-            "type" : "integer",
-            "writeOnly" : true
+          "writeOnlyInteger": {
+            "format": "int32",
+            "type": "integer",
+            "writeOnly": true
           }
         },
-        "example" : "This is the KitchenSink example field in Schema",
-        "deprecated" : true
+        "example": "This is the KitchenSink example field in Schema",
+        "deprecated": true
       }
     }
   }


### PR DESCRIPTION
Fixes #121 

Implementation of default schema naming using type parameters (and wildcard bounds). This also addresses an problem discovered where enumerated values are not generated when an `Enum` is the value of a `Map`.