### PR TITLE
Removed Apache Commons-related code and thus shrank dependencies

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -67,10 +67,6 @@
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-        </dependency>
 
         <!-- Provided Dependencies -->
         <dependency>

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -33,7 +33,6 @@ import java.util.TreeSet;
 
 import javax.ws.rs.core.Application;
 
-import org.apache.commons.beanutils.PropertyUtils;
 import org.eclipse.microprofile.openapi.annotations.enums.Explode;
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
@@ -1362,7 +1361,7 @@ public class OpenApiAnnotationScanner {
             }
             try {
                 PropertyDescriptor descriptor = new PropertyDescriptor(method.toUpperCase(), pathItem.getClass());
-                Method mutator = PropertyUtils.getWriteMethod(descriptor);
+                Method mutator = descriptor.getWriteMethod();
                 mutator.invoke(pathItem, operation);
             } catch (Exception e) {
                 LOG.error("Error reading a CallbackOperation annotation.", e);

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,6 @@
         <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>2.9.9.2</version.com.fasterxml.jackson.databind>
         <version.com.fasterxml.jackson.dataformat>2.9.9</version.com.fasterxml.jackson.dataformat>
-        <version.commons-beanutils>1.9.4</version.commons-beanutils>
-        <version.commons-logging>1.2</version.commons-logging>
         <version.eclipse.microprofile.config>1.3</version.eclipse.microprofile.config>
         <version.eclipse.microprofile.openapi>1.1.2</version.eclipse.microprofile.openapi>
         <version.io.smallrye.smallrye-config>1.3.9</version.io.smallrye.smallrye-config>
@@ -138,11 +136,6 @@
                 <version>${version.org.jboss.shrinkwrap}</version>
             </dependency>
             <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>${version.commons-beanutils}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${version.org.hamcrest}</version>
@@ -168,12 +161,6 @@
                 <groupId>org.skyscreamer</groupId>
                 <artifactId>jsonassert</artifactId>
                 <version>${version.org.skyscreamer}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>${version.commons-logging}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -59,11 +59,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Among other things this gets rid of commons logging.  Seemed useful to do so.

Signed-off-by: Laird Nelson <laird.nelson@oracle.com>