### PR TITLE
Use toString instead of name on enum constants

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -233,7 +233,7 @@ public class JandexUtil {
         String strVal = value.asString();
         T[] constants = clazz.getEnumConstants();
         for (T t : constants) {
-            if (t.name().equals(strVal)) {
+            if (t.toString().equals(strVal)) {
                 return t;
             }
         }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/util/JandexUtilTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/util/JandexUtilTests.java
@@ -3,27 +3,43 @@ package io.smallrye.openapi.runtime.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
 import javax.ws.rs.Path;
 
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.media.Encoding;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.json.JSONException;
 import org.junit.Test;
 
+import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
 import io.smallrye.openapi.runtime.util.JandexUtil.RefType;
 
 public class JandexUtilTests {
 
     @Test
-    public void testRefValueWithHttpUrl() throws IOException, JSONException {
+    public void testEnumValue() {
+        Index index = IndexScannerTestBase.indexOf(Implementor2.class);
+        ClassInfo clazz = index.getClassByName(DotName.createSimple(Implementor2.class.getName()));
+        AnnotationInstance annotation = clazz.method("getData")
+                .annotation(DotName.createSimple(APIResponse.class.getName()))
+                .value(OpenApiConstants.PROP_CONTENT)
+                .asNestedArray()[0]
+                        .value(OpenApiConstants.PROP_ENCODING)
+                        .asNestedArray()[0];
+        Encoding.Style style = JandexUtil.enumValue(annotation, OpenApiConstants.PROP_STYLE, Encoding.Style.class);
+        assertEquals(Encoding.Style.PIPE_DELIMITED, style);
+    }
+
+    @Test
+    public void testRefValueWithHttpUrl() {
         String ref = "https://www.example.com/openapi";
         AnnotationInstance annotation = AnnotationInstance.create(DotName.createSimple(""),
                 null,
@@ -33,7 +49,7 @@ public class JandexUtilTests {
     }
 
     @Test
-    public void testRefValueWithRelativeUrl() throws IOException, JSONException {
+    public void testRefValueWithRelativeUrl() {
         String ref = "./additional-schemas.json";
         AnnotationInstance annotation = AnnotationInstance.create(DotName.createSimple(""),
                 null,
@@ -43,7 +59,7 @@ public class JandexUtilTests {
     }
 
     @Test
-    public void testRefValueWithValidLinkName() throws IOException, JSONException {
+    public void testRefValueWithValidLinkName() {
         String ref = "L1nk.T0_Something-Useful";
         AnnotationInstance annotation = AnnotationInstance.create(DotName.createSimple(""),
                 null,
@@ -53,7 +69,7 @@ public class JandexUtilTests {
     }
 
     @Test
-    public void testGetJaxRsResourceClasses() throws IOException, JSONException {
+    public void testGetJaxRsResourceClasses() {
         Index index = IndexScannerTestBase.indexOf(I1.class, I2.class, Implementor1.class, Implementor2.class);
         Collection<ClassInfo> resources = JandexUtil.getJaxRsResourceClasses(index);
         assertEquals(3, resources.size());
@@ -81,6 +97,7 @@ public class JandexUtilTests {
     @Path("implementation2")
     static class Implementor2 implements I2 {
         @Override
+        @APIResponse(content = @Content(encoding = @org.eclipse.microprofile.openapi.annotations.media.Encoding(style = "pipeDelimited")))
         public String getData() {
             return null;
         }


### PR DESCRIPTION
Corrects mismatch between enum name and value for Encoding.Style constants. Minor issue of camel case vs underscores.