### PR TITLE
Scan OAI Definition on package-info classes

### DIFF
--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScannerTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScannerTest.java
@@ -137,6 +137,21 @@ public class OpenApiAnnotationScannerTest extends OpenApiDataObjectScannerTestBa
         assertJsonEquals("resource.testRequestBodyComponentGeneration.json", result);
     }
 
+    @Test
+    public void testPackageInfoDefinitionScanning() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/package-info.class");
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/PackageInfoTestApplication.class");
+        index(indexer,
+                "test/io/smallrye/openapi/runtime/scanner/resources/PackageInfoTestApplication$PackageInfoTestResource.class");
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), indexer.complete());
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("resource.testPackageInfoDefinitionScanning.json", result);
+    }
+
     /**
      * Example of a simple custom schema registry that has only UUID type schema.
      */

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/package-info.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/package-info.java
@@ -1,0 +1,2 @@
+@org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition(info = @org.eclipse.microprofile.openapi.annotations.info.Info(title = "Title from the package", description = "Description from the package", version = "1.1"))
+package test.io.smallrye.openapi.runtime.scanner;

--- a/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/PackageInfoTestApplication.java
+++ b/implementation/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/PackageInfoTestApplication.java
@@ -1,0 +1,26 @@
+package test.io.smallrye.openapi.runtime.scanner.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
+
+/**
+ *
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+@OpenAPIDefinition(info = @Info(title = "Title from the application", version = "1.0"))
+public class PackageInfoTestApplication extends Application {
+    @Path("package-info-test")
+    public static class PackageInfoTestResource {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getValue() {
+            return "";
+        }
+    }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testPackageInfoDefinitionScanning.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testPackageInfoDefinitionScanning.json
@@ -1,0 +1,26 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Title from the application",
+    "description": "Description from the package",
+    "version": "1.0"
+  },
+  "paths": {
+    "/package-info-test": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Scan of package-info occurs prior to scan of JAX-RS `Application` classes

Fixes #215 

Signed-off-by: Michael Edgar <michael@xlate.io>