### PR TITLE
Check for null schema when generating default response

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -665,7 +665,6 @@ public class OpenApiAnnotationScanner {
 
         // Process @APIResponse annotations
         /////////////////////////////////////////
-        APIResponses responses = null;
         List<AnnotationInstance> apiResponseAnnotations = JandexUtil.getRepeatableAnnotation(method,
                 OpenApiConstants.DOTNAME_API_RESPONSE, OpenApiConstants.DOTNAME_API_RESPONSES);
         for (AnnotationInstance annotation : apiResponseAnnotations) {
@@ -931,7 +930,7 @@ public class OpenApiAnnotationScanner {
                     produces = OpenApiConstants.DEFAULT_MEDIA_TYPES.get();
                 }
 
-                if (schema.getNullable() == null && TypeUtil.isOptional(returnType)) {
+                if (schema != null && schema.getNullable() == null && TypeUtil.isOptional(returnType)) {
                     schema.setNullable(Boolean.TRUE);
                 }
 

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -665,6 +665,7 @@ public class OpenApiAnnotationScanner {
 
         // Process @APIResponse annotations
         /////////////////////////////////////////
+        APIResponses responses = null;
         List<AnnotationInstance> apiResponseAnnotations = JandexUtil.getRepeatableAnnotation(method,
                 OpenApiConstants.DOTNAME_API_RESPONSE, OpenApiConstants.DOTNAME_API_RESPONSES);
         for (AnnotationInstance annotation : apiResponseAnnotations) {

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
@@ -23,6 +23,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -220,6 +221,37 @@ public class ResourceParameterTests extends OpenApiDataObjectScannerTestBase {
         @Produces("application/json")
         public Response doPost(GreetingMessage message) {
             return Response.created(URI.create("http://example.com")).build();
+        }
+    }
+
+    /*************************************************************************/
+
+    /*
+     * Test case derived from original example in SmallRye OpenAPI issue #248.
+     *
+     * https://github.com/smallrye/smallrye-open-api/issues/248
+     *
+     */
+    @Test
+    public void testResponseTypeUnindexed() throws IOException, JSONException {
+        // Index is intentionally missing ResponseTypeUnindexedTestResource$ThirdPartyType
+        Index index = indexOf(ResponseTypeUnindexedTestResource.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals("responses.unknown-type.empty-schema.json", result);
+    }
+
+    @Path("/unindexed")
+    static class ResponseTypeUnindexedTestResource {
+        // This type will not be in the Jandex index, nor does it implement Map or List.
+        static class ThirdPartyType {
+        }
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public ThirdPartyType hello() {
+            return null;
         }
     }
 }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.unknown-type.empty-schema.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.unknown-type.empty-schema.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/unindexed": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Backporting to 1.1.x for WildFly