### PR TITLE
Implement scan of APIResponseSchema and RequestBodySchema annotations

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -82,7 +82,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/requestbody/RequestBodyConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/requestbody/RequestBodyConstant.java
@@ -1,6 +1,7 @@
 package io.smallrye.openapi.runtime.io.requestbody;
 
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBodySchema;
 import org.jboss.jandex.DotName;
 
 /**
@@ -15,6 +16,7 @@ import org.jboss.jandex.DotName;
 public class RequestBodyConstant {
 
     static final DotName DOTNAME_REQUESTBODY = DotName.createSimple(RequestBody.class.getName());
+    static final DotName DOTNAME_REQUEST_BODY_SCHEMA = DotName.createSimple(RequestBodySchema.class.getName());
 
     static final String PROP_NAME = "name";
     static final String PROP_REQUIRED = "required";
@@ -22,6 +24,8 @@ public class RequestBodyConstant {
     static final String PROP_DESCRIPTION = "description";
     static final String PROP_REQUEST_BODY = "requestBody";
     static final String PROP_CONTENT = "content";
+
+    static final String PROP_VALUE = "value";
 
     private RequestBodyConstant() {
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/requestbody/RequestBodyReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/requestbody/RequestBodyReader.java
@@ -130,6 +130,13 @@ public class RequestBodyReader {
         return requestBody;
     }
 
+    /**
+     * Reads a RequestBodySchema annotation into a model.
+     * 
+     * @param context the scanning context
+     * @param annotation {@literal @}RequestBodySchema annotation
+     * @return RequestBody model
+     */
     public static RequestBody readRequestBodySchema(final AnnotationScannerContext context,
             AnnotationInstance annotation) {
         if (annotation == null || CurrentScannerInfo.getCurrentConsumes() == null) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/requestbody/RequestBodyReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/requestbody/RequestBodyReader.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.microprofile.openapi.models.media.Content;
+import org.eclipse.microprofile.openapi.models.media.MediaType;
 import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -13,14 +15,19 @@ import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import io.smallrye.openapi.api.models.media.ContentImpl;
+import io.smallrye.openapi.api.models.media.MediaTypeImpl;
 import io.smallrye.openapi.api.models.parameters.RequestBodyImpl;
 import io.smallrye.openapi.runtime.io.ContentDirection;
+import io.smallrye.openapi.runtime.io.CurrentScannerInfo;
 import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.Referenceable;
 import io.smallrye.openapi.runtime.io.content.ContentReader;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
+import io.smallrye.openapi.runtime.io.schema.SchemaFactory;
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
+import io.smallrye.openapi.runtime.util.TypeUtil;
 
 /**
  * Reading the RequestBody annotation
@@ -123,6 +130,29 @@ public class RequestBodyReader {
         return requestBody;
     }
 
+    public static RequestBody readRequestBodySchema(final AnnotationScannerContext context,
+            AnnotationInstance annotation) {
+        if (annotation == null || CurrentScannerInfo.getCurrentConsumes() == null) {
+            // Only generate the RequestBody if the endpoint declares an @Consumes media type
+            return null;
+        }
+        LOG.debug("Processing a single @RequestBodySchema annotation.");
+        Content content = new ContentImpl();
+
+        for (String mediaType : CurrentScannerInfo.getCurrentConsumes()) {
+            MediaType type = new MediaTypeImpl();
+            type.setSchema(SchemaFactory.typeToSchema(context.getIndex(),
+                    JandexUtil.value(annotation, RequestBodyConstant.PROP_VALUE),
+                    context.getExtensions()));
+            content.addMediaType(mediaType, type);
+        }
+
+        RequestBody requestBody = new RequestBodyImpl();
+        requestBody.setContent(content);
+
+        return requestBody;
+    }
+
     /**
      * Reads a {@link RequestBody} OpenAPI node.
      * 
@@ -148,4 +178,7 @@ public class RequestBodyReader {
                 RequestBodyConstant.DOTNAME_REQUESTBODY, null);
     }
 
+    public static AnnotationInstance getRequestBodySchemaAnnotation(final AnnotationTarget target) {
+        return TypeUtil.getAnnotation(target, RequestBodyConstant.DOTNAME_REQUEST_BODY_SCHEMA);
+    }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseConstant.java
@@ -1,6 +1,7 @@
 package io.smallrye.openapi.runtime.io.response;
 
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.jboss.jandex.DotName;
 
@@ -14,10 +15,12 @@ import org.jboss.jandex.DotName;
  */
 public class ResponseConstant {
 
-    public static final String PROP_RESPONSE_CODE = "responseCode";
+    static final String PROP_RESPONSE_CODE = "responseCode";
+    static final String PROP_RESPONSE_DESCRIPTION = "responseDescription";
 
     static final DotName DOTNAME_API_RESPONSE = DotName.createSimple(APIResponse.class.getName());
     static final DotName DOTNAME_API_RESPONSES = DotName.createSimple(APIResponses.class.getName());
+    static final DotName DOTNAME_API_RESPONSE_SCHEMA = DotName.createSimple(APIResponseSchema.class.getName());
 
     static final String PROP_NAME = "name";
     static final String PROP_HEADERS = "headers";
@@ -25,6 +28,7 @@ public class ResponseConstant {
     static final String PROP_DEFAULT = "default";
     static final String PROP_DESCRIPTION = "description";
     static final String PROP_CONTENT = "content";
+    static final String PROP_VALUE = "value";
 
     private ResponseConstant() {
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -33,7 +33,6 @@ import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
-import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
@@ -55,7 +54,6 @@ import io.smallrye.openapi.runtime.io.definition.DefinitionReader;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
 import io.smallrye.openapi.runtime.io.operation.OperationReader;
 import io.smallrye.openapi.runtime.io.requestbody.RequestBodyReader;
-import io.smallrye.openapi.runtime.io.response.ResponseConstant;
 import io.smallrye.openapi.runtime.io.response.ResponseReader;
 import io.smallrye.openapi.runtime.io.schema.SchemaFactory;
 import io.smallrye.openapi.runtime.io.securityrequirement.SecurityRequirementReader;
@@ -92,6 +90,8 @@ public interface AnnotationScanner {
     public boolean isMultipartOutput(Type returnType);
 
     public boolean isMultipartInput(Type inputType);
+
+    public String getReasonPhrase(int statusCode);
 
     public boolean containsScannerAnnotations(List<AnnotationInstance> instances,
             List<AnnotationScannerExtension> extensions);
@@ -277,6 +277,10 @@ public interface AnnotationScanner {
         for (AnnotationInstance annotation : apiResponseAnnotations) {
             addApiReponseFromAnnotation(context, annotation, operation);
         }
+
+        AnnotationInstance responseSchemaAnnotation = ResponseReader.getResponseSchemaAnnotation(method);
+        addApiReponseSchemaFromAnnotation(context, responseSchemaAnnotation, method, operation);
+
         /*
          * If there is no response from annotations, try to create one from the method return value.
          * Do not generate a response if the app has used an empty @ApiResponses annotation. This
@@ -327,20 +331,11 @@ public interface AnnotationScanner {
 
         Type returnType = method.returnType();
         APIResponse response = null;
-        String code = "200";
-        String description = "OK";
+        final int status = getDefaultStatus(method);
+        final String code = String.valueOf(status);
+        final String description = getReasonPhrase(status);
 
         if (returnType.kind() == Type.Kind.VOID) {
-            boolean asyncResponse = isAsyncResponse(method);
-
-            if (isPostMethod(method)) {
-                code = "201";
-                description = "Created";
-            } else if (!asyncResponse) {
-                code = "204";
-                description = "No Content";
-            }
-
             if (generateResponse(code, operation)) {
                 response = new APIResponseImpl().description(description);
             }
@@ -400,6 +395,24 @@ public interface AnnotationScanner {
         }
     }
 
+    default int getDefaultStatus(final MethodInfo method) {
+        final int status;
+
+        if (method.returnType().kind() == Type.Kind.VOID) {
+            if (isPostMethod(method)) {
+                status = 201; // Created
+            } else if (!isAsyncResponse(method)) {
+                status = 204; // No Content
+            } else {
+                status = 200; // OK
+            }
+        } else {
+            status = 200; // OK
+        }
+
+        return status;
+    }
+
     /**
      * Determine if the default response information should be generated.
      * It should be done when no responses have been declared or if the default
@@ -433,6 +446,41 @@ public interface AnnotationScanner {
     }
 
     /**
+     * Add api response to api responses using the annotation information
+     * 
+     * @param annotation The APIResponseSchema annotation
+     * @param operation the method operation
+     */
+    default void addApiReponseSchemaFromAnnotation(AnnotationScannerContext context,
+            AnnotationInstance annotation,
+            MethodInfo method,
+            Operation operation) {
+
+        if (annotation == null) {
+            return;
+        }
+
+        String responseCode = ResponseReader.getResponseName(annotation);
+        final int status;
+
+        if (responseCode != null && responseCode.matches("\\d{3}")) {
+            status = Integer.parseInt(responseCode);
+        } else {
+            status = getDefaultStatus(method);
+            responseCode = String.valueOf(status);
+        }
+
+        APIResponse response = ResponseReader.readResponseSchema(context, annotation);
+
+        if (response.getDescription() == null) {
+            response.setDescription(getReasonPhrase(status));
+        }
+
+        APIResponses responses = ModelUtil.responses(operation);
+        responses.addAPIResponse(responseCode, response);
+    }
+
+    /**
      * Check if the response code declared in the ExceptionMapper already defined in one of the ApiReponse annotations of the
      * method.
      * If the response code already exists then ignore the exception mapper annotation.
@@ -443,16 +491,15 @@ public interface AnnotationScanner {
      */
     default boolean responseCodeExistInMethodAnnotations(AnnotationInstance exMapperApiResponseAnnotation,
             List<AnnotationInstance> methodApiResponseAnnotations) {
-        AnnotationValue exMapperResponseCode = exMapperApiResponseAnnotation
-                .value(ResponseConstant.PROP_RESPONSE_CODE);
-        Optional<AnnotationInstance> apiResponseWithSameCode = methodApiResponseAnnotations.stream()
-                .filter(annotationInstance -> {
-                    AnnotationValue methodAnnotationValue = annotationInstance
-                            .value(ResponseConstant.PROP_RESPONSE_CODE);
-                    return (methodAnnotationValue != null && methodAnnotationValue.equals(exMapperResponseCode));
-                }).findFirst();
 
-        return apiResponseWithSameCode.isPresent();
+        String exMapperResponseCode = ResponseReader.getResponseName(exMapperApiResponseAnnotation);
+
+        return methodApiResponseAnnotations.stream()
+                .map(ResponseReader::getResponseName)
+                .filter(Objects::nonNull)
+                .filter(code -> code.equals(exMapperResponseCode))
+                .findFirst()
+                .isPresent();
     }
 
     /**
@@ -673,6 +720,11 @@ public interface AnnotationScanner {
                     requestBody.setRequired(Boolean.FALSE);
                 }
             }
+        }
+
+        if (requestBody == null) {
+            requestBody = RequestBodyReader.readRequestBodySchema(context,
+                    RequestBodyReader.getRequestBodySchemaAnnotation(method));
         }
 
         // If the request body is null, figure it out from the parameters.  Only if the

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -395,6 +395,15 @@ public interface AnnotationScanner {
         }
     }
 
+    /**
+     * Derives a default HTTP status code for the provided REST endpoint implementation
+     * method using the rules defined by
+     * {@link org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema#responseCode()
+     * APIResponseSchema#responseCode()}.
+     *
+     * @param method the endpoint method
+     * @return the derived HTTP status
+     */
     default int getDefaultStatus(final MethodInfo method) {
         final int status;
 

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response.Status;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
@@ -88,6 +89,12 @@ public class JaxRsAnnotationScanner implements AnnotationScanner {
     @Override
     public boolean isMultipartInput(Type inputType) {
         return RestEasyConstants.MULTIPART_INPUTS.contains(inputType.name());
+    }
+
+    @Override
+    public String getReasonPhrase(int statusCode) {
+        Status status = Status.fromStatusCode(statusCode);
+        return status != null ? status.getReasonPhrase() : null;
     }
 
     @Override

--- a/extension-spring/pom.xml
+++ b/extension-spring/pom.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>smallrye-open-api-spring</artifactId>
-    
+
     <name>SmallRye: MicroProfile OpenAPI Spring extension</name>
-    
+
     <properties>
         <version.spring>5.2.5.RELEASE</version.spring>
     </properties>
-    
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -32,14 +32,14 @@
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api-core</artifactId>
         </dependency>
-        
-        <!-- Test Only Dependencies -->
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
-        
+
+        <!-- Test Only Dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -56,8 +56,8 @@
             <version>2.5</version>
             <scope>test</scope>
         </dependency>
-        
-        
+
+
         <!-- Depend on core tests -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -67,7 +67,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>coverage</id>

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -21,6 +21,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
+import org.springframework.http.HttpStatus;
 
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.api.models.OpenAPIImpl;
@@ -40,7 +41,7 @@ import io.smallrye.openapi.runtime.util.ModelUtil;
 
 /**
  * Scanner that scan Spring entry points.
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class SpringAnnotationScanner implements AnnotationScanner {
@@ -82,6 +83,12 @@ public class SpringAnnotationScanner implements AnnotationScanner {
     }
 
     @Override
+    public String getReasonPhrase(int statusCode) {
+        HttpStatus status = HttpStatus.resolve(statusCode);
+        return status != null ? status.getReasonPhrase() : null;
+    }
+
+    @Override
     public boolean containsScannerAnnotations(List<AnnotationInstance> instances,
             List<AnnotationScannerExtension> extensions) {
         for (AnnotationInstance instance : instances) {
@@ -118,7 +125,7 @@ public class SpringAnnotationScanner implements AnnotationScanner {
     /**
      * Find and process all Spring Controllers
      * TODO: Also support Controller annotations ?
-     * 
+     *
      * @param context the scanning context
      * @param openApi the openAPI model
      */
@@ -148,7 +155,7 @@ public class SpringAnnotationScanner implements AnnotationScanner {
      * Processes a Spring Controller and creates an {@link OpenAPI} model. Performs
      * annotation scanning and other processing. Returns a model unique to that single Spring
      * controller.
-     * 
+     *
      * @param context the scanning context
      * @param controllerClass the Spring REST controller
      */
@@ -189,7 +196,7 @@ public class SpringAnnotationScanner implements AnnotationScanner {
 
     /**
      * Process the Spring controller Operation methods
-     * 
+     *
      * @param context the scanning context
      * @param resourceClass the class containing the methods
      * @param openApi the OpenApi model being processed
@@ -231,7 +238,7 @@ public class SpringAnnotationScanner implements AnnotationScanner {
 
     /**
      * Process a single Spring method to produce an OpenAPI Operation.
-     * 
+     *
      * @param openApi
      * @param resourceClass
      * @param method


### PR DESCRIPTION
Fixes #76 

This will not build until eclipse/microprofile-open-api#410 is merged, but I wanted to open the PR to make sure this is in alignment with the new structure and get any feedback. Tests all pass using my local build of the MP OAI TCK in that PR. I plan on going back and adding JavaDoc comments where they are missing on new methods.

This puts the Spring dependencies as "provided" to access the `HttpStatus` class to obtain the reason phrase. It seems like a lot of baggage just for that, but no other obvious solution occurred to me. What are everyone's thoughts on that?