### PR TITLE
Support annotated methods for schemas and user-defined prop order

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
@@ -313,8 +313,33 @@ public final class OpenApiConstants {
 
     public static final DotName COMPLETION_STAGE_NAME = DotName.createSimple(CompletionStage.class.getName());
 
-    public static final DotName DOTNAME_JSONB_PROPERTY = DotName.createSimple("javax.json.bind.annotation.JsonbProperty");
-    public static final DotName DOTNAME_JSONB_TRANSIENT = DotName.createSimple("javax.json.bind.annotation.JsonbTransient");
+    public static final DotName DOTNAME_JSONB_PROPERTY = DotName
+            .createSimple("javax.json.bind.annotation.JsonbProperty");
+    public static final DotName DOTNAME_JSONB_TRANSIENT = DotName
+            .createSimple("javax.json.bind.annotation.JsonbTransient");
+    public static final DotName DOTNAME_JSONB_PROPERTY_ORDER = DotName
+            .createSimple("javax.json.bind.annotation.JsonbPropertyOrder");
+
+    public static final DotName DOTNAME_JAXB_XML_TYPE = DotName
+            .createSimple("javax.xml.bind.annotation.XmlType");
+    public static final DotName DOTNAME_JAXB_XML_ELEMENT = DotName
+            .createSimple("javax.xml.bind.annotation.XmlElement");
+    public static final DotName DOTNAME_JAXB_XML_ATTRIBUTE = DotName
+            .createSimple("javax.xml.bind.annotation.XmlAttribute");
+
+    public static final DotName DOTNAME_JACKSON_PROPERTY = DotName
+            .createSimple("com.fasterxml.jackson.annotation.JsonProperty");
+    public static final DotName DOTNAME_JACKSON_IGNORE = DotName
+            .createSimple("com.fasterxml.jackson.annotation.JsonIgnore");
+    public static final DotName DOTNAME_JACKSON_IGNORE_PROPERTIES = DotName
+            .createSimple("com.fasterxml.jackson.annotation.JsonIgnoreProperties");
+    public static final DotName DOTNAME_JACKSON_PROPERTY_ORDER = DotName
+            .createSimple("com.fasterxml.jackson.annotation.JsonPropertyOrder");
+
+    public static final Set<DotName> DOTNAME_PROPERTY_ANNOTATIONS = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList(DOTNAME_SCHEMA,
+                    DOTNAME_JSONB_PROPERTY,
+                    DOTNAME_JACKSON_PROPERTY)));
 
     public static final String REF_PREFIX_API_RESPONSE = "#/components/responses/";
     public static final String REF_PREFIX_CALLBACK = "#/components/callbacks/";

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -15,19 +15,36 @@
  */
 package io.smallrye.openapi.runtime.scanner.dataobject;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeVariable;
 import org.jboss.logging.Logger;
 
+import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.runtime.util.TypeUtil;
 
 /**
@@ -36,18 +53,253 @@ import io.smallrye.openapi.runtime.util.TypeUtil;
 public class TypeResolver {
 
     private static final Logger LOG = Logger.getLogger(TypeResolver.class);
+    private static final Type BOOLEAN_TYPE = Type.create(DotName.createSimple(Boolean.class.getName()), Type.Kind.CLASS);
 
-    private Deque<Map<String, Type>> resolutionStack;
+    private final Deque<Map<String, Type>> resolutionStack;
+    private final String propertyName;
+    private FieldInfo field;
+    private MethodInfo readMethod;
+    private MethodInfo writeMethod;
     private Type leaf;
 
-    private TypeResolver(Type leaf, Deque<Map<String, Type>> resolutionStack) {
-        this.leaf = leaf;
+    /**
+     * A comparator to order the field, write method, and read method in the {@link #targets}
+     * {@link PriorityQueue}. The priority is:
+     * <ol>
+     * <li>Items annotated with MP Open API {@link org.eclipse.microprofile.openapi.annotations.media.Schema @Schema}
+     * <li>Items annotated with JSON-B {@link javax.json.bind.annotation.JsonbProperty @JsonbProperty}
+     * <li>Items annotated with Jackson {@link com.fasterxml.jackson.annotation.JsonProperty @JsonProperty}
+     * <li>Items annotated with JAXB {@link javax.xml.bind.annotation.XmlElement @XmlElement}
+     * <li>Items annotated with JAXB {@link javax.xml.bind.annotation.XmlAttribute @XmlAttribute}
+     * <li>Fields
+     * <li>Getter/accessor methods
+     * <li>Setter/mutator methods
+     * </ol>
+     *
+     */
+    private static Comparator<AnnotationTarget> targetComparator = (t1, t2) -> {
+        int result;
+
+        // Annotated elements sort to the top of the priority queue
+        if ((result = compareAnnotation(t1, t2, OpenApiConstants.DOTNAME_SCHEMA)) != 0) {
+            return result;
+        }
+        if ((result = compareAnnotation(t1, t2, OpenApiConstants.DOTNAME_JSONB_PROPERTY)) != 0) {
+            return result;
+        }
+        if ((result = compareAnnotation(t1, t2, OpenApiConstants.DOTNAME_JACKSON_PROPERTY)) != 0) {
+            return result;
+        }
+        if ((result = compareAnnotation(t1, t2, OpenApiConstants.DOTNAME_JAXB_XML_ELEMENT)) != 0) {
+            return result;
+        }
+        if ((result = compareAnnotation(t1, t2, OpenApiConstants.DOTNAME_JAXB_XML_ATTRIBUTE)) != 0) {
+            return result;
+        }
+        if (t1.kind() == Kind.FIELD) {
+            return -1;
+        }
+        if (t2.kind() == Kind.FIELD) {
+            return +1;
+        }
+        if (t1.asMethod().name().startsWith("get") && !t2.asMethod().name().startsWith("get")) {
+            return -1;
+        }
+
+        return 0;
+    };
+
+    /**
+     * Queue of this resolvers field, write method, and read method. The highest priority "best"
+     * target is in the first position, using the order determined by
+     * {@link TypeResolver#targetComparator targetComparator}.
+     */
+    private Queue<AnnotationTarget> targets = new PriorityQueue<>(targetComparator);
+
+    private static int compareAnnotation(AnnotationTarget t1, AnnotationTarget t2, DotName annotationName) {
+        boolean hasAnno1 = TypeUtil.hasAnnotation(t1, annotationName);
+        boolean hasAnno2 = TypeUtil.hasAnnotation(t2, annotationName);
+
+        // Element with @Schema is top priority
+        if (hasAnno1) {
+            if (!hasAnno2) {
+                return -1;
+            }
+        } else {
+            if (hasAnno2) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    private TypeResolver(String propertyName, FieldInfo field, Deque<Map<String, Type>> resolutionStack) {
+        this.propertyName = propertyName;
+        this.field = field;
         this.resolutionStack = resolutionStack;
+
+        if (field != null) {
+            this.leaf = field.type();
+            targets.add(field);
+        } else {
+            this.leaf = null;
+        }
+    }
+
+    /**
+     * Get the declaring class of the annotation target.
+     *
+     * @return the {@link ClassInfo} of the class that declares the optimal annotation target for the type represented by the
+     *         current instance.
+     */
+    public ClassInfo getDeclaringClass() {
+        return TypeUtil.getDeclaringClass(getAnnotationTarget());
+    }
+
+    /**
+     * Get the annotation target that represents this instance's schema property.
+     *
+     * @return the optimal annotation target for the type represented by the current instance.
+     */
+    public AnnotationTarget getAnnotationTarget() {
+        return targets.peek();
+    }
+
+    public Type getUnresolvedType() {
+        return this.leaf;
+    }
+
+    /**
+     * Determine the name of the instance's property. The name may be overridden by
+     * one of several annotations, selected in the following order:
+     *
+     * <ol>
+     * <li>MP Open API <code>@Schema</code>
+     * <li>JSON-B <code>@JsonbProperty</code>
+     * <li>Jackson <code>@JsonProperty</code>
+     * <li>JAXB <code>@XmlElement</code>
+     * <li>JAXB <code>@XmlAttribute</code>
+     * </ol>
+     *
+     * If no elements have been selected, the default Java bean property name will
+     * be returned.
+     *
+     * @return name of property
+     */
+    public String getPropertyName() {
+        AnnotationTarget target = getAnnotationTarget();
+        String name;
+
+        if ((name = TypeUtil.getAnnotationValue(target,
+                OpenApiConstants.DOTNAME_SCHEMA,
+                OpenApiConstants.PROP_NAME)) != null) {
+            return name;
+        }
+
+        if ((name = TypeUtil.getAnnotationValue(target,
+                OpenApiConstants.DOTNAME_JSONB_PROPERTY,
+                OpenApiConstants.PROP_VALUE)) != null) {
+            return name;
+        }
+
+        if ((name = TypeUtil.getAnnotationValue(target,
+                OpenApiConstants.DOTNAME_JACKSON_PROPERTY,
+                OpenApiConstants.PROP_VALUE)) != null) {
+            return name;
+        }
+
+        if ((name = TypeUtil.getAnnotationValue(target,
+                OpenApiConstants.DOTNAME_JAXB_XML_ELEMENT,
+                OpenApiConstants.PROP_NAME)) != null) {
+            return name;
+        }
+
+        if ((name = TypeUtil.getAnnotationValue(target,
+                OpenApiConstants.DOTNAME_JAXB_XML_ATTRIBUTE,
+                OpenApiConstants.PROP_NAME)) != null) {
+            return name;
+        }
+
+        return this.propertyName;
+    }
+
+    /**
+     * Retrieves the field associated with this property. May be null.
+     *
+     * @return field property
+     */
+    public FieldInfo getField() {
+        return field;
+    }
+
+    private void setField(FieldInfo field) {
+        this.field = field;
+    }
+
+    /**
+     * Retrieves the read method (getter) associated with this property.
+     * May be null.
+     *
+     * @return the property's read method (getter)
+     */
+    public MethodInfo getReadMethod() {
+        return readMethod;
+    }
+
+    /**
+     * Sets the read method for the property. May replace a previously-set method
+     * in the case where an interface defines an annotated method with more
+     * information than the implementation of the method.
+     *
+     * @param readMethod the property's read method (getter/accessor)
+     */
+    private void setReadMethod(MethodInfo readMethod) {
+        if (this.readMethod != null) {
+            targets.remove(this.readMethod);
+        }
+
+        this.readMethod = readMethod;
+
+        if (readMethod != null) {
+            this.leaf = readMethod.returnType();
+            targets.add(readMethod);
+        }
+    }
+
+    /**
+     * Retrieves the write method (setter) associated with this property.
+     * May be null.
+     *
+     * @return the property's write method (setter)
+     */
+    public MethodInfo getWriteMethod() {
+        return writeMethod;
+    }
+
+    /**
+     * Sets the write method for the property. May replace a previously-set method
+     * in the case where an interface defines an annotated method with more
+     * information than the implementation of the method.
+     *
+     * @param writeMethod the property's write method (setter/mutator)
+     */
+    private void setWriteMethod(MethodInfo writeMethod) {
+        if (this.writeMethod != null) {
+            targets.remove(this.writeMethod);
+        }
+
+        this.writeMethod = writeMethod;
+
+        if (writeMethod != null) {
+            this.leaf = writeMethod.parameters().get(0);
+            targets.add(writeMethod);
+        }
     }
 
     /**
      * Resolve the type that was used to initially construct this {@link TypeResolver}
-     * 
+     *
      * @return the resolved type (if found)
      */
     public Type resolveType() {
@@ -56,7 +308,7 @@ public class TypeResolver {
 
     /**
      * Resolve a type against this {@link TypeResolver}'s resolution stack
-     * 
+     *
      * @param fieldType type to resolve
      * @return resolved type (if found)
      */
@@ -76,37 +328,312 @@ public class TypeResolver {
         return current;
     }
 
-    public static Map<FieldInfo, TypeResolver> getAllFields(AugmentedIndexView index, Type leaf, ClassInfo leafKlazz) {
-        Map<FieldInfo, TypeResolver> fields = new LinkedHashMap<>();
-        Type currentType = leaf;
-        ClassInfo currentClass = leafKlazz;
+    public static Map<String, TypeResolver> getAllFields(AugmentedIndexView index, Type leaf, ClassInfo leafKlazz) {
+        Map<ClassInfo, Type> chain = inheritanceChain(index, leafKlazz, leaf);
+        Map<String, TypeResolver> properties = new LinkedHashMap<>();
         Deque<Map<String, Type>> stack = new ArrayDeque<>();
 
-        do {
+        for (Map.Entry<ClassInfo, Type> entry : chain.entrySet()) {
+            ClassInfo currentClass = entry.getKey();
+            Type currentType = entry.getValue();
+
             if (currentType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
                 Map<String, Type> resMap = buildParamTypeResolutionMap(currentClass, currentType.asParameterizedType());
                 stack.push(resMap);
             }
 
-            for (FieldInfo field : currentClass.fields()) {
-                TypeResolver resolver = new TypeResolver(field.type(), new ArrayDeque<>(stack));
-                fields.put(field, resolver);
+            // Store all field properties
+            currentClass.fields()
+                    .stream()
+                    .filter(field -> !Modifier.isStatic(field.flags()))
+                    .forEach(field -> scanField(properties, field, stack));
+
+            currentClass.methods()
+                    .stream()
+                    .filter(method -> !Modifier.isStatic(method.flags()))
+                    .forEach(method -> scanMethod(properties, method, stack));
+
+            currentClass.interfaceTypes()
+                    .stream()
+                    .map(index::getClass)
+                    .filter(Objects::nonNull)
+                    .flatMap(clazz -> clazz.methods().stream())
+                    .forEach(method -> scanMethod(properties, method, stack));
+        }
+
+        return sorted(properties, chain.keySet());
+    }
+
+    /**
+     * Builds an insertion-order map of a class's inheritance chain, starting
+     * with the klazz argument.
+     *
+     * @param index index for superclass retrieval
+     * @param klazz the class to retrieve inheritance
+     * @param type type of the klazz
+     * @return map of a class's inheritance chain/ancestry
+     */
+    private static Map<ClassInfo, Type> inheritanceChain(AugmentedIndexView index,
+            ClassInfo klazz,
+            Type type) {
+
+        Map<ClassInfo, Type> chain = new LinkedHashMap<>();
+
+        do {
+            chain.put(klazz, type);
+        } while ((type = klazz.superClassType()) != null && (klazz = index.getClass(type)) != null);
+
+        return chain;
+    }
+
+    /**
+     * Determines if a field is a bean property. This is the case if (1) no field having the same name
+     * has yet be scanned earlier (lower) in the inheritance chain or (2) if getter/setter methods were
+     * previously found but no field has yet been found. If case (2), the field must be either public or
+     * protected and it is assumed that the getter/setter methods scanned lower in the inheritance chain
+     * operate on the field which is in a super class.
+     *
+     * @param properties current map of properties discovered
+     * @param field the field to scan
+     * @param stack type resolution stack for parameterized types
+     */
+    private static void scanField(Map<String, TypeResolver> properties, FieldInfo field, Deque<Map<String, Type>> stack) {
+        String propertyName = field.name();
+
+        // Consider only using fields that are public?
+        if (properties.containsKey(propertyName)) {
+            TypeResolver resolver = properties.get(propertyName);
+
+            if (resolver.getField() == null && (Modifier.isPublic(field.flags()) || Modifier.isProtected(field.flags()))) {
+                /*
+                 * Field is declared in parent class and the getter/setter was
+                 * declared/overridden in child class
+                 */
+                resolver.setField(field);
             }
+        } else {
+            TypeResolver resolver = new TypeResolver(propertyName, field, new ArrayDeque<>(stack));
+            properties.put(propertyName, resolver);
+        }
+    }
 
-            currentType = currentClass.superClassType();
+    /**
+     * Determines if a method is a bean property method. The method must conform to the Java bean
+     * conventions for getter or setter methods.
+     *
+     * @param properties current map of properties discovered
+     * @param field the method to scan
+     * @param stack type resolution stack for parameterized types
+     */
+    private static void scanMethod(Map<String, TypeResolver> properties, MethodInfo method, Deque<Map<String, Type>> stack) {
+        Type returnType = method.returnType();
+        Type propertyType = null;
 
-            if (currentType == null) {
-                break;
+        if (isAccessor(method)) {
+            propertyType = returnType;
+        } else if (isMutator(method)) {
+            propertyType = method.parameters().get(0);
+        }
+
+        if (propertyType != null) {
+            updateTypeResolvers(properties, stack, method, propertyType);
+        }
+    }
+
+    /**
+     * Adds (or updates) a TypeResolver with the method if (1) the method represents
+     * a property not already in the properties map or (2) if the method has the same
+     * type as an existing property having the same name and the new method has a
+     * higher priority than the current method of the same type (getter or setter).
+     *
+     * @param properties current map of properties discovered
+     * @param stack type resolution stack for parameterized types
+     * @param method the method to add/update in properties
+     * @param propertyType the type of the property associated with the method
+     */
+    private static void updateTypeResolvers(Map<String, TypeResolver> properties,
+            Deque<Map<String, Type>> stack,
+            MethodInfo method,
+            Type propertyType) {
+        String methodName = method.name();
+        boolean isWriteMethod = isMutator(method);
+        String propertyName;
+        int nameStart;
+
+        if (isWriteMethod) {
+            nameStart = 3;
+        } else {
+            nameStart = methodName.startsWith("is") ? 2 : 3;
+        }
+
+        propertyName = Character.toLowerCase(methodName.charAt(nameStart)) + methodName.substring(nameStart + 1);
+        TypeResolver resolver;
+
+        if (properties.containsKey(propertyName)) {
+            resolver = properties.get(propertyName);
+
+            // Only store the accessor/mutator methods if the type of property matches
+            if (!TypeUtil.equalTypes(resolver.getUnresolvedType(), propertyType)) {
+                return;
             }
+        } else {
+            resolver = new TypeResolver(propertyName, null, new ArrayDeque<>(stack));
+            properties.put(propertyName, resolver);
+        }
 
-            currentClass = index.getClass(currentType);
-
-            if (currentClass == null) {
-                break;
+        if (isWriteMethod) {
+            if (isHigherPriority(method, resolver.getWriteMethod())) {
+                resolver.setWriteMethod(method);
             }
-        } while (currentClass.superClassType() != null);
+        } else {
+            if (isHigherPriority(method, resolver.getReadMethod())) {
+                resolver.setReadMethod(method);
+            }
+        }
+    }
 
-        return fields;
+    /**
+     * Returns whether a method follows the Java bean convention for an accessor
+     * method (getter). The method name typically begins with "get", but may also
+     * begin with "is" when the return type is boolean.
+     *
+     * @param method the method to check
+     * @return true if the method is a Java bean getter, otherwise false
+     */
+    private static boolean isAccessor(MethodInfo method) {
+        Type returnType = method.returnType();
+
+        if (!method.parameters().isEmpty() || Type.Kind.VOID.equals(returnType.kind())) {
+            return false;
+        }
+
+        String methodName = method.name();
+
+        if (methodName.startsWith("get")) {
+            return true;
+        }
+
+        return methodName.startsWith("is") && TypeUtil.equalTypes(returnType, BOOLEAN_TYPE);
+    }
+
+    /**
+     * Returns whether a method follows the Java bean convention for a mutator
+     * method (setter).
+     *
+     * @param method the method to check
+     * @return true if the method is a Java bean setter, otherwise false
+     */
+    private static boolean isMutator(MethodInfo method) {
+        Type returnType = method.returnType();
+
+        if (method.parameters().size() != 1 || !Type.Kind.VOID.equals(returnType.kind())) {
+            return false;
+        }
+
+        return method.name().startsWith("set");
+    }
+
+    private static boolean isHigherPriority(MethodInfo newMethod, MethodInfo oldMethod) {
+        if (oldMethod == null) {
+            return true;
+        }
+
+        if (Modifier.isInterface(newMethod.declaringClass().flags())) {
+            return targetComparator.compare(newMethod, oldMethod) < 0;
+        }
+
+        return false;
+    }
+
+    /**
+     * Orders the properties map based on annotations declared on classes in the
+     * ancestry chain or based on where in the class hierarchy the property is declared.
+     *
+     * Properties will be order as follows:
+     * <ol>
+     * <li>Properties with an order specified in a super class (highest first)
+     * <li>Properties with an order specified in the child class
+     * <li>Properties declared in a super class (highest first)
+     * <li>Properties declared in the child class
+     * </ol>
+     *
+     * @param properties current map of properties discovered
+     * @param chainKeys inheritance chain, child classes first
+     * @return ordered map of properties
+     */
+    private static Map<String, TypeResolver> sorted(Map<String, TypeResolver> properties, Set<ClassInfo> chainKeys) {
+        List<ClassInfo> chain = new ArrayList<>(chainKeys);
+        Collections.reverse(chain);
+        List<String> order = chain.stream()
+                .map(TypeResolver::propertyOrder)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+
+        return properties.entrySet()
+                .stream()
+                .sorted((e1, e2) -> {
+                    TypeResolver r1 = e1.getValue();
+                    TypeResolver r2 = e2.getValue();
+                    ClassInfo c1 = r1.getDeclaringClass();
+                    ClassInfo c2 = r2.getDeclaringClass();
+
+                    int pIndex1 = order.indexOf(r1.getPropertyName());
+                    if (pIndex1 < 0) {
+                        // The order was specified by the original property name, not the customized name (or not at all)
+                        pIndex1 = order.indexOf(e1.getKey());
+                    }
+
+                    int pIndex2 = order.indexOf(r2.getPropertyName());
+                    if (pIndex2 < 0) {
+                        // The order was specified by the original property name, not the customized name (or not at all)
+                        pIndex2 = order.indexOf(e2.getKey());
+                    }
+
+                    if (pIndex1 > -1) {
+                        if (pIndex2 < 0) {
+                            return -1;
+                        }
+                        return Integer.compare(pIndex1, pIndex2);
+                    }
+
+                    if (pIndex2 > -1) {
+                        return 1;
+                    }
+
+                    int cIndex1 = chain.indexOf(c1);
+                    int cIndex2 = chain.indexOf(c2);
+
+                    return Integer.compare(cIndex1, cIndex2);
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (e1, e2) -> e1,
+                        LinkedHashMap::new));
+    }
+
+    /**
+     * Retrieves the property order from annotations declare on the class, if available.
+     *
+     * @param clazz the class to check for property ordering
+     * @return a list of property names, in the order declared, or an empty list if none
+     */
+    private static List<String> propertyOrder(ClassInfo clazz) {
+        AnnotationInstance propertyOrder;
+        AnnotationValue orderArray = null;
+
+        if ((propertyOrder = clazz.classAnnotation(OpenApiConstants.DOTNAME_JSONB_PROPERTY_ORDER)) != null) {
+            orderArray = propertyOrder.value();
+        } else if ((propertyOrder = clazz.classAnnotation(OpenApiConstants.DOTNAME_JAXB_XML_TYPE)) != null) {
+            orderArray = propertyOrder.value("propOrder");
+        } else if ((propertyOrder = clazz.classAnnotation(OpenApiConstants.DOTNAME_JACKSON_PROPERTY_ORDER)) != null) {
+            orderArray = propertyOrder.value();
+        }
+
+        if (orderArray != null) {
+            return Arrays.asList(orderArray.asStringArray());
+        }
+
+        return Collections.emptyList();
     }
 
     private static Map<String, Type> buildParamTypeResolutionMap(ClassInfo klazz, ParameterizedType parameterizedType) {

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -111,6 +111,56 @@ public class JandexUtil {
     }
 
     /**
+     * Convenience method to retrieve the named parameter from an annotation.
+     * The value will be unwrapped from its containing {@link AnnotationValue}.
+     *
+     * @param <T> the type of the parameter being retrieved
+     * @param annotation the annotation from which to fetch the parameter
+     * @param name the name of the parameter
+     * @return an unwrapped annotation parameter value
+     */
+    @SuppressWarnings({ "unchecked", "squid:S3776" })
+    public static <T> T value(AnnotationInstance annotation, String name) {
+        final AnnotationValue value = annotation.value(name);
+
+        if (value == null) {
+            return null;
+        }
+
+        final boolean isArray = (AnnotationValue.Kind.ARRAY == value.kind());
+
+        switch (isArray ? value.componentKind() : value.kind()) {
+            case BOOLEAN:
+                return (T) (isArray ? value.asBooleanArray() : value.asBoolean());
+            case BYTE:
+                return (T) (isArray ? value.asByteArray() : value.asByte());
+            case CHARACTER:
+                return (T) (isArray ? value.asCharArray() : value.asChar());
+            case CLASS:
+                return (T) (isArray ? value.asClassArray() : value.asClass());
+            case DOUBLE:
+                return (T) (isArray ? value.asDoubleArray() : value.asDouble());
+            case ENUM:
+                return (T) (isArray ? value.asEnumArray() : value.asEnum());
+            case FLOAT:
+                return (T) (isArray ? value.asFloatArray() : value.asFloat());
+            case INTEGER:
+                return (T) (isArray ? value.asIntArray() : value.asInt());
+            case LONG:
+                return (T) (isArray ? value.asLongArray() : value.asLong());
+            case NESTED:
+                return (T) (isArray ? value.asNestedArray() : value.asNested());
+            case SHORT:
+                return (T) (isArray ? value.asShortArray() : value.asShort());
+            case STRING:
+                return (T) (isArray ? value.asStringArray() : value.asString());
+            case UNKNOWN:
+            default:
+                return null;
+        }
+    }
+
+    /**
      * Reads a String property value from the given annotation instance. If no value is found
      * this will return null.
      * 

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IndexScannerTestBase.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/IndexScannerTestBase.java
@@ -132,6 +132,15 @@ public class IndexScannerTestBase {
                 true);
     }
 
+    public static void assertJsonEquals(String expectedResource, Class<?>... classes)
+            throws IOException, JSONException {
+        Index index = indexOf(classes);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), index);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals(expectedResource, result);
+    }
+
     public static String loadResource(URL testResource) throws IOException {
         return IOUtils.toString(testResource, "UTF-8");
     }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+import org.junit.Test;
+
+import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
+import io.smallrye.openapi.runtime.util.TypeUtil;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+public class TypeResolverTests extends IndexScannerTestBase {
+
+    @Test
+    public void testAnnotatedMethodOverridesParentSchema() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(AbstractAnimal.class,
+                Feline.class,
+                Cat.class));
+
+        ClassInfo leafKlazz = index.getClassByName(componentize(Cat.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, leaf, leafKlazz);
+        TypeResolver resolver = properties.get("type");
+        assertEquals(Kind.METHOD, resolver.getAnnotationTarget().kind());
+        AnnotationInstance schema = TypeUtil.getSchemaAnnotation(resolver.getAnnotationTarget());
+        assertEquals("type", schema.value("name").asString());
+        assertEquals(false, schema.value("required").asBoolean());
+        assertEquals("Cat", schema.value("example").asString());
+        assertArrayEquals(new String[] { "age", "type", "name", "extinct" },
+                properties.values().stream().map(TypeResolver::getPropertyName).toArray());
+    }
+
+    @Test
+    public void testAnnotatedFieldsOverridesInterfaceSchema() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(AbstractAnimal.class,
+                Feline.class,
+                Cat.class));
+
+        ClassInfo leafKlazz = index.getClassByName(componentize(Cat.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, leaf, leafKlazz);
+        TypeResolver resolver = properties.get("name");
+        assertEquals(Kind.FIELD, resolver.getAnnotationTarget().kind());
+        AnnotationInstance schema = TypeUtil.getSchemaAnnotation(resolver.getAnnotationTarget());
+        assertEquals(true, schema.value("required").asBoolean());
+        assertEquals("Felix", schema.value("example").asString());
+    }
+
+    @Test
+    public void testAnnotatedInterfaceMethodOverridesImplMethod() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(AbstractAnimal.class,
+                Canine.class,
+                Dog.class));
+
+        ClassInfo leafKlazz = index.getClassByName(componentize(Dog.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, leaf, leafKlazz);
+        assertEquals(5, properties.size());
+        TypeResolver resolver = properties.get("name");
+        assertEquals(Kind.METHOD, resolver.getAnnotationTarget().kind());
+        AnnotationInstance schema = TypeUtil.getSchemaAnnotation(resolver.getAnnotationTarget());
+        assertEquals("c_name", schema.value("name").asString());
+        assertEquals(50, schema.value("maxLength").asInt());
+        assertEquals("The name of the canine", schema.value("description").asString());
+        assertArrayEquals(new String[] { "age", "type", "c_name", "bark", "extinct" },
+                properties.values().stream().map(TypeResolver::getPropertyName).toArray());
+    }
+
+    @Test
+    public void testAnnotatedInterfaceMethodOverridesStaticField() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(AbstractAnimal.class,
+                Reptile.class,
+                Lizard.class));
+
+        ClassInfo leafKlazz = index.getClassByName(componentize(Lizard.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, leaf, leafKlazz);
+
+        TypeResolver resolver = properties.get("scaleColor");
+        assertEquals(Kind.METHOD, resolver.getAnnotationTarget().kind());
+        AnnotationInstance schema = TypeUtil.getSchemaAnnotation(resolver.getAnnotationTarget());
+        assertEquals("scaleColor", schema.value("name").asString());
+        assertNull(schema.value("deprecated"));
+        assertEquals("The color of a reptile's scales", schema.value("description").asString());
+
+        TypeResolver ageResolver = properties.get("age");
+        assertEquals(Type.Kind.CLASS, ageResolver.getUnresolvedType().kind());
+        assertEquals(DotName.createSimple(String.class.getName()), ageResolver.getUnresolvedType().name());
+    }
+
+    @Test
+    public void testBareInterface() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(MySchema.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(MySchema.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, leaf, leafKlazz);
+        assertEquals(3, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+        assertEquals("field1", iter.next().getKey());
+        assertEquals("field3", iter.next().getKey());
+        assertEquals("field2", iter.next().getKey());
+
+        TypeResolver field1 = properties.get("field1");
+        assertEquals(Kind.METHOD, field1.getAnnotationTarget().kind());
+        AnnotationInstance schema1 = TypeUtil.getSchemaAnnotation(field1.getAnnotationTarget());
+        assertEquals(1, schema1.values().size());
+        assertEquals(true, schema1.value("required").asBoolean());
+
+        TypeResolver field2 = properties.get("field2");
+        assertEquals(Kind.METHOD, field1.getAnnotationTarget().kind());
+        AnnotationInstance schema2 = TypeUtil.getSchemaAnnotation(field2.getAnnotationTarget());
+        assertEquals(1, schema2.values().size());
+        assertEquals("anotherField", schema2.value("name").asString());
+
+        TypeResolver field3 = properties.get("field3");
+        assertEquals(Kind.METHOD, field3.getAnnotationTarget().kind());
+        AnnotationInstance schema3 = TypeUtil.getSchemaAnnotation(field3.getAnnotationTarget());
+        assertNull(schema3);
+    }
+
+    @Test
+    public void testJacksonPropertyOrderDefault() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(JacksonPropertyOrderDefault.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(JacksonPropertyOrderDefault.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, leaf, leafKlazz);
+        assertEquals(4, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+        assertEquals("comment", iter.next().getValue().getPropertyName());
+        assertEquals("theName", iter.next().getValue().getPropertyName());
+    }
+
+    @Test
+    public void testJacksonPropertyOrderCustomName() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(JacksonPropertyOrderCustomName.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(JacksonPropertyOrderCustomName.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, leaf, leafKlazz);
+        assertEquals(4, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+        assertEquals("theName", iter.next().getValue().getPropertyName());
+        assertEquals("comment2ActuallyFirst", iter.next().getValue().getPropertyName());
+        assertEquals("comment", iter.next().getValue().getPropertyName());
+    }
+
+    @Test
+    public void testJaxbCustomPropertyOrder() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(JaxbCustomPropertyOrder.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(JaxbCustomPropertyOrder.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, leaf, leafKlazz);
+        assertEquals(4, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+        assertEquals("theName", iter.next().getValue().getPropertyName());
+        assertEquals("comment2ActuallyFirst", iter.next().getValue().getPropertyName());
+        assertEquals("comment", iter.next().getValue().getPropertyName());
+        assertEquals("name2", iter.next().getValue().getPropertyName());
+    }
+
+    /* Test models and resources below. */
+
+    @com.fasterxml.jackson.annotation.JsonPropertyOrder({ "age", "type" })
+    public static abstract class AbstractAnimal {
+        @Schema
+        private String type;
+
+        protected Integer age;
+        private boolean extinct;
+
+        @Schema(name = "pet_type", required = true)
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+
+        @Schema
+        public Boolean isExtinct() {
+            return extinct;
+        }
+
+        public void setExtinct(boolean extinct) {
+            this.extinct = extinct;
+        }
+    }
+
+    public static interface Feline {
+        @Schema(name = "name", required = false, example = "Feline")
+        void setName(String name);
+    }
+
+    // "type" will be first due to ordering on AbstractAnimal
+    @javax.xml.bind.annotation.XmlType(propOrder = { "name", "type" })
+    public static class Cat extends AbstractAnimal implements Feline {
+        @Schema(required = true, example = "Felix")
+        String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        @Schema(name = "type", required = false, example = "Cat")
+        public String getType() {
+            return super.getType();
+        }
+    }
+
+    public static interface Canine {
+        @Schema(name = "c_name", description = "The name of the canine", maxLength = 50)
+        public String getName();
+    }
+
+    // "type" will be first due to ordering on AbstractAnimal
+    @javax.json.bind.annotation.JsonbPropertyOrder({ "name", "type", "bark" })
+    public static class Dog extends AbstractAnimal implements Canine {
+        @JsonbProperty("bark")
+        String bark;
+
+        @Schema(name = "bark")
+        public String getBark() {
+            return bark;
+        }
+
+        @Override
+        public String getName() {
+            return "Fido";
+        }
+
+        @Schema(description = "This property is not used due to being static")
+        public static int getStaticAge() {
+            return -1;
+        }
+    }
+
+    public static interface Reptile {
+        @Schema(name = "scaleColor", description = "The color of a reptile's scales")
+        public String getScaleColor();
+
+        @Schema(name = "scaleColor", description = "This is how the color is set, but the description comes from getScaleColor")
+        public void setScaleColor(String color);
+    }
+
+    public static class Lizard extends AbstractAnimal implements Reptile {
+        @Schema(deprecated = true)
+        static String scaleColor;
+        boolean lovesRocks;
+
+        @Override
+        public String getScaleColor() {
+            return "green";
+        }
+
+        public void setScaleColor(String scaleColor) {
+            // Bad idea, but doing it anyway ;-)
+            Lizard.scaleColor = scaleColor;
+        }
+
+        public void setAge(String age) {
+            super.setAge(Integer.parseInt(age));
+        }
+    }
+
+    // Out of order on purpose
+    @JsonbPropertyOrder({ "field1", "field3", "field2" })
+    public interface MySchema {
+        @Schema(required = true)
+        String getField1();
+
+        @Schema(name = "anotherField")
+        String getField2();
+
+        String getField3();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonPropertyOrder({ "comment", "name" })
+    public static class JacksonPropertyOrderDefault {
+
+        @com.fasterxml.jackson.annotation.JsonProperty("theName")
+        String name;
+        String name2;
+        String comment;
+        String comment2;
+
+        public String getComment() {
+            return comment;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    @com.fasterxml.jackson.annotation.JsonPropertyOrder({ "theName", "comment2ActuallyFirst", "comment" })
+    public static class JacksonPropertyOrderCustomName {
+
+        @com.fasterxml.jackson.annotation.JsonProperty("theName")
+        String name;
+        String name2;
+        String comment;
+        @com.fasterxml.jackson.annotation.JsonProperty("comment2ActuallyFirst")
+        String comment2;
+
+        public String getComment() {
+            return comment;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    @XmlType(propOrder = { "theName", "comment2ActuallyFirst", "comment", "name2" })
+    public static class JaxbCustomPropertyOrder {
+
+        @XmlElement(name = "theName")
+        String name;
+        @XmlAttribute
+        String name2;
+        @XmlElement
+        String comment;
+        @XmlAttribute(name = "comment2ActuallyFirst")
+        String comment2;
+
+        public String getComment() {
+            return comment;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getName2() {
+            return name2;
+        }
+
+        public String getComment2() {
+            return comment2;
+        }
+    }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator-empty-mapping.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator-empty-mapping.json
@@ -66,6 +66,10 @@
           "pet_type": {
             "type": "string"
           },
+          "dog_name" : {
+            "type": "string",
+            "description": "An annotated method, no field!"
+          },
           "bark": {
             "type": "string"
           }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator-no-mapping-key.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator-no-mapping-key.json
@@ -69,6 +69,10 @@
           "pet_type": {
             "type": "string"
           },
+          "dog_name" : {
+            "type": "string",
+            "description": "An annotated method, no field!"
+          },
           "bark": {
             "type": "string"
           }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator-no-mapping-schema.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator-no-mapping-schema.json
@@ -66,6 +66,10 @@
           "pet_type": {
             "type": "string"
           },
+          "dog_name" : {
+            "type": "string",
+            "description": "An annotated method, no field!"
+          },
           "bark": {
             "type": "string"
           }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator-no-property-name.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator-no-property-name.json
@@ -68,6 +68,10 @@
           "pet_type": {
             "type": "string"
           },
+          "dog_name" : {
+            "type": "string",
+            "description": "An annotated method, no field!"
+          },
           "bark": {
             "type": "string"
           }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/polymorphism.declared-discriminator.json
@@ -69,6 +69,10 @@
           "pet_type": {
             "type": "string"
           },
+          "dog_name" : {
+            "type": "string",
+            "description": "An annotated method, no field!"
+          },
           "bark": {
             "type": "string"
           }


### PR DESCRIPTION
Fixes #149
Works around #87

This may require some additional work/test cases/documentation, but I'm opening this request to get some early feedback and discussion. Note this will at least need to be re-based after #148.

- Property order determined by 3rd party standard or widely-used annotations

@neon-dev - if you don't agree that the use of 3rd party annotations addresses your issue #87, I'll remove from this comment that the issue is fixed by this PR.

*Edit*: updated comment for issue #87 