### PR TITLE
Exclude enum fields from values

### DIFF
--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IndexScannerTestBase.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IndexScannerTestBase.java
@@ -60,7 +60,7 @@ public class IndexScannerTestBase {
                 .getResourceAsStream(path);
     }
 
-    protected static Index indexOf(Class<?>... classes) {
+    public static Index indexOf(Class<?>... classes) {
         Indexer indexer = new Indexer();
 
         for (Class<?> klazz : classes) {

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/util/JandexUtilTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/util/JandexUtilTests.java
@@ -1,16 +1,23 @@
 package io.smallrye.openapi.runtime.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
+
+import javax.ws.rs.Path;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
 import org.json.JSONException;
 import org.junit.Test;
 
+import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
 import io.smallrye.openapi.runtime.util.JandexUtil.RefType;
 
 public class JandexUtilTests {
@@ -44,4 +51,39 @@ public class JandexUtilTests {
         String outRef = JandexUtil.refValue(annotation, RefType.Link);
         assertEquals("#/components/links/L1nk.T0_Something-Useful", outRef);
     }
+
+    @Test
+    public void testGetJaxRsResourceClasses() throws IOException, JSONException {
+        Index index = IndexScannerTestBase.indexOf(I1.class, I2.class, Implementor1.class, Implementor2.class);
+        Collection<ClassInfo> resources = JandexUtil.getJaxRsResourceClasses(index);
+        assertEquals(3, resources.size());
+        assertTrue(resources.contains(index.getClassByName(DotName.createSimple(I2.class.getName()))));
+        assertTrue(resources.contains(index.getClassByName(DotName.createSimple(Implementor1.class.getName()))));
+        assertTrue(resources.contains(index.getClassByName(DotName.createSimple(Implementor2.class.getName()))));
+    }
+
+    @Path("interface1")
+    interface I1 {
+        @Path("method1")
+        public String getData();
+    }
+
+    @Path("interface2")
+    interface I2 {
+        @Path("method1")
+        public String getData();
+    }
+
+    @Path("implementation1")
+    static abstract class Implementor1 implements I1 {
+    }
+
+    @Path("implementation2")
+    static class Implementor2 implements I2 {
+        @Override
+        public String getData() {
+            return null;
+        }
+    }
+
 }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/enum.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/enum.expected.json
@@ -5,7 +5,7 @@
         "type": "object",
         "properties" : {
           "bazEnum" : {
-            "enum" : [ "Gold", "Green", "Orange" ],
+            "enum" : [ "Gold", "Green" ],
             "type" : "string"
           }
         }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/enumRequired.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/enumRequired.expected.json
@@ -6,7 +6,7 @@
         "type": "object",
         "properties" : {
           "bazEnum" : {
-            "enum" : [ "Gold", "Green", "Orange" ],
+            "enum" : [ "Gold", "Green" ],
             "type" : "string"
           }
         }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.enum.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.enum.expected.json
@@ -5,8 +5,7 @@
         "type": "string",
         "enum": [
           "Gold",
-          "Green",
-          "Orange"
+          "Green"
         ]
       },
       "EnumContainer": {

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.enumRequired.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.enumRequired.expected.json
@@ -5,12 +5,13 @@
         "type": "string",
         "enum": [
           "Gold",
-          "Green",
-          "Orange"
+          "Green"
         ]
       },
       "EnumRequiredContainer": {
-        "required": [ "bazEnum" ],
+        "required": [
+          "bazEnum"
+        ],
         "type": "object",
         "properties": {
           "bazEnum": {

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
@@ -5,15 +5,8 @@
         "type": "string",
         "enum": [
           "Gold",
-          "Green",
-          "Orange"
-        ],
-        "properties": {
-          "z": {
-            "format": "int32",
-            "type": "integer"
-          }
-        }
+          "Green"
+        ]
       },
       "Baz": {
         "type": "object",


### PR DESCRIPTION
Fixes #106 

* Ignore static enum fields also
* Update affected unit tests
* Sort enum constant names for predictable results
* Add test for JandexUtil#getJaxRsResourceClasses (fixes #43)

With this PR, the results of scanning the enum used in several tests has changed. In the example below, only `Gold` and `Green` will be output in the list of enumerated values.

```java
public enum BazEnum {
    Green,
    Gold;

    int z = 0;

    static BazEnum Orange;
}
```