### PR TITLE
Schema scan enhancements

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -162,8 +162,8 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      */
     @Override
     public Set<String> pathServers(String path) {
-        String servers = getConfig().getOptionalValue(OASConfig.SERVERS_PATH_PREFIX + path, String.class).orElse(null);
-        return asCsvSet(servers);
+        String pathServers = getConfig().getOptionalValue(OASConfig.SERVERS_PATH_PREFIX + path, String.class).orElse(null);
+        return asCsvSet(pathServers);
     }
 
     /**
@@ -171,9 +171,9 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      */
     @Override
     public Set<String> operationServers(String operationId) {
-        String servers = getConfig().getOptionalValue(OASConfig.SERVERS_OPERATION_PREFIX + operationId, String.class)
+        String opServers = getConfig().getOptionalValue(OASConfig.SERVERS_OPERATION_PREFIX + operationId, String.class)
                 .orElse(null);
-        return asCsvSet(servers);
+        return asCsvSet(opServers);
     }
 
     /**
@@ -204,7 +204,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     public boolean schemaReferencesEnable() {
         if (schemaReferencesEnable == null) {
             schemaReferencesEnable = getConfig().getOptionalValue(OpenApiConstants.SCHEMA_REFERENCES_ENABLE, Boolean.class)
-                    .orElse(false);
+                    .orElse(true);
         }
         return schemaReferencesEnable;
     }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
@@ -2,14 +2,9 @@ package io.smallrye.openapi.runtime.scanner;
 
 import java.util.Collection;
 
-import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.Type;
-
-import io.smallrye.openapi.runtime.util.JandexUtil.JaxRsParameterInfo;
 
 /**
  * Extension point for supporting extensions to JAX-RS. Implement this directly or extend
@@ -17,33 +12,7 @@ import io.smallrye.openapi.runtime.util.JandexUtil.JaxRsParameterInfo;
  *
  * @see DefaultAnnotationScannerExtension
  */
-@SuppressWarnings("deprecation")
 public interface AnnotationScannerExtension {
-
-    /**
-     * Determines where an @Parameter can be found (examples include Query,
-     * Path, Header, Cookie, etc).
-     *
-     * @param paramInfo
-     * @return the parameter location, or null if unknown
-     */
-    @Deprecated
-    public In parameterIn(MethodParameterInfo paramInfo);
-
-    /**
-     * Returns jax-rs info about the parameter at the given index. If the index
-     * is invalid or does not refer to a jax-rs parameter then this should
-     * return null. Otherwise it will return a {@link JaxRsParameterInfo} object
-     * with the name and type of the param.
-     *
-     * @param method
-     *        MethodInfo
-     * @param idx
-     *        index of parameter
-     * @return JaxRsParameterInfo or null if unknown.
-     */
-    @Deprecated
-    public JaxRsParameterInfo getMethodParameterJaxRsInfo(MethodInfo method, int idx);
 
     /**
      * Unwraps an asynchronous type such as
@@ -54,7 +23,9 @@ public interface AnnotationScannerExtension {
      *        the type to unwrap if it is a supported async type
      * @return the resolved type or null if not supported
      */
-    public Type resolveAsyncType(Type type);
+    default Type resolveAsyncType(Type type) {
+        return null;
+    }
 
     /**
      * Gives a chance to extensions to process the set of jax-rs application classes.
@@ -62,7 +33,8 @@ public interface AnnotationScannerExtension {
      * @param scanner the scanner used for application scanning
      * @param applications the set of jax-rs application classes
      */
-    public void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications);
+    default void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications) {
+    }
 
     /**
      * Returns true if the given annotation is a jax-rs annotation extension, such as would be in the javax.ws.rs
@@ -71,6 +43,8 @@ public interface AnnotationScannerExtension {
      * @param instance the annotation to check
      * @return true if the given annotation is a jax-rs annotation extension
      */
-    public boolean isJaxRsAnnotationExtension(AnnotationInstance instance);
+    default boolean isJaxRsAnnotationExtension(AnnotationInstance instance) {
+        return false;
+    }
 
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/DefaultAnnotationScannerExtension.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/DefaultAnnotationScannerExtension.java
@@ -1,82 +1,10 @@
 package io.smallrye.openapi.runtime.scanner;
 
-import java.util.Collection;
-
-import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.MethodParameterInfo;
-import org.jboss.jandex.Type;
-
-import io.smallrye.openapi.runtime.util.JandexUtil.JaxRsParameterInfo;
-
 /**
  * Default extension point for supporting extensions to JAX-RS.
+ * 
+ * @deprecated implement {@link AnnotationScannerExtension} directly instead
  */
+@Deprecated
 public class DefaultAnnotationScannerExtension implements AnnotationScannerExtension {
-
-    /**
-     * Determines where an @Parameter can be found (examples include Query,
-     * Path, Header, Cookie, etc).
-     *
-     * @param paramInfo
-     * @return the parameter location, or null if unknown
-     */
-    @Deprecated
-    public In parameterIn(MethodParameterInfo paramInfo) {
-        return null;
-    }
-
-    /**
-     * Returns jax-rs info about the parameter at the given index. If the index
-     * is invalid or does not refer to a jax-rs parameter then this should
-     * return null. Otherwise it will return a {@link JaxRsParameterInfo} object
-     * with the name and type of the param.
-     *
-     * @param method
-     *        MethodInfo
-     * @param idx
-     *        index of parameter
-     * @return JaxRsParameterInfo or null if unknown.
-     */
-    @Deprecated
-    public JaxRsParameterInfo getMethodParameterJaxRsInfo(MethodInfo method, int idx) {
-        return null;
-    }
-
-    /**
-     * Unwraps an asynchronous type such as
-     * <code>CompletionStage&lt;X&gt;</code> into its resolved type
-     * <code>X</code>
-     *
-     * @param type
-     *        the type to unwrap if it is a supported async type
-     * @return the resolved type or null if not supported
-     */
-    public Type resolveAsyncType(Type type) {
-        return null;
-    }
-
-    /**
-     * Gives a chance to extensions to process the set of jax-rs application classes.
-     * 
-     * @param scanner the scanner used for application scanning
-     * @param applications the set of jax-rs application classes
-     */
-    public void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications) {
-    }
-
-    /**
-     * Returns true if the given annotation is a jax-rs annotation extension, such as would be in the javax.ws.rs
-     * package.
-     *
-     * @param instance the annotation to check
-     * @return true if the given annotation is a jax-rs annotation extension
-     */
-    @Override
-    public boolean isJaxRsAnnotationExtension(AnnotationInstance instance) {
-        return false;
-    }
-
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
@@ -226,8 +225,9 @@ public class OpenApiDataObjectScanner {
             Schema currentSchema = currentPathEntry.getSchema();
             Type currentType = currentPathEntry.getClazzType();
 
-            // First, handle class annotations.
-            currentPathEntry.setSchema(readKlass(currentClass, currentSchema));
+            // First, handle class annotations (re-assign since readKlass may return new schema)
+            currentSchema = readKlass(currentClass, currentSchema);
+            currentPathEntry.setSchema(currentSchema);
 
             if (currentSchema.getType() == null) {
                 // If not schema has yet been set, consider this an "object"
@@ -255,7 +255,7 @@ public class OpenApiDataObjectScanner {
         AnnotationInstance annotation = TypeUtil.getSchemaAnnotation(currentClass);
         if (annotation != null) {
             // Because of implementation= field, *may* return a new schema rather than modify.
-            return SchemaFactory.readSchema(index, currentSchema, annotation, Collections.emptyMap());
+            return SchemaFactory.readSchema(index, currentSchema, annotation, currentClass);
         }
         return currentSchema;
     }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -234,6 +234,11 @@ public class OpenApiDataObjectScanner {
                 currentSchema.setType(Schema.SchemaType.OBJECT);
             }
 
+            if (currentSchema.getType() != Schema.SchemaType.OBJECT) {
+                // Only 'object' type schemas should have properties of their own
+                continue;
+            }
+
             LOG.debugv("Getting all fields for: {0} in class: {1}", currentType, currentClass);
 
             // Get all fields *including* inherited.

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -15,10 +15,11 @@
  */
 package io.smallrye.openapi.runtime.scanner.dataobject;
 
-import static io.smallrye.openapi.runtime.util.TypeUtil.getSchemaAnnotation;
-
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.AnnotationInstance;
@@ -29,6 +30,7 @@ import org.jboss.logging.Logger;
 
 import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.api.util.MergeUtil;
 import io.smallrye.openapi.runtime.scanner.SchemaRegistry;
 import io.smallrye.openapi.runtime.scanner.dataobject.BeanValidationScanner.RequirementHandler;
 import io.smallrye.openapi.runtime.util.JandexUtil;
@@ -49,8 +51,6 @@ public class AnnotationTargetProcessor implements RequirementHandler {
     private final TypeResolver typeResolver;
     private final Type entityType;
 
-    // This can be overridden.
-    private Schema fieldSchema;
     // May be null if field is unannotated.
     private AnnotationTarget annotationTarget;
 
@@ -60,30 +60,13 @@ public class AnnotationTargetProcessor implements RequirementHandler {
             TypeResolver typeResolver,
             AnnotationTarget annotationTarget,
             Type entityType) {
+
         this.index = index;
         this.objectStack = objectStack;
         this.parentPathEntry = parentPathEntry;
         this.typeResolver = typeResolver;
         this.entityType = entityType;
         this.annotationTarget = annotationTarget;
-        this.fieldSchema = new SchemaImpl();
-    }
-
-    public AnnotationTargetProcessor(AugmentedIndexView index,
-            DataObjectDeque objectStack,
-            TypeResolver typeResolver,
-            DataObjectDeque.PathEntry parentPathEntry) {
-
-        this(index, objectStack, parentPathEntry, typeResolver, typeResolver.getAnnotationTarget(),
-                typeResolver.getUnresolvedType());
-    }
-
-    public AnnotationTargetProcessor(AugmentedIndexView index,
-            DataObjectDeque objectStack,
-            TypeResolver typeResolver,
-            DataObjectDeque.PathEntry parentPathEntry,
-            Type type) {
-        this(index, objectStack, parentPathEntry, typeResolver, index.getClass(type), type);
     }
 
     public static Schema process(AugmentedIndexView index,
@@ -91,7 +74,8 @@ public class AnnotationTargetProcessor implements RequirementHandler {
             TypeResolver typeResolver,
             DataObjectDeque.PathEntry parentPathEntry) {
 
-        AnnotationTargetProcessor fp = new AnnotationTargetProcessor(index, objectStack, typeResolver, parentPathEntry);
+        AnnotationTargetProcessor fp = new AnnotationTargetProcessor(index, objectStack, parentPathEntry, typeResolver,
+                typeResolver.getAnnotationTarget(), typeResolver.getUnresolvedType());
         return fp.processField();
     }
 
@@ -100,7 +84,8 @@ public class AnnotationTargetProcessor implements RequirementHandler {
             TypeResolver typeResolver,
             DataObjectDeque.PathEntry parentPathEntry,
             Type type) {
-        AnnotationTargetProcessor fp = new AnnotationTargetProcessor(index, objectStack, typeResolver, parentPathEntry, type);
+        AnnotationTargetProcessor fp = new AnnotationTargetProcessor(index, objectStack, parentPathEntry, typeResolver,
+                index.getClass(type), type);
         return fp.processField();
     }
 
@@ -109,7 +94,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         List<String> requiredProperties = parentPathEntry.getSchema().getRequired();
 
         if (requiredProperties == null || !requiredProperties.contains(propertyKey)) {
-            AnnotationInstance schemaAnnotation = getSchemaAnnotation(target);
+            AnnotationInstance schemaAnnotation = TypeUtil.getSchemaAnnotation(target);
 
             if (schemaAnnotation == null ||
                     schemaAnnotation.value(OpenApiConstants.PROP_REQUIRED) == null) {
@@ -122,32 +107,92 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         }
     }
 
+    /**
+     * This method will generate a schema for the {@link #annotationTarget} containing one
+     * of the following :
+     * 
+     * <ol>
+     * <li>A schema composed (using {@link Schema#allOf(List) allOf}) of a <code>$ref</code> to the schema of the
+     * {@link #entityType}
+     * and the schema attributes scanned or derived from the {@link #annotationTarget} itself that do not
+     * generally apply to the {@link #entityType}'s schema such as a field-specific <code>description</code>.
+     * </li>
+     * <li>A schema containing a <code>$ref</code> to the schema of the {@link #entityType}. This occurs when
+     * the field does not contribute any additional or different attributes that are not defined by the base
+     * schema of the {@link #entityType}.
+     * </li>
+     * <li>A schema containing only the attributes scanned or derived from the {@link #annotationTarget} which will include
+     * attributes
+     * of the {@link #entityType} if it is not able to be registered via
+     * {@link SchemaRegistry#checkRegistration(Type, TypeResolver, Schema) checkRegistration}.
+     * </li>
+     * </ol>
+     * 
+     * @return the individual or composite schema for the annotationTarget used to create this {@link AnnotationTargetProcessor}
+     */
     Schema processField() {
-        AnnotationInstance schemaAnnotation = TypeUtil.getSchemaAnnotation(annotationTarget);
-
+        final AnnotationInstance schemaAnnotation = TypeUtil.getSchemaAnnotation(annotationTarget);
         final String propertyKey = typeResolver.getPropertyName();
 
-        if (schemaAnnotation == null) {
-            // Handle unannotated field and just do simple inference.
-            if (shouldInferUnannotatedFields()) {
-                readUnannotatedField();
-            }
+        final Schema typeSchema;
+        final Schema registeredTypeSchema;
+        final Type fieldType;
+
+        if (schemaAnnotation != null && JandexUtil.hasImplementation(schemaAnnotation)) {
+            typeSchema = null;
+            registeredTypeSchema = null;
+            fieldType = JandexUtil.value(schemaAnnotation, OpenApiConstants.PROP_IMPLEMENTATION);
         } else {
+            // Process the type of the field to derive the typeSchema
+            TypeProcessor typeProcessor = new TypeProcessor(index, objectStack, parentPathEntry, typeResolver, entityType,
+                    new SchemaImpl(), annotationTarget);
+
+            // Type could be replaced (e.g. generics)
+            fieldType = typeProcessor.processType();
+
+            typeSchema = typeProcessor.getSchema();
+
+            // Set any default values that apply to the type schema as a result of the TypeProcessor
+            TypeUtil.applyTypeAttributes(fieldType, typeSchema);
+
+            // The registeredTypeSchema will be a reference to typeSchema if registration occurs
+            registeredTypeSchema = SchemaRegistry.checkRegistration(entityType, typeResolver, typeSchema);
+        }
+
+        Schema fieldSchema;
+
+        if (schemaAnnotation != null) {
             // Handle field annotated with @Schema.
-            readSchemaAnnotatedField(propertyKey, schemaAnnotation);
+            fieldSchema = readSchemaAnnotatedField(propertyKey, schemaAnnotation, fieldType);
+        } else {
+            // Use the type's schema for the field as a starting point
+            fieldSchema = typeSchema;
         }
 
         BeanValidationScanner.applyConstraints(annotationTarget, fieldSchema, propertyKey, this);
-        fieldSchema = SchemaRegistry.checkRegistration(entityType, typeResolver, fieldSchema);
+
+        // Only when registration was successful (ref is present and the registered type is a different instance)
+        if (typeSchema != registeredTypeSchema && registeredTypeSchema.getRef() != null) {
+            // Check if the field specifies something additional or different from the type's schema
+            if (fieldOverridesType(fieldSchema, typeSchema)) {
+                TypeUtil.clearMatchingDefaultAttributes(fieldSchema, typeSchema); // Remove duplicates
+                Schema composition = new SchemaImpl();
+                composition.addAllOf(registeredTypeSchema); // Reference to the type schema
+                composition.addAllOf(fieldSchema);
+                fieldSchema = composition;
+            } else {
+                fieldSchema = registeredTypeSchema; // Reference to the type schema
+            }
+        } else {
+            // Registration did not occur, overlay anything defined by the field on the type's schema
+            fieldSchema = MergeUtil.mergeObjects(typeSchema, fieldSchema);
+        }
+
         parentPathEntry.getSchema().addProperty(propertyKey, fieldSchema);
         return fieldSchema;
     }
 
-    private void readSchemaAnnotatedField(String propertyKey, AnnotationInstance annotation) {
-        if (annotation == null) {
-            throw new IllegalArgumentException("Annotation must not be null");
-        }
-
+    private Schema readSchemaAnnotatedField(String propertyKey, AnnotationInstance annotation, Type postProcessedField) {
         LOG.debugv("Processing @Schema annotation {0} on a field {1}", annotation, propertyKey);
 
         // If "required" attribute is on field. It should be applied to the *parent* schema.
@@ -156,34 +201,92 @@ public class AnnotationTargetProcessor implements RequirementHandler {
             parentPathEntry.getSchema().addRequired(propertyKey);
         }
 
-        // Type could be replaced (e.g. generics).
-        TypeProcessor typeProcessor = new TypeProcessor(index, objectStack, parentPathEntry, typeResolver, entityType,
-                fieldSchema, annotationTarget);
-
-        Type postProcessedField = typeProcessor.processType();
-        fieldSchema = typeProcessor.getSchema();
-
         // TypeFormat pair contains mappings for Java <-> OAS types and formats.
         // Provide inferred type and format if relevant.
-        Map<String, Object> defaults = TypeUtil.getTypeAttributes(postProcessedField);
+        Map<String, Object> defaults;
+
+        if (JandexUtil.isArraySchema(annotation)) {
+            defaults = Collections.emptyMap();
+        } else {
+            defaults = TypeUtil.getTypeAttributes(postProcessedField);
+        }
+
         // readSchema *may* replace the existing schema, so we must assign.
-        this.fieldSchema = SchemaFactory.readSchema(index, fieldSchema, annotation, defaults);
+        return SchemaFactory.readSchema(index, new SchemaImpl(), annotation, defaults);
     }
 
-    private void readUnannotatedField() {
-        LOG.debugv("Processing unannotated field {0}", entityType);
+    /**
+     * Determine if the fieldSchema defines any attributes that are not present or
+     * different from the attributes in the typeSchema.
+     * 
+     * @param fieldSchema
+     * @param typeSchema
+     * @return true if fieldSchema defines new attributes or different attributes from typeSchema, otherwise false
+     */
+    boolean fieldOverridesType(Schema fieldSchema, Schema typeSchema) {
+        List<Supplier<Object>> typeAttributes = getAttributeSuppliers(typeSchema);
+        List<Supplier<Object>> fieldAttributes = getAttributeSuppliers(fieldSchema);
 
-        TypeProcessor typeProcessor = new TypeProcessor(index, objectStack, parentPathEntry, typeResolver, entityType,
-                fieldSchema, annotationTarget);
+        for (int i = 0, m = typeAttributes.size(); i < m; i++) {
+            Object fieldAttr = fieldAttributes.get(i).get();
 
-        Type postProcessedField = typeProcessor.processType();
-        fieldSchema = typeProcessor.getSchema();
+            if (fieldAttr != null) {
+                Object typeAttr = typeAttributes.get(i).get();
 
-        TypeUtil.applyTypeAttributes(postProcessedField, fieldSchema);
+                if (typeAttr == null || !fieldAttr.equals(typeAttr)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
-    private boolean shouldInferUnannotatedFields() {
-        String infer = System.getProperties().getProperty("openapi.infer-unannotated-types", "true");
-        return Boolean.parseBoolean(infer);
+    /**
+     * Get accessors/suppliers for all schema attributes that are relevant to comparing two
+     * schemas.
+     * 
+     * @param schema the schema
+     * @return a list of suppliers (i.e. getters) for the schema's attributes
+     */
+    List<Supplier<Object>> getAttributeSuppliers(Schema schema) {
+        return Arrays.asList(schema::getAdditionalPropertiesBoolean,
+                schema::getAdditionalPropertiesSchema,
+                schema::getAllOf,
+                schema::getAnyOf,
+                schema::getDefaultValue,
+                schema::getDeprecated,
+                schema::getDescription,
+                schema::getDiscriminator,
+                schema::getEnumeration,
+                schema::getExample,
+                schema::getExclusiveMaximum,
+                schema::getExclusiveMinimum,
+                schema::getExtensions,
+                schema::getExternalDocs,
+                schema::getFormat,
+                schema::getItems,
+                schema::getMaximum,
+                schema::getMaxItems,
+                schema::getMaxLength,
+                schema::getMaxProperties,
+                schema::getMinimum,
+                schema::getMinItems,
+                schema::getMinLength,
+                schema::getMinProperties,
+                schema::getMultipleOf,
+                schema::getNot,
+                schema::getNullable,
+                schema::getOneOf,
+                schema::getPattern,
+                schema::getProperties,
+                schema::getReadOnly,
+                schema::getRef,
+                schema::getRequired,
+                schema::getTitle,
+                schema::getType,
+                schema::getUniqueItems,
+                schema::getWriteOnly,
+                schema::getXml);
     }
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTarget.Kind;
@@ -98,19 +97,19 @@ public class JandexUtil {
             return null;
         }
 
-        String $ref = value.asString();
+        String ref = value.asString();
 
-        if (!componentKeyPattern.matcher($ref).matches()) {
-            return $ref;
+        if (!componentKeyPattern.matcher(ref).matches()) {
+            return ref;
         }
 
         if (refType != null) {
-            $ref = "#/components/" + refType.componentPath + "/" + $ref;
+            ref = "#/components/" + refType.componentPath + "/" + ref;
         } else {
             throw new NullPointerException("RefType must not be null");
         }
 
-        return $ref;
+        return ref;
     }
 
     /**
@@ -446,8 +445,7 @@ public class JandexUtil {
      * @return Type
      */
     public static Type getMethodParameterType(MethodInfo method, short position) {
-        Type type = method.parameters().get(position);
-        return type;
+        return method.parameters().get(position);
     }
 
     /**
@@ -457,8 +455,7 @@ public class JandexUtil {
      * @return Type
      */
     public static Type getMethodParameterType(MethodParameterInfo parameter) {
-        Type type = parameter.method().parameters().get(parameter.position());
-        return type;
+        return parameter.method().parameters().get(parameter.position());
     }
 
     /**
@@ -528,8 +525,7 @@ public class JandexUtil {
      * @return Is it a simple class @Schema
      */
     public static boolean isSimpleClassSchema(AnnotationInstance annotation) {
-        List<AnnotationValue> values = annotation.values();
-        return values.size() == 1 && values.get(0).name().equals(OpenApiConstants.PROP_IMPLEMENTATION);
+        return annotation.values().size() == 1 && hasImplementation(annotation);
     }
 
     /**
@@ -541,14 +537,41 @@ public class JandexUtil {
      * @return Is it a simple array @Schema
      */
     public static boolean isSimpleArraySchema(AnnotationInstance annotation) {
-        List<AnnotationValue> values = annotation.values();
-        if (values.size() != 2) {
+        if (annotation.values().size() != 2) {
             return false;
         }
+
+        return isArraySchema(annotation);
+    }
+
+    /**
+     * Returns true if the given {@link org.eclipse.microprofile.openapi.annotations.media.Schema @Schema}
+     * annotation is an array schema. This is defined as a schema with a "type" field and "implementation"
+     * field defined *and* the type must be array.
+     * 
+     * @param annotation AnnotationInstance
+     * @return Is it an array {@link org.eclipse.microprofile.openapi.annotations.media.Schema @Schema}
+     */
+    public static boolean isArraySchema(AnnotationInstance annotation) {
+        if (!hasImplementation(annotation)) {
+            return false;
+        }
+
         org.eclipse.microprofile.openapi.models.media.Schema.SchemaType type = JandexUtil.enumValue(annotation,
                 OpenApiConstants.PROP_TYPE, org.eclipse.microprofile.openapi.models.media.Schema.SchemaType.class);
-        String implementation = JandexUtil.stringValue(annotation, OpenApiConstants.PROP_IMPLEMENTATION);
-        return (type == org.eclipse.microprofile.openapi.models.media.Schema.SchemaType.ARRAY && implementation != null);
+
+        return (type == org.eclipse.microprofile.openapi.models.media.Schema.SchemaType.ARRAY);
+    }
+
+    /**
+     * Returns true if the given {@link org.eclipse.microprofile.openapi.annotations.media.Schema @Schema}
+     * annotation has defined an "implementation" field.
+     * 
+     * @param annotation AnnotationInstance
+     * @return true if the annotation defines an implementation, otherwise false
+     */
+    public static boolean hasImplementation(AnnotationInstance annotation) {
+        return annotation.value(OpenApiConstants.PROP_IMPLEMENTATION) != null;
     }
 
     /**
@@ -569,17 +592,5 @@ public class JandexUtil {
                 (klazz = index.getClassByName(TypeUtil.getName(type))) != null);
 
         return chain;
-    }
-
-    /**
-     * Holds relevant information about a jax-rs method parameter. Specifically its name
-     * and type (path, query, cookie, etc).
-     * 
-     * @author eric.wittmann@gmail.com
-     */
-    @Deprecated
-    public static class JaxRsParameterInfo {
-        public String name;
-        public Parameter.In in;
     }
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
@@ -283,6 +284,26 @@ public class TypeUtil {
         schema.setPattern(attrs.getPattern());
     }
 
+    /**
+     * Removes the known default schema attributes from the fieldSchema if they are also
+     * present and have the same value in the typeSchema. This method reduces any duplicate
+     * attributes between the two schemas when they are in an 'allOf' composition.
+     * 
+     * @param fieldSchema the schema for a field of the type described by typeSchema
+     * @param typeSchema the schema for a class type
+     */
+    public static void clearMatchingDefaultAttributes(Schema fieldSchema, Schema typeSchema) {
+        if (Objects.equals(fieldSchema.getType(), typeSchema.getType())) {
+            fieldSchema.setType(null);
+        }
+        if (Objects.equals(fieldSchema.getFormat(), typeSchema.getFormat())) {
+            fieldSchema.setFormat(null);
+        }
+        if (Objects.equals(fieldSchema.getPattern(), typeSchema.getPattern())) {
+            fieldSchema.setPattern(null);
+        }
+    }
+
     public static TypeWithFormat arrayFormat() {
         return ARRAY_FORMAT;
     }
@@ -300,7 +321,7 @@ public class TypeUtil {
             Class<?> subjectKlazz = TypeUtil.getClass(subject);
             Class<?> objectKlazz = TypeUtil.getClass(object);
             return objectKlazz.isAssignableFrom(subjectKlazz);
-        } catch (ClassNotFoundException nfe) {
+        } catch (@SuppressWarnings("unused") ClassNotFoundException nfe) {
             return false;
         }
     }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
@@ -21,6 +21,7 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
@@ -28,6 +29,7 @@ import org.junit.Test;
 
 import io.smallrye.openapi.api.models.OpenAPIImpl;
 import test.io.smallrye.openapi.runtime.scanner.entities.NestedSchemaParent;
+import test.io.smallrye.openapi.runtime.scanner.resources.NestedSchemaOnParameterResource;
 
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
@@ -52,18 +54,12 @@ public class NestedSchemaReferenceTests extends OpenApiDataObjectScannerTestBase
 
     @Test
     public void testNestedSchemaOnParameter() throws IOException, JSONException {
-        Indexer indexer = new Indexer();
+        IndexView index = indexOf(NestedSchemaOnParameterResource.class,
+                NestedSchemaOnParameterResource.NestedParameterTestParent.class,
+                NestedSchemaOnParameterResource.NestedParameterTestChild.class,
+                NestedSchemaOnParameterResource.AnotherNestedChildWithSchemaName.class);
 
-        // Test samples
-        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.class");
-        index(indexer,
-                "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource$NestedParameterTestParent.class");
-        index(indexer,
-                "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource$NestedParameterTestChild.class");
-        index(indexer,
-                "test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource$AnotherNestedChildWithSchemaName.class");
-
-        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), indexer.complete());
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), index);
 
         OpenAPI result = scanner.scan();
 

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -38,6 +38,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
@@ -167,7 +168,8 @@ public class ParameterScanTests extends IndexScannerTestBase {
     public void testEnumQueryParam() throws IOException, JSONException {
         test("params.enum-form-param.json",
                 EnumQueryParamTestResource.class,
-                EnumQueryParamTestResource.TestEnum.class);
+                EnumQueryParamTestResource.TestEnum.class,
+                EnumQueryParamTestResource.TestEnumWithSchema.class);
     }
 
     @Test
@@ -480,11 +482,19 @@ public class ParameterScanTests extends IndexScannerTestBase {
             VAL3;
         }
 
+        @Schema(name = "RestrictedEnum", title = "Restricted enum with fewer values", enumeration = { "VAL1",
+                "VAL3" }, externalDocs = @ExternalDocumentation(description = "When to use RestrictedEnum?", url = "http://example.com/RestrictedEnum/info.html"))
+        static enum TestEnumWithSchema {
+            VAL1,
+            VAL2,
+            VAL3;
+        }
+
         @SuppressWarnings("unused")
         @POST
         @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
         @Produces(MediaType.TEXT_PLAIN)
-        public TestEnum postData(@QueryParam("val") TestEnum value) {
+        public TestEnum postData(@QueryParam("val") TestEnum value, @QueryParam("restr") TestEnumWithSchema restr) {
             return null;
         }
     }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
@@ -20,7 +20,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.Indexer;
 import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,13 +37,7 @@ public class BeanValidationResourceTest extends IndexScannerTestBase {
 
     @Before
     public void beforeEach() {
-        Indexer indexer = new Indexer();
-        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.class");
-        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest$BVTestContainer.class");
-        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest$BVTestResource.class");
-        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest$BVTestResourceEntity.class");
-
-        index = indexer.complete();
+        index = indexOf(BVTestResource.class, BVTestResourceEntity.class, BeanValidationScannerTest.BVTestContainer.class);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.java
@@ -35,7 +35,6 @@ import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.Indexer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,12 +55,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     @Before
     public void beforeEach() {
         testTarget = BeanValidationScanner.INSTANCE;
-
-        Indexer indexer = new Indexer();
-        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.class");
-        index(indexer, "io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest$BVTestContainer.class");
-        index = indexer.complete();
-
+        index = indexOf(BVTestContainer.class);
         methodsInvoked.clear();
         schema = new SchemaImpl();
         targetClass = index.getClassByName(componentize(BVTestContainer.class.getName()));

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/NestedSchemaOnParameterResource.java
@@ -31,7 +31,7 @@ public class NestedSchemaOnParameterResource {
         NestedParameterTestChild nested;
 
         @JsonbProperty("will_not_be_used")
-        @Schema(name = "another_child", description = "This schema and description will be replaced with a $ref to 'another_nested', but the name will be used for the property")
+        @Schema(name = "another_child", description = "This schema will be unioned to $ref to 'another_nested', name will be used for the property, and this description will be present on this property")
         AnotherNestedChildWithSchemaName another;
 
         List<NestedParameterTestChild> childList;

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.enum-form-param.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.enum-form-param.json
@@ -5,6 +5,12 @@
       "post": {
         "parameters": [
           {
+          "name": "restr",
+          "in": "query",
+          "schema": {
+            "$ref": "#/components/schemas/RestrictedEnum"
+          }
+        }, {
           "name": "val",
           "in": "query",
           "schema": {
@@ -32,6 +38,15 @@
       "TestEnum": {
         "type": "string",
         "enum": [ "VAL1", "VAL2", "VAL3" ]
+      },
+      "RestrictedEnum": {
+        "type": "string",
+        "title": "Restricted enum with fewer values",
+        "enum": [ "VAL1", "VAL3" ],
+        "externalDocs": {
+           "url": "http://example.com/RestrictedEnum/info.html",
+           "description": "When to use RestrictedEnum?"
+        }
       }
     }
   }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.uuid-params-responses.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.uuid-params-responses.json
@@ -59,7 +59,14 @@
         "type": "object",
         "properties": {
           "theUUID": {
-            "$ref": "#/components/schemas/UUID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UUID"
+              },
+              {
+                "description": "test"
+              }
+            ]
           }
         }
       },

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
@@ -12,12 +12,18 @@
             "type": "object"
           },
           "foo": {
-            "$ref": "#/components/schemas/FuzzStringDate"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FuzzStringDate"
+              },
+              {
+                "maxLength": 123456
+              }
+            ]
           }
         }
       },
       "FuzzStringDate": {
-        "maxLength": 123456,
         "type": "object",
         "properties": {
           "qAgain": {

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
@@ -2,7 +2,6 @@
   "components": {
     "schemas": {
       "KustomPairStringString": {
-        "maxLength": 123456,
         "required": [
           "bar",
           "foo"
@@ -30,7 +29,14 @@
             "type": "integer"
           },
           "foo": {
-            "$ref": "#/components/schemas/KustomPairStringString"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KustomPairStringString"
+              },
+              {
+                "maxLength": 123456
+              }
+            ]
           }
         }
       }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
@@ -178,7 +178,6 @@
         }
       },
       "FuzzStringObject": {
-        "maxLength": 123456,
         "type": "object",
         "properties": {
           "qAgain": {
@@ -214,7 +213,14 @@
             "type": "integer"
           },
           "foo": {
-            "$ref": "#/components/schemas/FuzzStringObject"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FuzzStringObject"
+              },
+              {
+                "maxLength": 123456
+              }
+            ]
           }
         }
       },
@@ -269,7 +275,14 @@
             "$ref": "#/components/schemas/FooExtendsFoo"
           },
           "qValue": {
-            "$ref": "#/components/schemas/FooExtendsFoo"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FooExtendsFoo"
+              },
+              {
+                "description": "Ah, Q, my favourite variable!"
+              }
+            ]
           },
           "tAgain2": {
             "type": "string"
@@ -310,12 +323,18 @@
             "type": "integer"
           },
           "foo": {
-            "$ref": "#/components/schemas/KustomPairStringString"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KustomPairStringString"
+              },
+              {
+                "maxLength": 123456
+              }
+            ]
           }
         }
       },
       "KustomPairStringString": {
-        "maxLength": 123456,
         "required": [
           "bar",
           "foo"

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.testNestedSchemaOnParameter.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.testNestedSchemaOnParameter.json
@@ -47,7 +47,14 @@
             "$ref": "#/components/schemas/NestedParameterTestChild"
           },
           "another_child": {
-            "$ref": "#/components/schemas/another_nested"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/another_nested"
+              },
+              {
+                "description": "This schema will be unioned to $ref to 'another_nested', name will be used for the property, and this description will be present on this property"
+              }
+            ]
           },
           "childList": {
             "type": "array",

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.string-implementation-wrapped.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.string-implementation-wrapped.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/hello": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GreetingMessage"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GreetingMessage": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SimpleString"
+              },
+              {
+                "description": "Used to send a message"
+              }
+            ]
+          },
+          "optionalMessage": {
+            "type": "string",
+            "description": "Simply a string"
+          }
+        }
+      },
+      "SimpleString": {
+        "type": "string",
+        "title": "A Simple String"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR includes some significant updates to the schema scanning process. Feedback/discussion/criticism is welcome.

- *** Support schema composition on property schemas using `allOf`. This allows for the global schema of the field's type (which is separately registered in `components`) to be combined with locally-declared schema data such as `description` or constraints.
- *** Change default value of `mp.openapi.extensions.schema-references.enable` to `true`
- Fixes #201 when `implementation` is specified.
- Fix class schema registration, ensures the class's `@Schema` information is the data used in `components` top-level entries
- Do not process using the field type if `@Schema` `implementation` is specified
- Add support for `@Schema` on `enum` classes. As pointed out by @pe-st in his ["Code First or Design First?" presentation](https://github.com/pe-st/apidocs), this was not previously supported
- Do not scan for or generate `properties` for non-object schemas, also pointed out by @pe-st
- Prune deprecated `AnnotationScannerExtension` methods and define defaults in interface
- Deprecate `DefaultAnnotationScannerExtension` as default methods are defined in interface
- Fix a few minor Sonar issues
