### PR TITLE
Use RolesAllowed/DeclareRoles values as OAuth2/OIDC security scopes

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
@@ -348,6 +348,15 @@ public final class OpenApiConstants {
                     DOTNAME_JSONB_PROPERTY,
                     DOTNAME_JACKSON_PROPERTY)));
 
+    public static final DotName DOTNAME_DECLARE_ROLES = DotName
+            .createSimple("javax.annotation.security.DeclareRoles");
+    public static final DotName DOTNAME_ROLES_ALLOWED = DotName
+            .createSimple("javax.annotation.security.RolesAllowed");
+    public static final DotName DOTNAME_PERMIT_ALL = DotName
+            .createSimple("javax.annotation.security.PermitAll");
+    public static final DotName DOTNAME_DENY_ALL = DotName
+            .createSimple("javax.annotation.security.DenyAll");
+
     public static final String REF_PREFIX_API_RESPONSE = "#/components/responses/";
     public static final String REF_PREFIX_CALLBACK = "#/components/callbacks/";
     public static final String REF_PREFIX_EXAMPLE = "#/components/examples/";

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -458,6 +458,15 @@ public class OpenApiAnnotationScanner {
         }
     }
 
+    /**
+     * Adds the array of roles as scopes to each of the OAuth2 flows stored previously.
+     * The flows are those declared by the application in components/securitySchemes
+     * using annotations where the scopes were not defined. The description of the scope
+     * will be set to the role name plus the string " role".
+     *
+     * @param roles array of roles from either <code>@DeclareRoles</code> or
+     *        <code>@RolesAllowed</code>
+     */
     void addScopes(String[] roles) {
         if (roles == null || this.currentFlows == null) {
             return;

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -330,6 +330,19 @@ public class TypeUtil {
     }
 
     /**
+     * Convenience method to retrieve the "value" parameter from an annotation bound to the target.
+     * The value will be unwrapped from its containing {@link AnnotationValue}.
+     *
+     * @param <T> the type of the parameter being retrieved
+     * @param target the target object annotated with the annotation named by annotationName
+     * @param annotationName name of the annotation from which to retrieve the value
+     * @return an unwrapped annotation parameter value
+     */
+    public static <T> T getAnnotationValue(AnnotationTarget target, DotName annotationName) {
+        return getAnnotationValue(target, annotationName, OpenApiConstants.PROP_VALUE, null);
+    }
+
+    /**
      * Convenience method to retrieve the named parameter from an annotation bound to the target.
      * The value will be unwrapped from its containing {@link AnnotationValue}.
      *

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/RolesAllowedScopeScanTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/RolesAllowedScopeScanTests.java
@@ -1,0 +1,214 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.security.DeclareRoles;
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.Components;
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.security.OAuthFlow;
+import org.eclipse.microprofile.openapi.annotations.security.OAuthFlows;
+import org.eclipse.microprofile.openapi.annotations.security.OAuthScope;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexView;
+import org.junit.Test;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+
+public class RolesAllowedScopeScanTests extends IndexScannerTestBase {
+
+    @Test
+    public void testClassRolesAllowedGeneratedScheme() throws IOException {
+        Index index = indexOf(RolesAllowedApp.class, RolesAllowedResource1.class);
+        OpenApiConfig config = emptyConfig();
+        IndexView filtered = new FilteredIndexView(index, config);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, filtered);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        SecurityRequirement requirement = result.getPaths().getPathItem("/v1/secured").getGET().getSecurity().get(0);
+        assertNotNull(requirement);
+        assertEquals(1, requirement.getScheme("rolesScheme").size());
+        assertEquals("admin", requirement.getScheme("rolesScheme").get(0));
+        assertEquals("admin",
+                result.getComponents()
+                        .getSecuritySchemes()
+                        .get("rolesScheme")
+                        .getFlows()
+                        .getClientCredentials()
+                        .getScopes()
+                        .getScopes()
+                        .keySet()
+                        .iterator().next());
+    }
+
+    @Test
+    public void testPermitAllWithoutGeneratedScheme() throws IOException {
+        Index index = indexOf(RolesAllowedApp.class, RolesAllowedResource1.class);
+        OpenApiConfig config = emptyConfig();
+        IndexView filtered = new FilteredIndexView(index, config);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, filtered);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertNull(result.getPaths().getPathItem("/v1/open").getGET().getSecurity());
+    }
+
+    @Test
+    public void testGeneratedSchemeEmptyRoles() throws IOException {
+        Index index = indexOf(RolesAllowedApp.class, RolesAllowedResource1.class);
+        OpenApiConfig config = emptyConfig();
+        IndexView filtered = new FilteredIndexView(index, config);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, filtered);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        SecurityRequirement requirement = result.getPaths().getPathItem("/v1/locked").getGET().getSecurity().get(0);
+        assertNotNull(requirement);
+        assertEquals(0, requirement.getScheme("rolesScheme").size());
+    }
+
+    @Test
+    public void testMethodRolesAllowedGeneratedScheme() throws IOException {
+        Index index = indexOf(RolesAllowedApp.class, RolesAllowedResource2.class);
+        OpenApiConfig config = emptyConfig();
+        IndexView filtered = new FilteredIndexView(index, config);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, filtered);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        SecurityRequirement requirement = result.getPaths().getPathItem("/v2/secured").getGET().getSecurity().get(0);
+        assertNotNull(requirement);
+        assertEquals(2, requirement.getScheme("rolesScheme").size());
+        assertEquals("admin", requirement.getScheme("rolesScheme").get(0));
+        assertEquals("users", requirement.getScheme("rolesScheme").get(1));
+        assertArrayEquals(new String[] { "admin", "users" },
+                result.getComponents()
+                        .getSecuritySchemes()
+                        .get("rolesScheme")
+                        .getFlows()
+                        .getClientCredentials()
+                        .getScopes()
+                        .getScopes()
+                        .keySet()
+                        .toArray());
+    }
+
+    @Test
+    public void testNoEligibleScheme() throws IOException {
+        Index index = indexOf(RolesNotAllowedApp.class, RolesAllowedResource1.class);
+        OpenApiConfig config = emptyConfig();
+        IndexView filtered = new FilteredIndexView(index, config);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, filtered);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        List<SecurityRequirement> requirements = result.getPaths().getPathItem("/v1/locked").getGET().getSecurity();
+        assertNull(requirements);
+    }
+
+    @Test
+    public void testDeclaredRolesMethodRolesAllowedGeneratedScheme() throws IOException {
+        Index index = indexOf(RolesAllowedApp.class, RolesDeclaredResource.class);
+        OpenApiConfig config = emptyConfig();
+        IndexView filtered = new FilteredIndexView(index, config);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, filtered);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        SecurityRequirement requirement = result.getPaths().getPathItem("/v1/secured").getGET().getSecurity().get(0);
+        assertNotNull(requirement);
+        assertEquals(1, requirement.getScheme("rolesScheme").size());
+        assertEquals("admin", requirement.getScheme("rolesScheme").get(0));
+        assertArrayEquals(new String[] { "admin", "users" },
+                result.getComponents()
+                        .getSecuritySchemes()
+                        .get("rolesScheme")
+                        .getFlows()
+                        .getClientCredentials()
+                        .getScopes()
+                        .getScopes()
+                        .keySet()
+                        .toArray());
+    }
+
+    @OpenAPIDefinition(info = @Info(title = "RolesAllowed App", version = "1.0"), components = @Components(securitySchemes = {
+            @SecurityScheme(securitySchemeName = "rolesScheme", type = SecuritySchemeType.OAUTH2, flows = @OAuthFlows(clientCredentials = @OAuthFlow(), implicit = @OAuthFlow(scopes = {
+                    @OAuthScope(name = "scope1", description = "Provided by OAI annotation") })))
+    }))
+    static class RolesAllowedApp extends Application {
+    }
+
+    @OpenAPIDefinition(info = @Info(title = "RolesNotAllowed App", version = "1.0"), components = @Components(securitySchemes = {
+            @SecurityScheme(securitySchemeName = "noTypeScheme", flows = @OAuthFlows(clientCredentials = @OAuthFlow(), implicit = @OAuthFlow(scopes = {
+                    @OAuthScope(name = "scope1", description = "Provided by OAI annotation") })))
+    }))
+    static class RolesNotAllowedApp extends Application {
+    }
+
+    @Path("/v1")
+    @RolesAllowed("admin")
+    @SuppressWarnings("unused")
+    static class RolesAllowedResource1 {
+        @GET
+        @Path("secured")
+        @Produces("application/json")
+        public Response getSecuredData(int id) {
+            return null;
+        }
+
+        @GET
+        @Path("open")
+        @Produces("application/json")
+        @PermitAll
+        public Response getOpenData(int id) {
+            return null;
+        }
+
+        @GET
+        @Path("locked")
+        @Produces("application/json")
+        @DenyAll
+        public Response getLockedData(int id) {
+            return null;
+        }
+    }
+
+    @Path("/v2")
+    @SuppressWarnings("unused")
+    static class RolesAllowedResource2 {
+        @GET
+        @Path("secured")
+        @Produces("application/json")
+        @RolesAllowed({ "admin", "users" })
+        public Response getSecuredData(int id) {
+            return null;
+        }
+    }
+
+    @Path("/v1")
+    @SuppressWarnings("unused")
+    @DeclareRoles({ "admin", "users" })
+    static class RolesDeclaredResource {
+        @GET
+        @Path("secured")
+        @Produces("application/json")
+        @RolesAllowed({ "admin" })
+        public Response getSecuredData(int id) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #15 

Differences from the discussion in #15 -
1. Presence of a `@PermitAll` annotation on a method will prevent a resource's `@RolesAllowed` from applying to an `Operation`.
2. Presence of a `@DenyAll` annotation on a method will generate an empty scope array on an `Operation`.
