### PR TITLE
Mark annotated fields with NotNull as required in containing Schema

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -116,7 +116,7 @@ public class AnnotationTargetProcessor {
             readSchemaAnnotatedField(propertyKey, schemaAnnotation);
         }
 
-        BeanValidationScanner.applyConstraints(annotationTarget, fieldSchema);
+        BeanValidationScanner.applyConstraints(annotationTarget, fieldSchema, parentPathEntry.getSchema(), propertyKey);
         fieldSchema = SchemaRegistry.checkRegistration(entityType, typeResolver, fieldSchema);
         parentPathEntry.getSchema().addProperty(propertyKey, fieldSchema);
         return fieldSchema;

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
@@ -75,28 +75,28 @@ public class BeanValidationResourceTest extends IndexScannerTestBase {
     static class BVTestResourceEntity {
         @Size(min = 5, max = 100)
         @NotNull
-        @Schema(minLength = 10, maxLength = 101, nullable = true, name = "string_no_bean_constraints")
+        @Schema(minLength = 10, maxLength = 101, nullable = true, name = "string_no_bean_constraints", required = false)
         @JsonbProperty("string_no_bean_constraints")
         private String stringIgnoreBvContraints;
 
         @Size(min = 1, max = 2000)
         @Digits(integer = 100, fraction = 100)
         @NotNull
-        @Schema(minimum = "101", maximum = "101.999", nullable = true, pattern = "^\\d{1,3}([.]\\d{1,3})?$", name = "big_int_no_bean_constraints")
+        @Schema(minimum = "101", maximum = "101.999", nullable = true, pattern = "^\\d{1,3}([.]\\d{1,3})?$", name = "big_int_no_bean_constraints", required = false)
         @JsonbProperty("big_int_no_bean_constraints")
         private BigInteger bIntegerIgnoreBvContraints;
 
         @NotNull
         @NotEmpty
         @Size(max = 200)
-        @Schema(minItems = 0, maxItems = 100, nullable = true, name = "list_no_bean_constraints")
+        @Schema(minItems = 0, maxItems = 100, nullable = true, name = "list_no_bean_constraints", required = false)
         @JsonbProperty("list_no_bean_constraints")
         private List<String> listIgnoreBvContraints;
 
         @NotNull
         @NotEmpty
         @Size(max = 200)
-        @Schema(minProperties = 0, maxProperties = 100, nullable = true, name = "map_no_bean_constraints")
+        @Schema(minProperties = 0, maxProperties = 100, nullable = true, name = "map_no_bean_constraints", required = false)
         @JsonbProperty("map_no_bean_constraints")
         private Map<String, String> mapIgnoreBvContraints;
     }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
@@ -76,6 +76,12 @@
       },
       "BVTestContainer": {
         "type": "object",
+        "required": [
+            "arrayListNotNullAndNotEmptyAndMaxItems",
+            "booleanNotNull",
+            "mapObjectNotNullAndNotEmptyAndMaxProperties",
+            "stringNotBlankNotNull"
+        ],
         "properties": {
           "arrayListNotNullAndNotEmptyAndMaxItems": {
             "type": "array",


### PR DESCRIPTION
Fixes #131 

* Required by default, overridden by Schema#required = false
* Update bean validation scanner unit tests