### PR TITLE
Check for null schema when generating default response

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -732,7 +732,6 @@ public class OpenApiAnnotationScanner {
 
         // Process @APIResponse annotations
         /////////////////////////////////////////
-        APIResponses responses = null;
         List<AnnotationInstance> apiResponseAnnotations = JandexUtil.getRepeatableAnnotation(method,
                 OpenApiConstants.DOTNAME_API_RESPONSE, OpenApiConstants.DOTNAME_API_RESPONSES);
         for (AnnotationInstance annotation : apiResponseAnnotations) {
@@ -1036,7 +1035,7 @@ public class OpenApiAnnotationScanner {
                     produces = OpenApiConstants.DEFAULT_MEDIA_TYPES.get();
                 }
 
-                if (schema.getNullable() == null && TypeUtil.isOptional(returnType)) {
+                if (schema != null && schema.getNullable() == null && TypeUtil.isOptional(returnType)) {
                     schema.setNullable(Boolean.TRUE);
                 }
 

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
@@ -322,4 +322,35 @@ public class ResourceParameterTests extends OpenApiDataObjectScannerTestBase {
             return null;
         }
     }
+
+    /*************************************************************************/
+
+    /*
+     * Test case derived from original example in SmallRye OpenAPI issue #248.
+     *
+     * https://github.com/smallrye/smallrye-open-api/issues/248
+     *
+     */
+    @Test
+    public void testResponseTypeUnindexed() throws IOException, JSONException {
+        // Index is intentionally missing ResponseTypeUnindexedTestResource$ThirdPartyType
+        Index index = indexOf(ResponseTypeUnindexedTestResource.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals("responses.unknown-type.empty-schema.json", result);
+    }
+
+    @Path("/unindexed")
+    static class ResponseTypeUnindexedTestResource {
+        // This type will not be in the Jandex index, nor does it implement Map or List.
+        static class ThirdPartyType {
+        }
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public ThirdPartyType hello() {
+            return null;
+        }
+    }
 }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.unknown-type.empty-schema.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.unknown-type.empty-schema.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/unindexed": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #248 