### PR TITLE
Small pom cleanup

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -72,17 +72,13 @@
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Provided Dependencies -->
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
@@ -17,8 +17,6 @@ package io.smallrye.openapi.runtime.scanner.dataobject;
 
 import java.util.Collection;
 
-import javax.validation.constraints.NotNull;
-
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -37,19 +35,23 @@ public class AugmentedIndexView implements IndexView {
 
     private final IndexView index;
 
-    public AugmentedIndexView(@NotNull IndexView index) {
+    public AugmentedIndexView(IndexView index) {
+        validateInput(index);
         this.index = index;
     }
 
-    public ClassInfo getClass(@NotNull Type type) {
+    public ClassInfo getClass(Type type) {
+        validateInput(type);
         return index.getClassByName(TypeUtil.getName(type));
     }
 
-    public boolean containsClass(@NotNull Type type) {
+    public boolean containsClass(Type type) {
+        validateInput(type);
         return getClass(type) != null;
     }
 
-    public ClassInfo getClass(@NotNull Class<?> klazz) {
+    public ClassInfo getClass(Class<?> klazz) {
+        validateInput(klazz);
         return index.getClassByName(DotName.createSimple(klazz.getName()));
     }
 
@@ -59,32 +61,43 @@ public class AugmentedIndexView implements IndexView {
     }
 
     @Override
-    public ClassInfo getClassByName(@NotNull DotName className) {
+    public ClassInfo getClassByName(DotName className) {
+        validateInput(className);
         return index.getClassByName(className);
     }
 
     @Override
-    public Collection<ClassInfo> getKnownDirectSubclasses(@NotNull DotName className) {
+    public Collection<ClassInfo> getKnownDirectSubclasses(DotName className) {
+        validateInput(className);
         return index.getKnownDirectSubclasses(className);
     }
 
     @Override
-    public Collection<ClassInfo> getAllKnownSubclasses(@NotNull DotName className) {
+    public Collection<ClassInfo> getAllKnownSubclasses(DotName className) {
+        validateInput(className);
         return index.getAllKnownSubclasses(className);
     }
 
     @Override
-    public Collection<ClassInfo> getKnownDirectImplementors(@NotNull DotName className) {
+    public Collection<ClassInfo> getKnownDirectImplementors(DotName className) {
+        validateInput(className);
         return index.getKnownDirectSubclasses(className);
     }
 
     @Override
-    public Collection<ClassInfo> getAllKnownImplementors(@NotNull DotName interfaceName) {
+    public Collection<ClassInfo> getAllKnownImplementors(DotName interfaceName) {
+        validateInput(interfaceName);
         return index.getAllKnownImplementors(interfaceName);
     }
 
     @Override
-    public Collection<AnnotationInstance> getAnnotations(@NotNull DotName annotationName) {
+    public Collection<AnnotationInstance> getAnnotations(DotName annotationName) {
+        validateInput(annotationName);
         return index.getAnnotations(annotationName);
+    }
+
+    private <T> void validateInput(T input) {
+        if (input == null)
+            throw new RuntimeException("Input parameter can not be null");
     }
 }

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java
@@ -8,8 +8,6 @@ import static org.jboss.jandex.DotName.createComponentized;
 
 import java.math.BigDecimal;
 
-import javax.validation.groups.Default;
-
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.jboss.jandex.AnnotationInstance;
@@ -78,7 +76,7 @@ public class BeanValidationScanner {
      * Each of the constraints (defined in javax.validation.constraints) will
      * apply to the schema based on the schema's type.
      *
-     * When a {@link javax.validation.constraints.NotNull @NotNull} constraint
+     * When a bean validation @NotNull constraint
      * applies to the schema, the provided {@link RequirementHandler} will be
      * called in order for the component calling this method to determine if and
      * how to apply the requirement. E.g. a required Schema is communicated
@@ -94,8 +92,7 @@ public class BeanValidationScanner {
      *        schema
      * @param handler
      *        the handler to be called when a
-     *        {@link javax.validation.constraints.NotNull @NotNull}
-     *        constraint is encountered.
+     *        bean validation @NotNull constraint is encountered.
      */
     public static void applyConstraints(AnnotationTarget target,
             Schema schema,

--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/DataObjectDeque.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/DataObjectDeque.java
@@ -19,8 +19,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 
-import javax.validation.constraints.NotNull;
-
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
@@ -98,9 +96,11 @@ public class DataObjectDeque {
      * @param schema the schema corresponding to this position
      */
     public void push(AnnotationTarget annotationTarget,
-            @NotNull PathEntry parentPathEntry,
-            @NotNull Type type,
-            @NotNull Schema schema) {
+            PathEntry parentPathEntry,
+            Type type,
+            Schema schema) {
+
+        validateInput(parentPathEntry, type, schema);
         PathEntry entry = leafNode(parentPathEntry, annotationTarget, type, schema);
         ClassInfo klazzInfo = entry.getClazz();
         if (parentPathEntry.hasParent(entry)) {
@@ -161,9 +161,10 @@ public class DataObjectDeque {
 
         private PathEntry(PathEntry enclosing,
                 AnnotationTarget annotationTarget,
-                @NotNull ClassInfo clazz,
-                @NotNull Type clazzType,
-                @NotNull Schema schema) {
+                ClassInfo clazz,
+                Type clazzType,
+                Schema schema) {
+            validateInput(clazz, clazzType, schema);
             this.enclosing = enclosing;
             this.annotationTarget = annotationTarget;
             this.clazz = clazz;
@@ -257,6 +258,12 @@ public class DataObjectDeque {
                     ", schema=" + schema +
                     ", parent=" + (enclosing != null ? enclosing.toStringWithGraph() : "<root>") + "}";
         }
+    }
 
+    private static <T> void validateInput(T... input) {
+        for (T t : input) {
+            if (t == null)
+                throw new RuntimeException("Input parameter can not be null");
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>
-        <version.org.jboss.resteasy>4.5.1.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>4.5.2.Final</version.org.jboss.resteasy>
 
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/tck/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../tck/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
         <version.jakarta.validation.api>2.0.2</version.jakarta.validation.api>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>
         <version.org.jboss.resteasy>4.5.1.Final</version.org.jboss.resteasy>
 
@@ -112,6 +111,7 @@
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>
                 <version>${version.io.smallrye.smallrye-config}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- Specifications -->
@@ -119,6 +119,7 @@
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>
                 <version>${version.jakarta.validation.api}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- Third Party Libraries -->
@@ -138,24 +139,16 @@
                 <version>${version.com.fasterxml.jackson}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.shrinkwrap</groupId>
-                <artifactId>shrinkwrap-api</artifactId>
-                <version>${version.org.jboss.shrinkwrap}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap</groupId>
-                <artifactId>shrinkwrap-impl-base</artifactId>
-                <version>${version.org.jboss.shrinkwrap}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${version.org.hamcrest}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>java-hamcrest</artifactId>
                 <version>${version.org.hamcrest.java-hamcrest}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -13,16 +13,19 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- SmallRye Config -->
         <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Test Only -->


### PR DESCRIPTION
Small pom clean up. Biggest change is the removal of the dependency on bean validation (jakarta.validation) that can not be guaranteed as it's not part of MicroProfile.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>