### PR TITLE
Remove jackson-annotations runtime dependency, bump Jackson to 2.9.10

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -29,6 +29,16 @@
 
     <name>SmallRye: MicroProfile OpenAPI Implementation</name>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- MP OpenAPI Spec -->
         <dependency>

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
@@ -338,6 +338,8 @@ public final class OpenApiConstants {
             .createSimple("com.fasterxml.jackson.annotation.JsonProperty");
     public static final DotName DOTNAME_JACKSON_IGNORE = DotName
             .createSimple("com.fasterxml.jackson.annotation.JsonIgnore");
+    public static final DotName DOTNAME_JACKSON_IGNORE_TYPE = DotName
+            .createSimple("com.fasterxml.jackson.annotation.JsonIgnoreType");
     public static final DotName DOTNAME_JACKSON_IGNORE_PROPERTIES = DotName
             .createSimple("com.fasterxml.jackson.annotation.JsonIgnoreProperties");
     public static final DotName DOTNAME_JACKSON_PROPERTY_ORDER = DotName

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
@@ -35,8 +35,6 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreType;
-
 import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.runtime.scanner.dataobject.DataObjectDeque.PathEntry;
 import io.smallrye.openapi.runtime.util.JandexUtil;
@@ -284,7 +282,7 @@ public class IgnoreResolver {
 
         @Override
         public DotName getName() {
-            return DotName.createSimple(JsonIgnoreType.class.getName());
+            return OpenApiConstants.DOTNAME_JACKSON_IGNORE_TYPE;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
 
     <properties>
         <version.buildhelper.plugin>3.0.0</version.buildhelper.plugin>
-        <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.databind>2.9.9.2</version.com.fasterxml.jackson.databind>
-        <version.com.fasterxml.jackson.dataformat>2.9.9</version.com.fasterxml.jackson.dataformat>
+        <version.com.fasterxml.jackson>2.9.10</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>2.9.10</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.dataformat>2.9.10</version.com.fasterxml.jackson.dataformat>
         <version.eclipse.microprofile.config>1.3</version.eclipse.microprofile.config>
         <version.eclipse.microprofile.openapi>1.1.2</version.eclipse.microprofile.openapi>
         <version.io.smallrye.smallrye-config>1.3.9</version.io.smallrye.smallrye-config>


### PR DESCRIPTION
This change will eliminate the run time dependency on jackson-annotations by using a `DotName` created with the class name in the constants. 

* Use jackson-annotations only in tests
* Add new `DotName` for implementation
* Bump Jackson versions to address security issue