### PR TITLE
Allow missing OAI Parameter name when target also has JAX-RS param (1.x)

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/ParameterProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/ParameterProcessor.java
@@ -1372,7 +1372,10 @@ public class ParameterProcessor {
         ParameterContext context = params.get(key);
 
         if (context == null) {
-            context = params.values().stream().filter(c -> haveSameAnnotatedTarget(c, target, key.name))
+            context = params
+                    .values()
+                    .stream()
+                    .filter(c -> haveSameAnnotatedTarget(c, target, key.name))
                     .findFirst()
                     .orElse(null);
         }
@@ -1399,13 +1402,11 @@ public class ParameterProcessor {
 
         if (target.equals(context.target)) {
             /*
-             * If the annotations have the same (non-method) target or the same name with a common
-             * method target, it's the same parameter.
-             * 
-             * This covers the situation where a @Parameter annotation was missing either
-             * 'name' or 'location' attributes (or both).
+             * This logic formerly also required that the parameter names matched
+             * (nameMatches == true) or that the kind of the target was not a
+             * method.
              */
-            return nameMatches || target.kind() != Kind.METHOD;
+            return true;
         }
 
         if (nameMatches && target.kind() == Kind.METHOD && context.target.kind() == Kind.METHOD_PARAMETER) {

--- a/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/implementation/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -226,6 +226,11 @@ public class ParameterScanTests extends IndexScannerTestBase {
                 ParamNameOverrideTestResource.class);
     }
 
+    @Test
+    public void testCommonTargetMethodParameter() throws IOException, JSONException {
+        test("params.common-annotation-target-method.json", CommonTargetMethodParameterResource.class);
+    }
+
     /***************** Test models and resources below. ***********************/
 
     public static class Widget {
@@ -821,6 +826,21 @@ public class ParameterScanTests extends IndexScannerTestBase {
         public String echo(
                 @Parameter(name = "Path1", in = ParameterIn.PATH, style = ParameterStyle.SIMPLE, description = "The name 'Path1' will not be used instead of 'p1'") @PathParam("p1") String p1) {
             return p1;
+        }
+    }
+
+    @Path("/common-target-method")
+    static class CommonTargetMethodParameterResource {
+        @DefaultValue("10")
+        @QueryParam("limit")
+        @Parameter(description = "Description of the limit query parameter")
+        public void setLimit(int limit) {
+        }
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public String[] getRecords() {
+            return null;
         }
     }
 }

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.common-annotation-target-method.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.common-annotation-target-method.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/common-target-method": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "limit",
+          "in": "query",
+          "description": "Description of the limit query parameter",
+          "schema": {
+            "format": "int32",
+            "default": 10,
+            "type": "integer"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #285 

This addresses the problem in the `1.x` branch. I'll submit a second PR with the same change on `master` after the other open PRs are completed.