### PR TITLE
Add Extension parsing method to AnnotationScannerExtension

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -117,7 +117,6 @@
             <scope>test</scope>
             <type>pom</type>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -131,13 +130,36 @@
                         <SMALLRYE_MP_CONFIG_PROP>1234</SMALLRYE_MP_CONFIG_PROP>
                     </environmentVariables>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <!--
-                    TODO: Confirm if these are necessary
-                    <enableAssertions>true</enableAssertions>
-                    <argLine>-Xmx512m</argLine>
-                    <forkMode>once</forkMode>
-                    -->
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/CustomExtensionParsingTests.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jackson-exclusion-tests</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/CustomExtensionParsingTests.java</include>
+                            </includes>
+                            <systemProperties>
+                                <classpath.jackson.excluded>true</classpath.jackson.excluded>
+                            </systemProperties>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-core</classpathDependencyExclude>
+                                <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
+                                <classpathDependencyExclude>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/io/JsonUtil.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/io/JsonUtil.java
@@ -17,8 +17,16 @@
 package io.smallrye.openapi.runtime.io;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -30,6 +38,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public final class JsonUtil {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final JsonNodeFactory factory = JsonNodeFactory.instance;
 
     public static ObjectNode objectNode() {
@@ -192,5 +201,112 @@ public final class JsonUtil {
 
     private static boolean isIntegerValue(BigDecimal bd) {
         return bd.signum() == 0 || bd.scale() <= 0 || bd.stripTrailingZeros().scale() <= 0;
+    }
+
+    /**
+     * Reads the node as a Java object. This is typically expected to be a literal of
+     * some sort, as in the case of default values and examples. The node may be anything
+     * from a string to a javascript object.
+     * 
+     * @param node
+     */
+    public static Object readObject(JsonNode node) {
+        if (node == null) {
+            return null;
+        }
+        if (node.isBigDecimal()) {
+            return new BigDecimal(node.asText());
+        }
+        if (node.isBigInteger()) {
+            return new BigInteger(node.asText());
+        }
+        if (node.isBoolean()) {
+            return node.asBoolean();
+        }
+        if (node.isDouble()) {
+            return node.asDouble();
+        }
+        if (node.isFloat()) {
+            return node.asDouble();
+        }
+        if (node.isInt()) {
+            return node.asInt();
+        }
+        if (node.isLong()) {
+            return node.asLong();
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        if (node.isArray()) {
+            ArrayNode arrayNode = (ArrayNode) node;
+            List<Object> items = new ArrayList<>();
+            for (JsonNode itemNode : arrayNode) {
+                items.add(readObject(itemNode));
+            }
+            return items;
+        }
+        if (node.isObject()) {
+            Map<String, Object> items = new LinkedHashMap<>();
+            for (Iterator<Entry<String, JsonNode>> fields = node.fields(); fields.hasNext();) {
+                Entry<String, JsonNode> field = fields.next();
+                String fieldName = field.getKey();
+                Object fieldValue = readObject(field.getValue());
+                items.put(fieldName, fieldValue);
+            }
+            return items;
+        }
+        return null;
+    }
+
+    /**
+     * Parses an extension value. The value may be:
+     *
+     * - JSON object - starts with {
+     * - JSON array - starts with [
+     * - number
+     * - boolean
+     * - string
+     *
+     * @param value
+     */
+    public static Object parseValue(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        value = value.trim();
+
+        if ("true".equals(value) || "false".equals(value)) {
+            return Boolean.valueOf(value);
+        }
+
+        switch (value.charAt(0)) {
+            case '{': /* JSON Object */
+            case '[': /* JSON Array */
+            case '-': /* JSON Negative Number */
+            case '0': /* JSON Numbers */
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                try {
+                    com.fasterxml.jackson.databind.JsonNode node = MAPPER.readTree(value);
+                    return readObject(node);
+                } catch (Exception e) {
+                    // TODO log the error
+                    break;
+                }
+            default:
+                break;
+        }
+
+        // JSON String
+        return value;
     }
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java
@@ -16,10 +16,10 @@
 
 package io.smallrye.openapi.runtime.io;
 
+import static io.smallrye.openapi.runtime.io.JsonUtil.readObject;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.ParseException;
@@ -28,7 +28,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.Extensible;
@@ -1355,62 +1354,6 @@ public class OpenApiParser {
             rval.put(fieldName, value);
         }
         return rval;
-    }
-
-    /**
-     * Reads the node as a Java object. This is typically expected to be a literal of
-     * some sort, as in the case of default values and examples. The node may be anything
-     * from a string to a javascript object.
-     * 
-     * @param node
-     */
-    private Object readObject(JsonNode node) {
-        if (node == null) {
-            return null;
-        }
-        if (node.isBigDecimal()) {
-            return new BigDecimal(node.asText());
-        }
-        if (node.isBigInteger()) {
-            return new BigInteger(node.asText());
-        }
-        if (node.isBoolean()) {
-            return node.asBoolean();
-        }
-        if (node.isDouble()) {
-            return node.asDouble();
-        }
-        if (node.isFloat()) {
-            return node.asDouble();
-        }
-        if (node.isInt()) {
-            return node.asInt();
-        }
-        if (node.isLong()) {
-            return node.asLong();
-        }
-        if (node.isTextual()) {
-            return node.asText();
-        }
-        if (node.isArray()) {
-            ArrayNode arrayNode = (ArrayNode) node;
-            List<Object> items = new ArrayList<>();
-            for (JsonNode itemNode : arrayNode) {
-                items.add(readObject(itemNode));
-            }
-            return items;
-        }
-        if (node.isObject()) {
-            Map<String, Object> items = new LinkedHashMap<>();
-            for (Iterator<Entry<String, JsonNode>> fields = node.fields(); fields.hasNext();) {
-                Entry<String, JsonNode> field = fields.next();
-                String fieldName = field.getKey();
-                Object fieldValue = readObject(field.getValue());
-                items.put(fieldName, fieldValue);
-            }
-            return items;
-        }
-        return null;
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
@@ -47,4 +47,19 @@ public interface AnnotationScannerExtension {
         return false;
     }
 
+    /**
+     * Parses an OpenAPI Extension value. The value may be:
+     *
+     * - JSON object - starts with '{'
+     * - JSON array - starts with '['
+     * - number
+     * - boolean
+     * - string
+     *
+     * @param key the name of the extension property
+     * @param value the string value of the extension
+     */
+    default Object parseExtension(String key, String value) {
+        return io.smallrye.openapi.runtime.io.JsonUtil.parseValue(value);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/CustomExtensionParsingTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/CustomExtensionParsingTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.smallrye.openapi.runtime.scanner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.callbacks.Callback;
+import org.eclipse.microprofile.openapi.annotations.callbacks.CallbackOperation;
+import org.eclipse.microprofile.openapi.annotations.callbacks.Callbacks;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * Special tests using a custom {@link AnnotationScannerExtension#parseExtension(String, String)}
+ * implementation. The tests in this class will only run when system property `classpath.jackson.excluded`
+ * is set to `true`. In that case, the Jackson dependencies should not be present on the class path.
+ * 
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ */
+@RunWith(CustomExtensionParsingTests.JacksonExcludedRunner.class)
+public class CustomExtensionParsingTests {
+
+    public static class JacksonExcludedRunner extends BlockJUnit4ClassRunner {
+
+        public JacksonExcludedRunner(Class<?> testClass) throws InitializationError {
+            super(testClass);
+        }
+
+        @Override
+        protected boolean isIgnored(FrameworkMethod child) {
+            return !Boolean.valueOf(System.getProperty("classpath.jackson.excluded"));
+        }
+    }
+
+    @Test
+    public void testDefaultExtensionParseThrowsJacksonNotFound() {
+        Index index = IndexScannerTestBase.indexOf(ExtensionParsingTestResource.class);
+        NoClassDefFoundError err = assertThrows(NoClassDefFoundError.class,
+                () -> new OpenApiAnnotationScanner(IndexScannerTestBase.emptyConfig(), index).scan());
+        assertTrue(err.getMessage().contains("jackson"));
+    }
+
+    @Test
+    public void testCustomAnnotationScannerExtension() {
+        Index index = IndexScannerTestBase.indexOf(ExtensionParsingTestResource.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(IndexScannerTestBase.emptyConfig(), index,
+                Arrays.asList(new AnnotationScannerExtension() {
+                    @Override
+                    public Object parseExtension(String name, String value) {
+                        /*
+                         * "parsing" consists of creating a singleton map with the
+                         * extension name as the key and the unparsed value as the value
+                         */
+                        return Collections.singletonMap(name, value);
+                    }
+                }));
+
+        OpenAPI result = scanner.scan();
+        org.eclipse.microprofile.openapi.models.callbacks.Callback cb;
+        cb = result.getPaths().getPathItem("/ext-custom").getPOST().getCallbacks().get("extendedCallback");
+        Map<String, Object> ext = cb.getPathItem("http://localhost:8080/resources/ext-callback").getGET().getExtensions();
+        assertEquals(4, ext.size());
+        assertEquals(Collections.singletonMap("x-object", "{ \"key\":\"value\" }"), ext.get("x-object"));
+        assertEquals("{ \"key\":\"value\" }", ext.get("x-object-unparsed"));
+        assertEquals(Collections.singletonMap("x-array", "[ \"val1\",\"val2\" ]"), ext.get("x-array"));
+        assertEquals("true", ext.get("x-booltrue"));
+    }
+
+    /* Test models and resources below. */
+
+    @Path("/ext-custom")
+    static class ExtensionParsingTestResource {
+        @POST
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.TEXT_PLAIN)
+        @Callbacks({
+                @Callback(name = "extendedCallback", callbackUrlExpression = "http://localhost:8080/resources/ext-callback", operations = @CallbackOperation(summary = "Get results", extensions = {
+                        @Extension(name = "x-object", value = "{ \"key\":\"value\" }", parseValue = true),
+                        @Extension(name = "x-object-unparsed", value = "{ \"key\":\"value\" }"),
+                        @Extension(name = "x-array", value = "[ \"val1\",\"val2\" ]", parseValue = true),
+                        @Extension(name = "x-booltrue", value = "true", parseValue = false)
+                }, method = "get", responses = @APIResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.ARRAY, implementation = String.class)))))
+        })
+        public String get(String data) {
+            return data;
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
@@ -15,7 +15,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 public class ExceptionMapperScanTests extends IndexScannerTestBase {
 
@@ -35,7 +35,8 @@ public class ExceptionMapperScanTests extends IndexScannerTestBase {
 
     @Test
     public void testMethodAnnotationOverrideExceptionMapper() throws IOException, JSONException {
-        test("responses.exception-mapper-overridden-by-method-annotation-generation.json", TestResource2.class, ExceptionHandler1.class, ExceptionHandler2.class);
+        test("responses.exception-mapper-overridden-by-method-annotation-generation.json", TestResource2.class,
+                ExceptionHandler1.class, ExceptionHandler2.class);
     }
 
     @Path("/resources")
@@ -68,7 +69,6 @@ public class ExceptionMapperScanTests extends IndexScannerTestBase {
         }
 
     }
-
 
     @Provider
     static class ExceptionHandler1 implements ExceptionMapper<WebApplicationException> {

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExtensionParsingTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ExtensionParsingTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.smallrye.openapi.runtime.scanner;
+
+import java.io.IOException;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.callbacks.Callback;
+import org.eclipse.microprofile.openapi.annotations.callbacks.CallbackOperation;
+import org.eclipse.microprofile.openapi.annotations.callbacks.Callbacks;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.json.JSONException;
+import org.junit.Test;
+
+/**
+ * @author Michael Edgar {@literal <michael@xlate.io>}
+ * 
+ */
+public class ExtensionParsingTests extends IndexScannerTestBase {
+
+    @Test
+    public void testAllExpectedParseTypes() throws IOException, JSONException {
+        assertJsonEquals("extensions.parsing.expected.json",
+                ExtensionParsingTestResource.class);
+    }
+
+    /* Test models and resources below. */
+
+    @Path("/ext")
+    static class ExtensionParsingTestResource {
+        @POST
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.TEXT_PLAIN)
+        @Callbacks({
+                @Callback(name = "extendedCallback", callbackUrlExpression = "http://localhost:8080/resources/ext-callback", operations = @CallbackOperation(summary = "Get results", extensions = {
+                        @Extension(name = "x-object", value = "{ \"key\":\"value\" }", parseValue = true),
+                        @Extension(name = "x-object-unparsed", value = "{ \"key\":\"value\" }"),
+                        @Extension(name = "x-array", value = "[ \"val1\",\"val2\" ]", parseValue = true),
+                        @Extension(name = "x-booltrue", value = "true", parseValue = true),
+                        @Extension(name = "x-boolfalse", value = "false", parseValue = true),
+                        @Extension(name = "x-number", value = "42", parseValue = true),
+                        @Extension(name = "x-number-sci", value = "42e55", parseValue = true),
+                        @Extension(name = "x-positive-number-remains-string", value = "+42", parseValue = true),
+                        @Extension(name = "x-negative-number", value = "-42", parseValue = true),
+                        @Extension(name = "x-unparsable-number", value = "-Not.A.Number", parseValue = true)
+                }, method = "get", responses = @APIResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.ARRAY, implementation = String.class)))))
+        })
+        public String get(String data) {
+            return data;
+        }
+    }
+}

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/extensions.parsing.expected.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/extensions.parsing.expected.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/ext": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "callbacks": {
+          "extendedCallback": {
+            "http://localhost:8080/resources/ext-callback": {
+              "get": {
+                "summary": "Get results",
+                "responses": {
+                  "200": {
+                    "description": "successful operation",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "x-object": {
+                  "key": "value"
+                },
+                "x-object-unparsed": "{ \"key\":\"value\" }",
+                "x-array": [
+                  "val1",
+                  "val2"
+                ],
+                "x-booltrue": true,
+                "x-boolfalse": false,
+                "x-number": 42,
+                "x-number-sci": 4.2E56,
+                "x-positive-number-remains-string": "+42",
+                "x-negative-number": -42,
+                "x-unparsable-number": "-Not.A.Number"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #245 

- Add tests to require that Jackson library is not necessary for
annotation scanning when providing custom implementation of
`AnnotationScannerExtension#parseExtension`
- Refactor `ExceptionMapper` search to eliminate Sonar "bugs"
- Replace TestNG `@Test` annotation with JUnit annotation in `ExceptionMapperScanTests`