### PR TITLE
Avoid NPE when generic type variable declared outside type hierarchy

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -317,13 +317,22 @@ public class TypeResolver {
         Type current = TypeUtil.resolveWildcard(fieldType);
 
         for (Map<String, Type> map : resolutionStack) {
-            // Look in next entry map-set.
-            if (current.kind() == Type.Kind.TYPE_VARIABLE) {
-                current = map.get(current.asTypeVariable().identifier());
-            } else if (current.kind() == Type.Kind.UNRESOLVED_TYPE_VARIABLE) {
-                current = map.get(current.asUnresolvedTypeVariable().identifier());
-            } else {
-                return current;
+            String varName = null;
+
+            switch (current.kind()) {
+                case TYPE_VARIABLE:
+                    varName = current.asTypeVariable().identifier();
+                    break;
+                case UNRESOLVED_TYPE_VARIABLE:
+                    varName = current.asUnresolvedTypeVariable().identifier();
+                    break;
+                default:
+                    break;
+            }
+
+            // Look in next entry map-set if the name is present.
+            if (varName != null && map.containsKey(varName)) {
+                current = map.get(varName);
             }
         }
         return current;

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
@@ -21,11 +21,13 @@ import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -163,6 +165,8 @@ public class ResourceParameterTests extends OpenApiDataObjectScannerTestBase {
         }
     }
 
+    /*************************************************************************/
+
     /*
      * Test case derived from original example in Smallrye OpenAPI issue #201.
      *
@@ -229,6 +233,8 @@ public class ResourceParameterTests extends OpenApiDataObjectScannerTestBase {
         }
     }
 
+    /*************************************************************************/
+
     /*
      * Test case derived for Smallrye OpenAPI issue #233.
      *
@@ -275,6 +281,45 @@ public class ResourceParameterTests extends OpenApiDataObjectScannerTestBase {
         @POST
         public OffsetTime toUTC(@QueryParam("local") LocalTime local, @QueryParam("offsetId") String offsetId) {
             return OffsetTime.of(local, ZoneOffset.of(offsetId));
+        }
+    }
+
+    /*************************************************************************/
+
+    /*
+     * Test case derived from original example in SmallRye OpenAPI issue #237.
+     *
+     * https://github.com/smallrye/smallrye-open-api/issues/237
+     *
+     */
+    @Test
+    public void testTypeVariableResponse() throws IOException, JSONException {
+        Index index = indexOf(TypeVariableResponseTestResource.class,
+                TypeVariableResponseTestResource.Dto.class);
+        OpenApiConfig config = emptyConfig();
+        IndexView filtered = new FilteredIndexView(index, config);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, filtered);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals("resource.parameters.type-variable.json", result);
+    }
+
+    @Path("/variable-types")
+    @SuppressWarnings("unused")
+    static class TypeVariableResponseTestResource<TEST extends TypeVariableResponseTestResource.Dto> {
+        static class Dto {
+            String id;
+        }
+
+        @GET
+        public List<TEST> getAll() {
+            return null;
+        }
+
+        @GET
+        @Path("{id}")
+        public TEST getOne(@PathParam("id") String id) {
+            return null;
         }
     }
 }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.type-variable.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.type-variable.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/variable-types": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Dto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/variable-types/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dto"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Dto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #237 

This change allows the `TypeVariable` to pass through, avoiding the NPE. A more involved enhancement in the future should consider the type variable declared in the JAX-RS resource class hierarchy. That information is not currently available during type resolution of the schema model.