### PR TITLE
Reduce the occurrence of reflection for many known cases

### DIFF
--- a/implementation/src/test/java/io/smallrye/openapi/runtime/util/TypeUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/util/TypeUtilTest.java
@@ -1,0 +1,161 @@
+package io.smallrye.openapi.runtime.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Type;
+import org.junit.Test;
+
+import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
+import io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner;
+
+public class TypeUtilTest extends IndexScannerTestBase {
+
+    private static final Type TYPE_COLLECTION = OpenApiDataObjectScanner.COLLECTION_TYPE;
+    private static final Type TYPE_ENUM = OpenApiDataObjectScanner.ENUM_TYPE;
+    private static final Type TYPE_MAP = OpenApiDataObjectScanner.MAP_TYPE;
+
+    @Test
+    public void testIsA_BothIndexed() {
+        final Class<?> subjectClass = ArrayCollection.class;
+        Index index = indexOf(subjectClass, Collection.class);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsA_SubjectIndexed() {
+        final Class<?> subjectClass = ArrayCollection.class;
+        Index index = indexOf(subjectClass);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsA_ObjectIndexed() {
+        final Class<?> subjectClass = ArrayCollection.class;
+        Index index = indexOf(Collection.class);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsA_IndexedSubjectImplementsObject() {
+        final Class<?> subjectClass = CustomCollection.class;
+        Index index = indexOf(subjectClass);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsA_IndexedSubjectImplementsOther() {
+        final Class<?> subjectClass = CustomMap.class;
+        Index index = indexOf(subjectClass);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsA_IndexedSubjectExtendsUnindexedCollection() {
+        final Class<?> subjectClass = ChildCollection.class;
+        Index index = indexOf(subjectClass);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsA_IndexedSubjectUnrelatedToObject() {
+        final Class<?> subjectClass = UnrelatedType.class;
+        Index index = indexOf(subjectClass);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsA_UnindexedPrimitiveSubjectUnrelatedToObject() {
+        final Class<?> subjectClass = int.class;
+        Index index = indexOf();
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.PRIMITIVE);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsA_UnindexedPrimitiveWrapperSubjectUnrelatedToObject() {
+        final Class<?> subjectClass = Integer.class;
+        final DotName subjectName = DotName.createSimple(subjectClass.getName());
+        Index index = indexOf();
+        Type testSubject = Type.create(subjectName, Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsA_SubjectIsJavaLangObject() {
+        final Class<?> subjectClass = Object.class;
+        Index index = indexOf(subjectClass);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_COLLECTION);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsA_SubjectSameAsObject() {
+        final Class<?> subjectClass = MapContainer.class;
+        final DotName subjectName = DotName.createSimple(subjectClass.getName());
+        Index index = indexOf(subjectClass);
+        ClassInfo subjectInfo = index.getClassByName(subjectName);
+        Type testSubject = subjectInfo.field("theMap").type();
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_MAP);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsA_SubjectSuperSameAsObject() {
+        final Class<?> subjectClass = TestEnum.class;
+        Index index = indexOf(subjectClass);
+        Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
+        boolean result = TypeUtil.isA(index, testSubject, TYPE_ENUM);
+        assertTrue(result);
+    }
+
+    static class ArrayCollection extends ArrayList<String> {
+        private static final long serialVersionUID = 1L;
+    }
+
+    static abstract class CustomCollection implements Collection<String> {
+    }
+
+    static abstract class CustomMap implements Map<String, Object> {
+    }
+
+    static abstract class ChildCollection extends CustomCollection {
+    }
+
+    static class UnrelatedType {
+
+    }
+
+    static class MapContainer {
+        @SuppressWarnings("unused")
+        private Map<String, String> theMap;
+    }
+
+    static enum TestEnum {
+        VALUE1, VALUE2, VALUE3;
+    }
+}


### PR DESCRIPTION
Relates to #191 and also the fix for quarkusio/quarkus#2961.

The idea with these changes is to mostly eliminate the fallback to reflection during the "is a" tests used by class/annotation scanning by including a small internal index of JDK classes most commonly used. Ideally, this would eliminate the need for any downstream work-around like in [the fix for quarkus 2961](https://github.com/quarkusio/quarkus/commit/cc654c6f0fef16f0f37554ad4d22c7a826ced210#diff-25a0f7545a16a5e105652956c74d3736).