### PR TITLE
Ensure java.lang not scanned, add jackson-annotations, enum scan fix

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -29,16 +29,6 @@
 
     <name>SmallRye: MicroProfile OpenAPI Implementation</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- MP OpenAPI Spec -->
         <dependency>

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -127,6 +127,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
         if (scanExcludePackages == null) {
             String packages = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_PACKAGES, String.class).orElse(null);
             scanExcludePackages = asCsvSet(packages);
+            scanExcludePackages.addAll(OpenApiConstants.NEVER_SCAN_PACKAGES);
         }
         return scanExcludePackages;
     }
@@ -139,6 +140,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
         if (scanExcludeClasses == null) {
             String classes = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_CLASSES, String.class).orElse(null);
             scanExcludeClasses = asCsvSet(classes);
+            scanExcludeClasses.addAll(OpenApiConstants.NEVER_SCAN_CLASSES);
         }
         return scanExcludeClasses;
     }

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConstants.java
@@ -80,6 +80,18 @@ public final class OpenApiConstants {
     public static final String SCHEMA_REFERENCES_ENABLE = "mp.openapi.extensions.schema-references.enable";
     public static final String CUSTOM_SCHEMA_REGISTRY_CLASS = "mp.openapi.extensions.custom-schema-registry.class";
 
+    /**
+     * Set of classes which should never be scanned, regardless of user configuration.
+     */
+    public static final Set<String> NEVER_SCAN_CLASSES = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList()));
+
+    /**
+     * Set of packages which should never be scanned, regardless of user configuration.
+     */
+    public static final Set<String> NEVER_SCAN_PACKAGES = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList("java.lang")));
+
     public static final String CLASS_SUFFIX = ".class";
     public static final String JAR_SUFFIX = ".jar";
     public static final String WEB_ARCHIVE_CLASS_PREFIX = "/WEB-INF/classes/";

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -164,7 +164,13 @@ public class OpenApiAnnotationScanner {
      */
     public OpenApiAnnotationScanner(OpenApiConfig config, IndexView index, List<AnnotationScannerExtension> extensions) {
         this.config = config;
-        this.index = index;
+
+        if (index instanceof FilteredIndexView) {
+            this.index = index;
+        } else {
+            this.index = new FilteredIndexView(index, config);
+        }
+
         this.extensions = extensions;
     }
 

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -191,11 +191,15 @@ public class OpenApiDataObjectScanner {
         LOG.debugv("Starting processing with root: {0}", rootClassType.name());
 
         // If top level item is simple
-        if (isTerminalType(rootClassType)) {
+        if (TypeUtil.isTerminalType(rootClassType)) {
             SchemaImpl simpleSchema = new SchemaImpl();
             simpleSchema.setType(rootClassTypeFormat.getSchemaType());
             simpleSchema.setFormat(rootClassTypeFormat.getFormat().format());
             return simpleSchema;
+        }
+
+        if (isA(rootClassType, ENUM_TYPE) && index.containsClass(rootClassType)) {
+            return SchemaFactory.enumToSchema(index, rootClassType);
         }
 
         // If top level item is not indexed
@@ -274,24 +278,6 @@ public class OpenApiDataObjectScanner {
 
     private boolean isA(Type testSubject, Type test) {
         return TypeUtil.isA(index, testSubject, test);
-    }
-
-    private boolean isTerminalType(Type type) {
-        if (type.kind() == Type.Kind.TYPE_VARIABLE ||
-                type.kind() == Type.Kind.WILDCARD_TYPE ||
-                type.kind() == Type.Kind.ARRAY) {
-            return false;
-        }
-
-        if (type.kind() == Type.Kind.PRIMITIVE ||
-                type.kind() == Type.Kind.VOID) {
-            return true;
-        }
-
-        TypeUtil.TypeWithFormat tf = TypeUtil.getTypeFormat(type);
-        // If is known type.
-        return tf.getSchemaType() != Schema.SchemaType.OBJECT &&
-                tf.getSchemaType() != Schema.SchemaType.ARRAY;
     }
 
     // Is Map, Collection, etc.

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -45,6 +45,7 @@ import org.jboss.jandex.TypeVariable;
 import org.jboss.logging.Logger;
 
 import io.smallrye.openapi.api.OpenApiConstants;
+import io.smallrye.openapi.runtime.util.JandexUtil;
 import io.smallrye.openapi.runtime.util.TypeUtil;
 
 /**
@@ -329,7 +330,7 @@ public class TypeResolver {
     }
 
     public static Map<String, TypeResolver> getAllFields(AugmentedIndexView index, Type leaf, ClassInfo leafKlazz) {
-        Map<ClassInfo, Type> chain = inheritanceChain(index, leafKlazz, leaf);
+        Map<ClassInfo, Type> chain = JandexUtil.inheritanceChain(index, leafKlazz, leaf);
         Map<String, TypeResolver> properties = new LinkedHashMap<>();
         Deque<Map<String, Type>> stack = new ArrayDeque<>();
 
@@ -370,28 +371,6 @@ public class TypeResolver {
 
     private static boolean acceptField(FieldInfo field) {
         return !Modifier.isStatic(field.flags());
-    }
-
-    /**
-     * Builds an insertion-order map of a class's inheritance chain, starting
-     * with the klazz argument.
-     *
-     * @param index index for superclass retrieval
-     * @param klazz the class to retrieve inheritance
-     * @param type type of the klazz
-     * @return map of a class's inheritance chain/ancestry
-     */
-    private static Map<ClassInfo, Type> inheritanceChain(AugmentedIndexView index,
-            ClassInfo klazz,
-            Type type) {
-
-        Map<ClassInfo, Type> chain = new LinkedHashMap<>();
-
-        do {
-            chain.put(klazz, type);
-        } while ((type = klazz.superClassType()) != null && (klazz = index.getClass(type)) != null);
-
-        return chain;
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
+import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -201,6 +202,24 @@ public class TypeUtil {
             superKlazzType = superKlazz.superClassType();
         }
         return false;
+    }
+
+    public static boolean isTerminalType(Type type) {
+        if (type.kind() == Type.Kind.TYPE_VARIABLE ||
+                type.kind() == Type.Kind.WILDCARD_TYPE ||
+                type.kind() == Type.Kind.ARRAY) {
+            return false;
+        }
+
+        if (type.kind() == Type.Kind.PRIMITIVE ||
+                type.kind() == Type.Kind.VOID) {
+            return true;
+        }
+
+        TypeUtil.TypeWithFormat tf = TypeUtil.getTypeFormat(type);
+        // If is known type.
+        return tf.getSchemaType() != Schema.SchemaType.OBJECT &&
+                tf.getSchemaType() != Schema.SchemaType.ARRAY;
     }
 
     public static DotName getName(Type type) {

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -161,6 +161,13 @@ public class ParameterScanTests extends IndexScannerTestBase {
                 Widget.class);
     }
 
+    @Test
+    public void testEnumQueryParam() throws IOException, JSONException {
+        test("params.enum-form-param.json",
+                EnumQueryParamTestResource.class,
+                EnumQueryParamTestResource.TestEnum.class);
+    }
+
     /***************** Test models and resources below. ***********************/
 
     public static class Widget {
@@ -440,6 +447,23 @@ public class ParameterScanTests extends IndexScannerTestBase {
         public CompletionStage<Widget> upd(@MultipartForm Bean form,
                 @FormParam("f3") @DefaultValue("3") int formField3,
                 @org.jboss.resteasy.annotations.jaxrs.FormParam @NotNull String formField4) {
+            return null;
+        }
+    }
+
+    @Path("/enum/formparam")
+    static class EnumQueryParamTestResource {
+        static enum TestEnum {
+            VAL1,
+            VAL2,
+            VAL3;
+        }
+
+        @SuppressWarnings("unused")
+        @POST
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        @Produces(MediaType.TEXT_PLAIN)
+        public TestEnum postData(@QueryParam("val") TestEnum value) {
             return null;
         }
     }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.enum-form-param.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.enum-form-param.json
@@ -1,0 +1,38 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/enum/formparam": {
+      "post": {
+        "parameters": [
+          {
+          "name": "val",
+          "in": "query",
+          "schema": {
+            "$ref": "#/components/schemas/TestEnum"
+          }
+        }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestEnum"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TestEnum": {
+        "type": "string",
+        "enum": [ "VAL1", "VAL2", "VAL3" ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #185 - always make top-level index a ```FilteredIndexView``` and always exclude ```java.lang``` from scanning
Fixes #186 - handle enum types in ```OpenApiDataObjectScanner```, move some common code into utility classes
Fixes #187 - remove ```dependencyManagement``` for jackson-annotations

Also refactored ```JandexUtil#getJaxRsResourceClasses``` to more easily remove duplicates with a ```Stream```. The Quarkus Jandex index tree contains duplicate entries which results in resources being scanned multiple times.
