### PR TITLE
Baby steps: Adding support for ResponseEntity in Spring

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -347,9 +347,14 @@ public class SchemaFactory {
     public static Schema typeToSchema(IndexView index, Type type, List<AnnotationScannerExtension> extensions) {
         Schema schema = null;
 
+        AnnotationScanner annotationScanner = CurrentScannerInfo.getCurrentAnnotationScanner();
+
         if (TypeUtil.isOptional(type)) {
             // Recurse using the optional's type
             return typeToSchema(index, TypeUtil.getOptionalType(type), extensions);
+        } else if (annotationScanner.isWrapperType(type)) {
+            // Recurse using the wrapped type
+            return typeToSchema(index, annotationScanner.unwrapType(type), extensions);
         } else if (type.kind() == Type.Kind.ARRAY) {
             schema = new SchemaImpl().type(SchemaType.ARRAY);
             ArrayType array = type.asArrayType();

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -96,6 +96,18 @@ public interface AnnotationScanner {
     public boolean containsScannerAnnotations(List<AnnotationInstance> instances,
             List<AnnotationScannerExtension> extensions);
 
+    // For wrapped type (other than Optional) - default no others
+    default boolean isWrapperType(Type type) {
+        return false;
+    }
+
+    default Type unwrapType(Type type) {
+        if (isWrapperType(type)) {
+            return type.asParameterizedType().arguments().get(0);
+        }
+        return null;
+    }
+
     /**
      * Process a certain class for OpenApiDefinition annotations.
      * 

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingResource.java
@@ -1,32 +1,77 @@
-/*
- * Copyright 2018 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package test.io.smallrye.openapi.runtime.scanner.resources;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
 
-@Path("/greeting/{name}")
+/**
+ * JAX-RS.
+ * Some basic tests, mostly to compare with the Spring implementation
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+@Path("/greeting")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class GreetingResource {
 
+    // 1) Basic path var test
     @GET
-    public Greeting hello(@PathParam("name") String name) {
+    @Path("/helloPathVariable/{name}")
+    public Greeting helloPathVariable(@PathParam("name") String name) {
         return new Greeting("Hello " + name);
     }
+
+    // 2) Basic path var that return a collection test
+    @GET
+    @Path("/hellosPathVariable/{name}")
+    public List<Greeting> hellosPathVariable(@PathParam("name") String name) {
+        return Arrays.asList(new Greeting("Hello " + name));
+    }
+
+    // 3) Basic path var with Optional test
+    @GET
+    @Path("/helloOptional/{name}")
+    public Optional<Greeting> helloOptional(@PathParam("name") String name) {
+        return Optional.of(new Greeting("Hello " + name));
+    }
+
+    // 4) Basic request param test
+    @GET
+    @Path("/helloRequestParam")
+    public Greeting helloRequestParam(@QueryParam("name") String name) {
+        return new Greeting("Hello " + name);
+    }
+
+    // 5) Response where you do not have a type.
+    @GET
+    @Path("/helloPathVariableWithResponse/{name}")
+    @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(ref = "#/components/schemas/Greeting"))) // TODO: Why is not working to just do implementation ?
+    public Response helloPathVariableWithResponse(@PathParam("name") String name) {
+        return Response.ok(new Greeting("Hello " + name)).build();
+    }
+
+    // 6) ResponseEntity with a type specified (No JaxRS comparison) (repeat of above as there is not wrapped type return
+    @GET
+    @Path("/helloPathVariableWithResponseTyped/{name}")
+    @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(ref = "#/components/schemas/Greeting"))) // TODO: Why is not working to just do implementation ?
+    public Response helloPathVariableWithResponseTyped(@PathParam("name") String name) {
+        return Response.ok(new Greeting("Hello " + name)).build();
+    }
+
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testBasicJaxRsDefinitionScanning.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testBasicJaxRsDefinitionScanning.json
@@ -1,7 +1,7 @@
 {
   "openapi" : "3.0.1",
   "paths" : {
-    "/greeting/{name}" : {
+    "/greeting/helloOptional/{name}" : {
       "get" : {
         "parameters" : [ {
           "name" : "name",
@@ -15,9 +15,131 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponse/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloRequestParam" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/hellosPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Greeting"
+                  }
                 }
               }
             }

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -54,6 +54,10 @@ public class SpringAnnotationScanner implements AnnotationScanner {
         return "Spring";
     }
 
+    public boolean isWrapperType(Type type) {
+        return type.name().equals(SpringConstants.RESPONSE_ENTITY) && type.kind().equals(Type.Kind.PARAMETERIZED_TYPE);
+    }
+
     @Override
     public boolean isAsyncResponse(final MethodInfo method) {
         // TODO: Implement this.
@@ -62,12 +66,18 @@ public class SpringAnnotationScanner implements AnnotationScanner {
 
     @Override
     public boolean isPostMethod(final MethodInfo method) {
+        // TODO: Also check for @RequestMapping(method = RequestMethod.POST)
         return method.hasAnnotation(SpringConstants.POST_MAPPING);
     }
 
     @Override
     public boolean isScannerInternalResponse(Type returnType) {
-        return returnType.name().equals(SpringConstants.RESPONSE_ENTITY);
+        // If it's Response Entity that does not have a valid type, then stop
+        if (returnType.name().equals(SpringConstants.RESPONSE_ENTITY)
+                && !returnType.kind().equals(Type.Kind.PARAMETERIZED_TYPE)) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/extension-spring/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingController.java
+++ b/extension-spring/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingController.java
@@ -1,18 +1,67 @@
 package test.io.smallrye.openapi.runtime.scanner.resources;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
 
+/**
+ * Spring.
+ * Some basic test, comparing with what we get in the JAX-RS version.
+ * See the GreetingController in the JAX-RS test
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
 @RestController
-@RequestMapping("/greeting")
+@RequestMapping(value = "/greeting", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 public class GreetingController {
 
-    @GetMapping("/{name}")
-    public Greeting hello(@PathVariable(name = "name") String name) {
+    // 1) Basic path var test
+    @GetMapping("/helloPathVariable/{name}")
+    public Greeting helloPathVariable(@PathVariable(name = "name") String name) {
         return new Greeting("Hello " + name);
+    }
+
+    // 2) Basic path var test
+    @GetMapping("/hellosPathVariable/{name}")
+    public List<Greeting> hellosPathVariable(@PathVariable(name = "name") String name) {
+        return Arrays.asList(new Greeting("Hello " + name));
+    }
+
+    // 3) Basic path var with Optional test
+    @GetMapping("/helloOptional/{name}")
+    public Optional<Greeting> helloOptional(@PathVariable(name = "name") String name) {
+        return Optional.of(new Greeting("Hello " + name));
+    }
+
+    // 4) Basic request param test
+    @GetMapping("/helloRequestParam")
+    public Greeting helloRequestParam(@RequestParam(value = "name", required = false) String name) {
+        return new Greeting("Hello " + name);
+    }
+
+    // 5) ResponseEntity without a type specified
+    @GetMapping("/helloPathVariableWithResponse/{name}")
+    @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(ref = "#/components/schemas/Greeting")))
+    public ResponseEntity helloPathVariableWithResponse(@PathVariable(name = "name") String name) {
+        return ResponseEntity.ok(new Greeting("Hello " + name));
+    }
+
+    // 6) ResponseEntity with a type specified (No JaxRS comparison)
+    @GetMapping("/helloPathVariableWithResponseTyped/{name}")
+    public ResponseEntity<Greeting> helloPathVariableWithResponseTyped(@PathVariable(name = "name") String name) {
+        return ResponseEntity.ok(new Greeting("Hello " + name));
     }
 }

--- a/extension-spring/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testBasicSpringDefinitionScanning.json
+++ b/extension-spring/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testBasicSpringDefinitionScanning.json
@@ -1,7 +1,7 @@
 {
   "openapi" : "3.0.1",
   "paths" : {
-    "/greeting/{name}" : {
+    "/greeting/helloOptional/{name}" : {
       "get" : {
         "parameters" : [ {
           "name" : "name",
@@ -15,9 +15,131 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponse/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloRequestParam" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/hellosPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Greeting"
+                  }
                 }
               }
             }


### PR DESCRIPTION
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>

As discussed with @ebullient - baby steps to add Spring use cases. 
This PR only add support for ResponseEntity as a response type.

You will see there is a JAX-RS test case that mimic the Spring test case for comparison. The result of the JaxRs and Spring is exactly the same (so the json file we test against)

@ebullient @MikeEdgar - let me know what you think. After this we can do support for 
`@RequestMapping(method = RequestMethod.XXX)` as at the moment we only do `@XXXMapping`