### PR TITLE
Handle custom `Converter`s returning "".

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -230,7 +230,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      * getConfig().getOptionalValue(key) can return "" if optional {@link Converter}s are used. Enforce a null value if
      * we get an empty string back.
      */
-    private String getStringConfigValue(String key) {
+    String getStringConfigValue(String key) {
         return getConfig().getOptionalValue(key, String.class).map(v -> "".equals(v.trim()) ? null : v).orElse(null);
     }
 

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -231,7 +231,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      * we get an empty string back.
      */
     private String getStringConfigValue(String key) {
-        return getConfig().getOptionalValue(key, String.class).map(v -> "".equals(v) ? null : v).orElse(null);
+        return getConfig().getOptionalValue(key, String.class).map(v -> "".equals(v.trim()) ? null : v).orElse(null);
     }
 
     private static Set<String> asCsvSet(String items) {

--- a/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/implementation/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -69,7 +69,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public String modelReader() {
         if (modelReader == null) {
-            modelReader = getConfig().getOptionalValue(OASConfig.MODEL_READER, String.class).orElse(null);
+            modelReader = getStringConfigValue(OASConfig.MODEL_READER);
         }
         return modelReader;
     }
@@ -80,7 +80,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public String filter() {
         if (filter == null) {
-            filter = getConfig().getOptionalValue(OASConfig.FILTER, String.class).orElse(null);
+            filter = getStringConfigValue(OASConfig.FILTER);
         }
         return filter;
     }
@@ -102,7 +102,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public Set<String> scanPackages() {
         if (scanPackages == null) {
-            String packages = getConfig().getOptionalValue(OASConfig.SCAN_PACKAGES, String.class).orElse(null);
+            String packages = getStringConfigValue(OASConfig.SCAN_PACKAGES);
             scanPackages = asCsvSet(packages);
         }
         return scanPackages;
@@ -114,7 +114,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public Set<String> scanClasses() {
         if (scanClasses == null) {
-            String classes = getConfig().getOptionalValue(OASConfig.SCAN_CLASSES, String.class).orElse(null);
+            String classes = getStringConfigValue(OASConfig.SCAN_CLASSES);
             scanClasses = asCsvSet(classes);
         }
         return scanClasses;
@@ -126,7 +126,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public Set<String> scanExcludePackages() {
         if (scanExcludePackages == null) {
-            String packages = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_PACKAGES, String.class).orElse(null);
+            String packages = getStringConfigValue(OASConfig.SCAN_EXCLUDE_PACKAGES);
             scanExcludePackages = asCsvSet(packages);
             scanExcludePackages.addAll(OpenApiConstants.NEVER_SCAN_PACKAGES);
         }
@@ -139,7 +139,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public Set<String> scanExcludeClasses() {
         if (scanExcludeClasses == null) {
-            String classes = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_CLASSES, String.class).orElse(null);
+            String classes = getStringConfigValue(OASConfig.SCAN_EXCLUDE_CLASSES);
             scanExcludeClasses = asCsvSet(classes);
             scanExcludeClasses.addAll(OpenApiConstants.NEVER_SCAN_CLASSES);
         }
@@ -152,7 +152,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public Set<String> servers() {
         if (servers == null) {
-            String theServers = getConfig().getOptionalValue(OASConfig.SERVERS, String.class).orElse(null);
+            String theServers = getStringConfigValue(OASConfig.SERVERS);
             servers = asCsvSet(theServers);
         }
         return servers;
@@ -163,7 +163,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      */
     @Override
     public Set<String> pathServers(String path) {
-        String pathServers = getConfig().getOptionalValue(OASConfig.SERVERS_PATH_PREFIX + path, String.class).orElse(null);
+        String pathServers = getStringConfigValue(OASConfig.SERVERS_PATH_PREFIX + path);
         return asCsvSet(pathServers);
     }
 
@@ -172,8 +172,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      */
     @Override
     public Set<String> operationServers(String operationId) {
-        String opServers = getConfig().getOptionalValue(OASConfig.SERVERS_OPERATION_PREFIX + operationId, String.class)
-                .orElse(null);
+        String opServers = getStringConfigValue(OASConfig.SERVERS_OPERATION_PREFIX + operationId);
         return asCsvSet(opServers);
     }
 
@@ -195,7 +194,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public Set<String> scanDependenciesJars() {
         if (scanDependenciesJars == null) {
-            String classes = getConfig().getOptionalValue(OpenApiConstants.SCAN_DEPENDENCIES_JARS, String.class).orElse(null);
+            String classes = getStringConfigValue(OpenApiConstants.SCAN_DEPENDENCIES_JARS);
             scanDependenciesJars = asCsvSet(classes);
         }
         return scanDependenciesJars;
@@ -213,8 +212,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     @Override
     public String customSchemaRegistryClass() {
         if (customSchemaRegistryClass == null) {
-            customSchemaRegistryClass = getConfig()
-                    .getOptionalValue(OpenApiConstants.CUSTOM_SCHEMA_REGISTRY_CLASS, String.class).orElse(null);
+            customSchemaRegistryClass = getStringConfigValue(OpenApiConstants.CUSTOM_SCHEMA_REGISTRY_CLASS);
         }
         return customSchemaRegistryClass;
     }
@@ -226,6 +224,14 @@ public class OpenApiConfigImpl implements OpenApiConfig {
                     .orElse(false);
         }
         return applicationPathDisable;
+    }
+
+    /**
+     * getConfig().getOptionalValue(key) can return "" if optional {@link Converter}s are used. Enforce a null value if
+     * we get an empty string back.
+     */
+    private String getStringConfigValue(String key) {
+        return getConfig().getOptionalValue(key, String.class).map(v -> "".equals(v) ? null : v).orElse(null);
     }
 
     private static Set<String> asCsvSet(String items) {

--- a/implementation/src/test/java/io/smallrye/openapi/api/OpenApiConfigImplTest.java
+++ b/implementation/src/test/java/io/smallrye/openapi/api/OpenApiConfigImplTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.OASConfig;
+import org.junit.Test;
+
+public class OpenApiConfigImplTest {
+
+    private static final String TEST_PROPERTY = OASConfig.EXTENSIONS_PREFIX + "OpenApiConfigImplTest";
+
+    @Test
+    public void testGetStringConfigValueMissingIsNull() {
+        System.clearProperty(TEST_PROPERTY);
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfigImpl oaiConfig = new OpenApiConfigImpl(config);
+        assertNull(oaiConfig.getStringConfigValue(TEST_PROPERTY));
+    }
+
+    @Test
+    public void testGetStringConfigValueBlankIsNull() {
+        System.setProperty(TEST_PROPERTY, "\t \n\r");
+
+        try {
+            Config config = ConfigProvider.getConfig();
+            OpenApiConfigImpl oaiConfig = new OpenApiConfigImpl(config);
+            // White-space only value is treated as absent value
+            assertNull(oaiConfig.getStringConfigValue(TEST_PROPERTY));
+        } finally {
+            System.clearProperty(TEST_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testGetStringConfigValuePresent() {
+        System.setProperty(TEST_PROPERTY, "  VALUE  \t");
+
+        try {
+            Config config = ConfigProvider.getConfig();
+            OpenApiConfigImpl oaiConfig = new OpenApiConfigImpl(config);
+            // Trim is only used to determine if the value is blank. Full value returned for app use
+            assertEquals("  VALUE  \t", oaiConfig.getStringConfigValue(TEST_PROPERTY));
+        } finally {
+            System.clearProperty(TEST_PROPERTY);
+        }
+    }
+
+}


### PR DESCRIPTION
Fix for #258 

Custom `Converter<String>`s registered by users can cause errors when starting.
https://github.com/smallrye/smallrye-config/blob/1.6.1/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java#L90 _can_ pass in an empty string if `OpenApiConstants.CUSTOM_SCHEMA_REGISTRY_CLASS` is not specified. In this case, the Converter (correctly) returns null back to the caller and the caller will then try to load a class named `""`.
We should validate the empty string on return and treat it as `null`