### PR TITLE
Make ShrinkWrap dependency optional

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -66,6 +66,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Provided Dependencies -->

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -14,6 +14,10 @@
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+        </dependency>
 
         <!-- SmallRye Config -->
         <dependency>


### PR DESCRIPTION
This gets rid of ShrinkWrap as a hard dependency on the smallrye-open-api implementation

Fixes #246