### PR TITLE
Sort and merge tags of same name

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/io/OpenApiSerializer.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/io/OpenApiSerializer.java
@@ -486,7 +486,7 @@ public class OpenApiSerializer {
     }
 
     /**
-     * Writes the {@link Schema} model to the give node.
+     * Writes the {@link Schema} model to the given node.
      * 
      * @param node
      * @param model

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/ParameterProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/ParameterProcessor.java
@@ -1249,7 +1249,7 @@ public class ParameterProcessor {
     }
 
     /**
-     * Determines if the give method is a JAX-RS sub-resource locator method
+     * Determines if the given method is a JAX-RS sub-resource locator method
      * annotated by {@code @Path} but NOT annotated with one of the HTTP method
      * annotations.
      *
@@ -1265,7 +1265,7 @@ public class ParameterProcessor {
     }
 
     /**
-     * Determines if the give method is a JAX-RS resource method annotated by one
+     * Determines if the given method is a JAX-RS resource method annotated by one
      * of the HTTP method annotations.
      *
      * @param method method to check

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -103,7 +103,7 @@ public class SchemaRegistry {
      * @param schema
      *        {@link Schema} to add to the registry
      * @return the same schema if not eligible for registration, or a reference
-     *         to the schema registered for the give Type
+     *         to the schema registered for the given Type
      */
     public static Schema checkRegistration(Type type, TypeResolver resolver, Schema schema) {
         Type resolvedType = resolver.getResolvedType(type);

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -408,52 +408,33 @@ public class JandexUtil {
      * look for both and return a list of all found. Both the single and wrapper annotation names
      * must be provided.
      * 
-     * @param method MethodInfo
+     * @param target the annotated target (e.g. ClassInfo, MethodInfo)
      * @param singleAnnotationName DotName
      * @param repeatableAnnotationName DotName
      * @return List of AnnotationInstance's
      */
-    public static List<AnnotationInstance> getRepeatableAnnotation(MethodInfo method,
-            DotName singleAnnotationName, DotName repeatableAnnotationName) {
-        List<AnnotationInstance> annotations = method.annotations()
-                .stream().filter(annotation -> annotation.name().equals(singleAnnotationName))
-                .collect(toList());
-        if (repeatableAnnotationName != null && method.hasAnnotation(repeatableAnnotationName)) {
-            AnnotationInstance annotation = method.annotation(repeatableAnnotationName);
-            AnnotationValue annotationValue = annotation.value();
-            if (annotationValue != null) {
-                AnnotationInstance[] nestedArray = annotationValue.asNestedArray();
-                annotations.addAll(Arrays.asList(nestedArray));
-            }
-        }
-        return annotations;
-    }
+    public static List<AnnotationInstance> getRepeatableAnnotation(AnnotationTarget target,
+            DotName singleAnnotationName,
+            DotName repeatableAnnotationName) {
 
-    /**
-     * Many OAI annotations can either be found singly or as a wrapped array. This method will
-     * look for both and return a list of all found. Both the single and wrapper annotation names
-     * must be provided.
-     * 
-     * @param clazz ClassInfo
-     * @param singleAnnotationName DotName
-     * @param repeatableAnnotationName DotName
-     * @return List of AnnotationInstance's
-     */
-    public static List<AnnotationInstance> getRepeatableAnnotation(ClassInfo clazz,
-            DotName singleAnnotationName, DotName repeatableAnnotationName) {
         List<AnnotationInstance> annotations = new ArrayList<>();
-        AnnotationInstance single = JandexUtil.getClassAnnotation(clazz, singleAnnotationName);
-        AnnotationInstance repeatable = JandexUtil.getClassAnnotation(clazz, repeatableAnnotationName);
-        if (single != null) {
-            annotations.add(single);
+
+        AnnotationInstance annotation = TypeUtil.getAnnotation(target, singleAnnotationName);
+
+        if (annotation != null) {
+            annotations.add(annotation);
         }
-        if (repeatable != null) {
-            AnnotationValue annotationValue = repeatable.value();
-            if (annotationValue != null) {
-                AnnotationInstance[] nestedArray = annotationValue.asNestedArray();
+
+        if (repeatableAnnotationName != null) {
+            AnnotationInstance[] nestedArray = TypeUtil.getAnnotationValue(target,
+                    repeatableAnnotationName,
+                    OpenApiConstants.PROP_VALUE);
+
+            if (nestedArray != null) {
                 annotations.addAll(Arrays.asList(nestedArray));
             }
         }
+
         return annotations;
     }
 

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/ModelUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/ModelUtil.java
@@ -32,6 +32,7 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.models.responses.APIResponses;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
 
 import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.api.models.ComponentsImpl;
@@ -40,6 +41,7 @@ import io.smallrye.openapi.api.models.PathsImpl;
 import io.smallrye.openapi.api.models.media.ContentImpl;
 import io.smallrye.openapi.api.models.media.MediaTypeImpl;
 import io.smallrye.openapi.api.models.responses.APIResponsesImpl;
+import io.smallrye.openapi.api.util.MergeUtil;
 
 /**
  * Class with some convenience methods useful for working with the OAI data model.
@@ -52,6 +54,34 @@ public class ModelUtil {
      * Constructor.
      */
     private ModelUtil() {
+    }
+
+    /**
+     * Adds a {@link Tag} to the {@link OpenAPI} model. If a tag having the same
+     * name already exists in the model, the tags' attributes are merged, with the
+     * new tag's attributes overriding the value of any attributes specified on
+     * both.
+     * 
+     * @param openApi the OpenAPI model
+     * @param tag a new {@link Tag} to add
+     */
+    public static void addTag(OpenAPI openApi, Tag tag) {
+        List<Tag> tags = openApi.getTags();
+
+        if (tags == null || tags.isEmpty()) {
+            openApi.addTag(tag);
+            return;
+        }
+
+        Tag current = tags.stream().filter(t -> t.getName().equals(tag.getName())).findFirst().orElse(null);
+        int currentIndex = tags.indexOf(current);
+
+        if (current != null) {
+            Tag replacement = MergeUtil.mergeObjects(current, tag);
+            tags.set(currentIndex, replacement);
+        } else {
+            openApi.addTag(tag);
+        }
     }
 
     /**
@@ -264,5 +294,4 @@ public class ModelUtil {
         String[] split = ref.split("/");
         return split[split.length - 1];
     }
-
 }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.tags.multilocation.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.tags.multilocation.json
@@ -1,0 +1,115 @@
+{
+  "openapi" : "3.0.1",
+  "tags" : [ {
+    "name" : "tag1",
+    "description" : "TAG1 from TagTestResource2"
+  }, {
+    "name" : "tag3",
+    "description" : "TAG3 from TagTestResource2#getValue1",
+    "externalDocs" : {
+      "description" : "Ext doc from TagTestResource2#getValue1"
+    }
+  } ],
+  "paths" : {
+    "/tags1" : {
+      "get" : {
+        "tags" : [ "tag3" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tag1" ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          }
+        }
+      },
+      "patch" : {
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      }
+    },
+    "/tags2" : {
+      "get" : {
+        "tags" : [ "tag3" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tag1", "http://example/com/tag2" ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          }
+        }
+      },
+      "patch" : {
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.tags.ordergiven.annotation.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.tags.ordergiven.annotation.json
@@ -1,0 +1,119 @@
+{
+  "openapi" : "3.0.1",
+  "info": {
+    "title" : "Testing user-specified tag order",
+    "version" : "1.0.0"
+  },
+  "tags" : [ {
+    "name" : "tag3",
+    "description" : "TAG3 from TagTestResource2#getValue1",
+    "externalDocs" : {
+      "description" : "Ext doc from TagTestResource2#getValue1"
+    }
+  }, {
+    "name" : "tag1",
+    "description" : "TAG1 from TagTestResource2"
+  } ],
+  "paths" : {
+    "/tags/tags1" : {
+      "get" : {
+        "tags" : [ "tag3" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tag1" ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          }
+        }
+      },
+      "patch" : {
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      }
+    },
+    "/tags/tags2" : {
+      "get" : {
+        "tags" : [ "tag3" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tag1", "http://example/com/tag2" ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          }
+        }
+      },
+      "patch" : {
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.tags.ordergiven.staticfile.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.tags.ordergiven.staticfile.json
@@ -1,0 +1,119 @@
+{
+  "openapi" : "3.0.1",
+  "info": {
+    "title" : "Tag order in static file",
+    "version" : "1.0.0-static"
+  },
+  "tags" : [ {
+    "name" : "tag3",
+    "description" : "TAG3 from TagTestResource2#getValue1",
+    "externalDocs" : {
+      "description" : "Ext doc from TagTestResource2#getValue1"
+    }
+  }, {
+    "name" : "tag1",
+    "description" : "TAG1 from TagTestResource2"
+  } ],
+  "paths" : {
+    "/tags1" : {
+      "get" : {
+        "tags" : [ "tag3" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tag1" ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          }
+        }
+      },
+      "patch" : {
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      }
+    },
+    "/tags2" : {
+      "get" : {
+        "tags" : [ "tag3" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tag1", "http://example/com/tag2" ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          }
+        }
+      },
+      "patch" : {
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #117 - only tag order discussion

This should help with Swagger UI: https://swagger.io/docs/specification/grouping-operations-with-tags/
> The tag order in the global tags section also controls the default sorting in Swagger UI.

Sorting will only occur if tags were not given in `@OpenAPIDefinition`. The order in a static file will also be maintained.

- Consolidate repeating annotation utils into single method