### PR TITLE
Built-in support for CompletableFuture as CompletionStage implementation

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/constants/JDKConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/JDKConstants.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
 
 /**
  * Constants from the JDK
@@ -32,6 +33,8 @@ public class JDKConstants {
                     DOTNAME_OPTIONAL_DOUBLE,
                     DOTNAME_OPTIONAL_INT,
                     DOTNAME_OPTIONAL_LONG)));
+
+    public static final Type COMPLETION_STAGE_TYPE = Type.create(COMPLETION_STAGE_NAME, Type.Kind.CLASS);
 
     private JDKConstants() {
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -368,7 +368,7 @@ public class SchemaFactory {
         } else if (type.kind() == Type.Kind.PRIMITIVE) {
             schema = OpenApiDataObjectScanner.process(type.asPrimitiveType());
         } else {
-            Type asyncType = resolveAsyncType(type, extensions);
+            Type asyncType = resolveAsyncType(index, type, extensions);
             schema = schemaRegistration(index, asyncType, OpenApiDataObjectScanner.process(index, asyncType));
         }
 
@@ -501,12 +501,13 @@ public class SchemaFactory {
                 .collect(Collectors.toList());
     }
 
-    private static Type resolveAsyncType(Type type, List<AnnotationScannerExtension> extensions) {
+    static Type resolveAsyncType(IndexView index, Type type, List<AnnotationScannerExtension> extensions) {
         if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
             ParameterizedType pType = type.asParameterizedType();
-            if (pType.name().equals(JDKConstants.COMPLETION_STAGE_NAME)
-                    && pType.arguments().size() == 1)
+            if (pType.arguments().size() == 1
+                    && TypeUtil.isA(index, type, JDKConstants.COMPLETION_STAGE_TYPE)) {
                 return pType.arguments().get(0);
+            }
         }
         for (AnnotationScannerExtension extension : extensions) {
             Type asyncType = extension.resolveAsyncType(type);

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -209,6 +209,10 @@ public class TypeUtil {
         index(indexer, java.util.concurrent.PriorityBlockingQueue.class);
         index(indexer, java.util.concurrent.SynchronousQueue.class);
 
+        // CompletionStage and implementation
+        index(indexer, java.util.concurrent.CompletionStage.class);
+        index(indexer, java.util.concurrent.CompletableFuture.class);
+
         jdkIndex = indexer.complete();
     }
 

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/schema/SchemaFactoryTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/schema/SchemaFactoryTest.java
@@ -1,0 +1,29 @@
+package io.smallrye.openapi.runtime.io.schema;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.junit.Test;
+
+import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
+
+public class SchemaFactoryTest extends IndexScannerTestBase {
+
+    @Test
+    public void testResolveAsyncType() {
+        Index index = indexOf();
+        Type STRING_TYPE = Type.create(DotName.createSimple(String.class.getName()), Type.Kind.CLASS);
+        Type target = ParameterizedType.create(DotName.createSimple(CompletableFuture.class.getName()),
+                new Type[] { STRING_TYPE },
+                null);
+        Type result = SchemaFactory.resolveAsyncType(index, target, Collections.emptyList());
+        assertEquals(STRING_TYPE, result);
+    }
+
+}

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import javax.validation.constraints.Max;
@@ -491,7 +492,7 @@ public class ParameterScanTests extends IndexScannerTestBase {
         @Produces(MediaType.APPLICATION_JSON)
         @RequestBody(content = @Content(schema = @Schema(requiredProperties = { "f3" }), encoding = {
                 @Encoding(name = "formField1", contentType = "text/x-custom-type") }))
-        public CompletionStage<Widget> upd(@MultipartForm Bean form,
+        public CompletableFuture<Widget> upd(@MultipartForm Bean form,
                 @FormParam("f3") @DefaultValue("3") int formField3,
                 @org.jboss.resteasy.annotations.jaxrs.FormParam @NotNull String formField4) {
             return null;


### PR DESCRIPTION
Fixes #292 

Add support for implementations of `CompletionStage`. Repurposed one of the JAX-RS tests to use `CompletableFuture` as the response type.