### PR TITLE
Stop trying to lookup primitive array types in @Ignore resolver

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
@@ -258,6 +258,8 @@ public class IgnoreResolver {
             // Primitive and non-indexed types will result in a null
             if (classType.kind() == Type.Kind.PRIMITIVE ||
                     classType.kind() == Type.Kind.VOID ||
+                    (classType.kind() == Type.Kind.ARRAY && classType.asArrayType().component().kind() == Type.Kind.PRIMITIVE)
+                    ||
                     !index.containsClass(classType)) {
                 return false;
             }


### PR DESCRIPTION
This should fix the following issue:

https://github.com/quarkusio/quarkus/issues/3537

Signed-off-by: Eric Wittmann <eric.wittmann@gmail.com>