### PR TITLE
Add support for RestEasy multipart request content types

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -106,6 +106,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-multipart-provider</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-tck</artifactId>
             <scope>test</scope>

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
@@ -86,9 +86,7 @@ public final class OpenApiConstants {
     public static final String EXTENSION_PROPERTY_PREFIX = "x-";
 
     private static final String MIME_ANY = "*/*";
-    public static final Supplier<String[]> DEFAULT_MEDIA_TYPES = () -> {
-        return new String[] { MIME_ANY };
-    };
+    public static final Supplier<String[]> DEFAULT_MEDIA_TYPES = () -> new String[] { MIME_ANY };
 
     public static final String PROP_TRACE = "trace";
     public static final String PROP_PATCH = "patch";
@@ -164,6 +162,7 @@ public final class OpenApiConstants {
     public static final String PROP_MAXIMUM = "maximum";
     public static final String PROP_MULTIPLE_OF = "multipleOf";
     public static final String PROP_FORMAT = "format";
+    @SuppressWarnings("squid:S00115") // Instruct SonarCloud to ignore this unconventional variable name
     public static final String PROP_$REF = "$ref";
     public static final String PROP_CALLBACKS = "callbacks";
     public static final String PROP_LINKS = "links";
@@ -249,6 +248,7 @@ public final class OpenApiConstants {
     public static final DotName DOTNAME_MATRIX_PARAM = DotName.createSimple(MatrixParam.class.getName());
     public static final DotName DOTNAME_BEAN_PARAM = DotName.createSimple(BeanParam.class.getName());
 
+    // RestEasy parameter extension annotations
     public static final DotName DOTNAME_RESTEASY_QUERY_PARAM = DotName
             .createSimple("org.jboss.resteasy.annotations.jaxrs.QueryParam");
     public static final DotName DOTNAME_RESTEASY_FORM_PARAM = DotName
@@ -261,6 +261,33 @@ public final class OpenApiConstants {
             .createSimple("org.jboss.resteasy.annotations.jaxrs.HeaderParam");
     public static final DotName DOTNAME_RESTEASY_MATRIX_PARAM = DotName
             .createSimple("org.jboss.resteasy.annotations.jaxrs.MatrixParam");
+
+    // RestEasy multi-part form annotations
+    public static final DotName DOTNAME_RESTEASY_MULTIPART_FORM = DotName
+            .createSimple("org.jboss.resteasy.annotations.providers.multipart.MultipartForm");
+    public static final DotName DOTNAME_RESTEASY_PART_TYPE = DotName
+            .createSimple("org.jboss.resteasy.annotations.providers.multipart.PartType");
+
+    // RestEasy multi-part request body types
+    public static final DotName DOTNAME_RESTEASY_MULTIPART_INPUT = DotName
+            .createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartInput");
+    public static final DotName DOTNAME_RESTEASY_MULTIPART_FORM_DATA_INPUT = DotName
+            .createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput");
+    public static final DotName DOTNAME_RESTEASY_MULTIPART_RELATED_INPUT = DotName
+            .createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartRelatedInput");
+
+    public static final Set<DotName> DOTNAME_RESTEASY_MULTIPART_INPUTS = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList(DOTNAME_RESTEASY_MULTIPART_INPUT,
+                    DOTNAME_RESTEASY_MULTIPART_FORM_DATA_INPUT,
+                    DOTNAME_RESTEASY_MULTIPART_RELATED_INPUT)));
+
+    // RestEasy multi-part response types
+    public static final DotName DOTNAME_RESTEASY_MULTIPART_OUTPUT = DotName
+            .createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartOutput");
+    public static final DotName DOTNAME_RESTEASY_MULTIPART_FORM_DATA_OUTPUT = DotName
+            .createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput");
+    public static final DotName DOTNAME_RESTEASY_MULTIPART_RELATED_OUTPUT = DotName
+            .createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartRelatedOutput");
 
     public static final DotName DOTNAME_DEFAULT_VALUE = DotName.createSimple(DefaultValue.class.getName());
 

--- a/implementation/src/main/java/io/smallrye/openapi/api/models/media/ContentImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/models/media/ContentImpl.java
@@ -41,7 +41,7 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
         if (mediaType == null) {
             return this;
         }
-        this.put(name, mediaType);
+        super.put(name, mediaType);
         return this;
     }
 

--- a/implementation/src/main/java/io/smallrye/openapi/api/util/MergeUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/util/MergeUtil.java
@@ -166,7 +166,7 @@ public class MergeUtil {
      * @param values2
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private static Map mergeMaps(Map values1, Map values2) {
+    public static Map mergeMaps(Map values1, Map values2) {
         if (values1 == null && values2 == null) {
             return null;
         }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -40,6 +40,7 @@ import org.jboss.jandex.Type;
 
 import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
+import io.smallrye.openapi.runtime.scanner.ParameterProcessor.JaxRsParameter;
 
 /**
  * Some utility methods for working with Jandex objects.
@@ -447,6 +448,9 @@ public class JandexUtil {
     private static boolean containsJaxRsAnnotations(List<AnnotationInstance> instances,
             List<AnnotationScannerExtension> extensions) {
         for (AnnotationInstance instance : instances) {
+            if (JaxRsParameter.isParameter(instance.name())) {
+                return true;
+            }
             if (instance.name().toString().startsWith(JAXRS_PACKAGE)) {
                 return true;
             }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -41,11 +41,14 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Encoding;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+import org.jboss.resteasy.annotations.providers.multipart.PartType;
 import org.json.JSONException;
 import org.junit.Test;
 
@@ -147,6 +150,14 @@ public class ParameterScanTests extends IndexScannerTestBase {
         test("params.all-the-params.json",
                 AllTheParamsTestResource.class,
                 AllTheParamsTestResource.Bean.class,
+                Widget.class);
+    }
+
+    @Test
+    public void testMultipartForm() throws IOException, JSONException {
+        test("params.multipart-form.json",
+                MultipartFormTestResource.class,
+                MultipartFormTestResource.Bean.class,
                 Widget.class);
     }
 
@@ -399,6 +410,36 @@ public class ParameterScanTests extends IndexScannerTestBase {
         @Produces(MediaType.APPLICATION_JSON)
         public Widget get(@QueryParam("q1") @Deprecated long q1,
                 @org.jboss.resteasy.annotations.jaxrs.QueryParam("q2") String notQ2) {
+            return null;
+        }
+    }
+
+    @Path("/multipart/{id1}/{id2}")
+    @SuppressWarnings("unused")
+    static class MultipartFormTestResource {
+        public MultipartFormTestResource(@PathParam("id1") int id1,
+                @org.jboss.resteasy.annotations.jaxrs.PathParam String id2) {
+        }
+
+        static class Bean {
+            @org.jboss.resteasy.annotations.jaxrs.FormParam
+            @DefaultValue("f1-default")
+            String formField1;
+
+            @FormParam("f2")
+            @DefaultValue("default2")
+            @PartType("text/plain")
+            String formField2;
+        }
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.APPLICATION_JSON)
+        @RequestBody(content = @Content(schema = @Schema(requiredProperties = { "f3" }), encoding = {
+                @Encoding(name = "formField1", contentType = "text/x-custom-type") }))
+        public CompletionStage<Widget> upd(@MultipartForm Bean form,
+                @FormParam("f3") @DefaultValue("3") int formField3,
+                @org.jboss.resteasy.annotations.jaxrs.FormParam @NotNull String formField4) {
             return null;
         }
     }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/RequestBodyScanTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/RequestBodyScanTests.java
@@ -1,0 +1,120 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartInput;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartRelatedInput;
+import org.json.JSONException;
+import org.junit.Test;
+
+public class RequestBodyScanTests extends IndexScannerTestBase {
+
+    private static void test(String expectedResource, Class<?>... classes) throws IOException, JSONException {
+        Index index = indexOf(classes);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), index);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals(expectedResource, result);
+    }
+
+    @Test
+    public void testResteasyMultipartInput() throws IOException, JSONException {
+        test("params.resteasy-multipart-mixed.json",
+                ResteasyMultipartInputTestResource.class);
+    }
+
+    @Test
+    public void testResteasyMultipartInputList() throws IOException, JSONException {
+        test("params.resteasy-multipart-mixed-array.json",
+                ResteasyMultipartMixedListTestResource.class,
+                RequestBodyWidget.class);
+    }
+
+    @Test
+    public void testResteasyMultipartFormDataInput() throws IOException, JSONException {
+        test("params.resteasy-multipart-form-data-input.json",
+                ResteasyMultipartFormDataInputTestResource.class);
+    }
+
+    @Test
+    public void testResteasyMultipartFormDataMap() throws IOException, JSONException {
+        test("params.resteasy-multipart-form-data-map.json",
+                ResteasyMultipartFormDataMapTestResource.class,
+                RequestBodyWidget.class);
+    }
+
+    @Test
+    public void testResteasyMultipartRelatedInput() throws IOException, JSONException {
+        test("params.resteasy-multipart-related-input.json",
+                ResteasyMultipartRelatedInputTestResource.class);
+    }
+
+    /***************** Test models and resources below. ***********************/
+
+    public static class RequestBodyWidget {
+        long id;
+        String name;
+    }
+
+    @Path("multipart-mixed")
+    static class ResteasyMultipartInputTestResource {
+        @POST
+        @Path("post")
+        @Consumes("multipart/mixed")
+        @SuppressWarnings("unused")
+        public void post(MultipartInput input) {
+        }
+    }
+
+    @Path("multipart-mixed-array")
+    static class ResteasyMultipartMixedListTestResource {
+        @POST
+        @Path("post")
+        @Consumes("multipart/mixed")
+        @SuppressWarnings("unused")
+        public void post(List<RequestBodyWidget> input) {
+        }
+    }
+
+    @Path("multipart-form-data-input")
+    static class ResteasyMultipartFormDataInputTestResource {
+        @POST
+        @Path("post")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @SuppressWarnings("unused")
+        public void post(MultipartFormDataInput input) {
+        }
+    }
+
+    @Path("multipart-form-data-map")
+    static class ResteasyMultipartFormDataMapTestResource {
+        @POST
+        @Path("post")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @SuppressWarnings("unused")
+        public void post(Map<String, RequestBodyWidget> input) {
+        }
+    }
+
+    @Path("multipart-related-input")
+    static class ResteasyMultipartRelatedInputTestResource {
+        @POST
+        @Path("post/{id}")
+        @Consumes("multipart/related")
+        @RequestBody(required = true)
+        @SuppressWarnings("unused")
+        public void post(@org.jboss.resteasy.annotations.jaxrs.PathParam("id") String id, MultipartRelatedInput input) {
+        }
+    }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.multipart-form.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.multipart-form.json
@@ -1,0 +1,92 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/multipart/{id1}/{id2}": {
+      "parameters": [
+        {
+          "name": "id1",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        {
+          "name": "id2",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [ "formField4", "f3" ],
+                "properties": {
+                  "formField1": {
+                    "type": "string",
+                    "default": "f1-default"
+                  },
+                  "f2": {
+                    "type": "string",
+                    "default": "default2"
+                  },
+                  "f3": {
+                    "type": "integer",
+                    "format": "int32",
+                    "default": 3
+                  },
+                  "formField4": {
+                    "type": "string",
+                    "nullable": false
+                  }
+                }
+              },
+              "encoding": {
+                "formField1": {
+                  "contentType": "text/x-custom-type"
+                },
+                "f2": {
+                  "contentType": "text/plain"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Widget"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Widget": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-form-data-input.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-form-data-input.json
@@ -1,0 +1,23 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/multipart-form-data-input/post": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-form-data-map.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-form-data-map.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/multipart-form-data-map/post": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/RequestBodyWidget"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RequestBodyWidget": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-mixed-array.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-mixed-array.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/multipart-mixed-array/post": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/mixed": {
+              "schema": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/RequestBodyWidget"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RequestBodyWidget": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-mixed.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-mixed.json
@@ -1,0 +1,23 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/multipart-mixed/post": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/mixed": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-related-input.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-multipart-related-input.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/multipart-related-input/post/{id}": {
+      "post": {
+        "parameters": [{
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }],
+        "requestBody": {
+          "content": {
+            "multipart/related": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,12 @@
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>
-        <version.org.jboss.resteasy.core-spi>4.0.0.Final</version.org.jboss.resteasy.core-spi>
+        <version.org.jboss.resteasy.core-spi>4.1.0.Final</version.org.jboss.resteasy.core-spi>
+        <version.org.jboss.resteasy.multipart-provider>4.1.0.Final</version.org.jboss.resteasy.multipart-provider>
 
         <!-- Used by release plugin to define git tag -->
         <tagNameFormat>smallrye-open-api-1.1-@{project.version}</tagNameFormat>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/tck/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../tck/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <scm>
@@ -144,6 +146,12 @@
                 <artifactId>resteasy-core-spi</artifactId>
                 <version>${version.org.jboss.resteasy.core-spi}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.jboss.resteasy</groupId>
+              <artifactId>resteasy-multipart-provider</artifactId>
+              <version>${version.org.jboss.resteasy.multipart-provider}</version>
+              <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.skyscreamer</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -136,4 +136,31 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <properties>
+                <argLine>@{jacocoArgLine}</argLine>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fixes #144 ; feedback welcome.

* Add JaCoCo aggregation to TCK and parent for full coverage report in SonarCloud
* Treat RestEasy multipart interfaces as object types in scan
* Always retrieve types for `CollectionStandin` and `MapStandin`, even when not indexed by the app/calling code
* Clean up several "smells" reported in SonarCloud
* Update resteasy-core-spi