### PR TITLE
Support additional default schema properties in TypeUtil, SchemaFactory

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -224,7 +224,7 @@ public class SchemaRegistry {
          * property name rather then a schema name.
          */
         AnnotationTarget targetSchema = index.getClassByName(key.type.name());
-        AnnotationInstance schemaAnnotation = getSchemaAnnotation(targetSchema);
+        AnnotationInstance schemaAnnotation = targetSchema != null ? getSchemaAnnotation(targetSchema) : null;
         String schemaName = null;
 
         if (schemaAnnotation != null) {
@@ -294,7 +294,7 @@ public class SchemaRegistry {
      */
     static class TypeKey {
         private final Type type;
-        private int hash = 0;
+        private int hashCode = 0;
 
         TypeKey(Type type) {
             this.type = type;
@@ -410,7 +410,7 @@ public class SchemaRegistry {
          */
         @Override
         public int hashCode() {
-            int hash = this.hash;
+            int hash = this.hashCode;
 
             if (hash != 0) {
                 return hash;
@@ -436,7 +436,8 @@ public class SchemaRegistry {
                 hash = 31 * hash + Objects.hash(wildType.extendsBound(), wildType.superBound());
             }
 
-            return this.hash = hash;
+            this.hashCode = hash;
+            return hash;
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -17,7 +17,6 @@ package io.smallrye.openapi.runtime.scanner.dataobject;
 
 import static io.smallrye.openapi.runtime.util.TypeUtil.getSchemaAnnotation;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -165,14 +164,10 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         fieldSchema = typeProcessor.getSchema();
 
         // TypeFormat pair contains mappings for Java <-> OAS types and formats.
-        TypeUtil.TypeWithFormat typeFormat = TypeUtil.getTypeFormat(postProcessedField);
-
         // Provide inferred type and format if relevant.
-        Map<String, Object> overrides = new HashMap<>();
-        overrides.put(OpenApiConstants.PROP_TYPE, typeFormat.getSchemaType());
-        overrides.put(OpenApiConstants.PROP_FORMAT, typeFormat.getFormat().format());
+        Map<String, Object> defaults = TypeUtil.getTypeAttributes(postProcessedField);
         // readSchema *may* replace the existing schema, so we must assign.
-        this.fieldSchema = SchemaFactory.readSchema(index, fieldSchema, annotation, overrides);
+        this.fieldSchema = SchemaFactory.readSchema(index, fieldSchema, annotation, defaults);
     }
 
     private void readUnannotatedField() {
@@ -184,12 +179,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         Type postProcessedField = typeProcessor.processType();
         fieldSchema = typeProcessor.getSchema();
 
-        TypeUtil.TypeWithFormat typeFormat = TypeUtil.getTypeFormat(postProcessedField);
-        fieldSchema.setType(typeFormat.getSchemaType());
-
-        if (typeFormat.getFormat().hasFormat()) {
-            fieldSchema.setFormat(typeFormat.getFormat().format());
-        }
+        TypeUtil.applyTypeAttributes(postProcessedField, fieldSchema);
     }
 
     private boolean shouldInferUnannotatedFields() {

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
@@ -94,9 +94,7 @@ public class TypeProcessor {
             schema.type(Schema.SchemaType.ARRAY);
 
             // Only use component (excludes the special name formatting for arrays).
-            TypeUtil.TypeWithFormat typeFormat = TypeUtil.getTypeFormat(arrayType.component());
-            arrSchema.setType(typeFormat.getSchemaType());
-            arrSchema.setFormat(typeFormat.getFormat().format());
+            TypeUtil.applyTypeAttributes(arrayType.component(), arrSchema);
 
             // If it's not a terminal type, then push for later inspection.
             if (!isTerminalType(arrayType.component()) && index.containsClass(type)) {
@@ -162,9 +160,7 @@ public class TypeProcessor {
             Type arg = pType.arguments().get(0);
 
             if (isTerminalType(arg)) {
-                TypeUtil.TypeWithFormat terminalType = TypeUtil.getTypeFormat(arg);
-                arraySchema.type(terminalType.getSchemaType());
-                arraySchema.format(terminalType.getFormat().format());
+                TypeUtil.applyTypeAttributes(arg, arraySchema);
             } else {
                 arraySchema = resolveParameterizedType(arg, arraySchema);
             }
@@ -180,9 +176,7 @@ public class TypeProcessor {
                 Type valueType = pType.arguments().get(1);
                 Schema propsSchema = new SchemaImpl();
                 if (isTerminalType(valueType)) {
-                    TypeUtil.TypeWithFormat tf = TypeUtil.getTypeFormat(valueType);
-                    propsSchema.setType(tf.getSchemaType());
-                    propsSchema.setFormat(tf.getFormat().format());
+                    TypeUtil.applyTypeAttributes(valueType, propsSchema);
                 } else {
                     propsSchema = resolveParameterizedType(valueType, propsSchema);
                 }
@@ -229,9 +223,7 @@ public class TypeProcessor {
         LOG.debugv("Resolved type {0} -> {1}", fieldType, resolvedType);
         if (isTerminalType(resolvedType) || !index.containsClass(resolvedType)) {
             LOG.debugv("Is a terminal type {0}", resolvedType);
-            TypeUtil.TypeWithFormat replacement = TypeUtil.getTypeFormat(resolvedType);
-            schema.setType(replacement.getSchemaType());
-            schema.setFormat(replacement.getFormat().format());
+            TypeUtil.applyTypeAttributes(resolvedType, schema);
         } else {
             LOG.debugv("Attempting to do TYPE_VARIABLE substitution: {0} -> {1}", fieldType, resolvedType);
             if (index.containsClass(resolvedType)) {

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -205,7 +205,7 @@ public class JandexUtil {
      * @param propertyName String
      * @return Boolean value
      */
-    public static Boolean booleanValueWithDefault(AnnotationInstance annotation, String propertyName) {
+    public static boolean booleanValueWithDefault(AnnotationInstance annotation, String propertyName) {
         AnnotationValue value = annotation.value(propertyName);
         return value != null && value.asBoolean();
     }
@@ -277,13 +277,25 @@ public class JandexUtil {
      * @param <T> Type parameter
      * @return Value of property
      */
-    @SuppressWarnings("rawtypes")
-    public static <T extends Enum> T enumValue(AnnotationInstance annotation, String propertyName, Class<T> clazz) {
+    public static <T extends Enum<?>> T enumValue(AnnotationInstance annotation, String propertyName, Class<T> clazz) {
         AnnotationValue value = annotation.value(propertyName);
         if (value == null) {
             return null;
         }
-        String strVal = value.asString();
+        return enumValue(value.asString(), clazz);
+    }
+
+    /**
+     * Converts a string value to the given enum type. If the string does not match
+     * one of the the enum's values name (case-insensitive) or toString value, null
+     * will be returned.
+     * 
+     * @param strVal String
+     * @param clazz Class type of the Enum
+     * @param <T> Type parameter
+     * @return Value of property
+     */
+    public static <T extends Enum<?>> T enumValue(String strVal, Class<T> clazz) {
         T[] constants = clazz.getEnumConstants();
         for (T t : constants) {
             if (t.toString().equals(strVal)) {

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -16,6 +16,7 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
 import javax.validation.constraints.Max;
@@ -59,7 +60,7 @@ public class ParameterScanTests extends IndexScannerTestBase {
 
     private static void test(String expectedResource, Class<?>... classes) throws IOException, JSONException {
         Index index = indexOf(classes);
-        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), index);
         OpenAPI result = scanner.scan();
         printToConsole(result);
         assertJsonEquals(expectedResource, result);
@@ -166,6 +167,13 @@ public class ParameterScanTests extends IndexScannerTestBase {
         test("params.enum-form-param.json",
                 EnumQueryParamTestResource.class,
                 EnumQueryParamTestResource.TestEnum.class);
+    }
+
+    @Test
+    public void testUUIDQueryParam() throws IOException, JSONException {
+        test("params.uuid-params-responses.json",
+                UUIDQueryParamTestResource.class,
+                UUIDQueryParamTestResource.WrappedUUID.class);
     }
 
     /***************** Test models and resources below. ***********************/
@@ -465,6 +473,29 @@ public class ParameterScanTests extends IndexScannerTestBase {
         @Produces(MediaType.TEXT_PLAIN)
         public TestEnum postData(@QueryParam("val") TestEnum value) {
             return null;
+        }
+    }
+
+    @Path("/uuid")
+    static class UUIDQueryParamTestResource {
+        static class WrappedUUID {
+            @Schema(format = "uuid", description = "test")
+            UUID theUUID;
+        }
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public WrappedUUID[] echoWrappedUUID(@QueryParam("val") UUID value) {
+            WrappedUUID result = new WrappedUUID();
+            result.theUUID = value;
+            return new WrappedUUID[] { result };
+        }
+
+        @POST
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.TEXT_PLAIN)
+        public UUID echoPostedUUID(UUID value) {
+            return value;
         }
     }
 }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/util/TypeUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/util/TypeUtilTest.java
@@ -156,6 +156,8 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     static enum TestEnum {
-        VALUE1, VALUE2, VALUE3;
+        VALUE1,
+        VALUE2,
+        VALUE3;
     }
 }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.uuid-params-responses.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.uuid-params-responses.json
@@ -1,0 +1,73 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/uuid": {
+      "get": {
+        "parameters": [
+          {
+            "name": "val",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WrappedUUID"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/UUID"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UUID"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "WrappedUUID": {
+        "type": "object",
+        "properties": {
+          "theUUID": {
+            "$ref": "#/components/schemas/UUID"
+          }
+        }
+      },
+      "UUID": {
+        "type": "string",
+        "format": "uuid",
+        "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
@@ -459,7 +459,8 @@
             "$ref": "#/components/schemas/KustomPairKustomPairInteger"
           },
           "password": {
-            "type": "string"
+            "type": "string",
+            "format": "password"
           },
           "primitiveFoo": {
             "format": "int32",


### PR DESCRIPTION
Fixes #193 

* Add `java.util.UUID` and `java.net.URI` to the `TYPE_MAP` in `TypeUtil` and allow for UUID to be a registered type, referenced with $ref if used in multiple locations. 
* Reverse how defaults and `@Schema` are read for annotated fields. Previously, the defaults from `TypeUtil` were preferred. The changes in `SchemaFactory` allow for the user-specified `@Schema` on a field to be used.
* Several non-functional updates to get rid of Sonar code smells