### PR TITLE
Add deep package scan capability with regular expression support

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -2,6 +2,7 @@ package io.smallrye.openapi.api;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Accessor to OpenAPI configuration options.
@@ -19,13 +20,13 @@ public interface OpenApiConfig {
 
     public boolean scanDisable();
 
-    public Set<String> scanPackages();
+    public Pattern scanPackages();
 
-    public Set<String> scanClasses();
+    public Pattern scanClasses();
 
-    public Set<String> scanExcludePackages();
+    public Pattern scanExcludePackages();
 
-    public Set<String> scanExcludeClasses();
+    public Pattern scanExcludeClasses();
 
     public Set<String> servers();
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/FilteredIndexView.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/FilteredIndexView.java
@@ -1,7 +1,8 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.util.Collection;
-import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -22,10 +23,10 @@ public class FilteredIndexView implements IndexView {
 
     private final IndexView delegate;
 
-    private final Set<String> scanClasses;
-    private final Set<String> scanPackages;
-    private final Set<String> scanExcludeClasses;
-    private final Set<String> scanExcludePackages;
+    private final Pattern scanClasses;
+    private final Pattern scanPackages;
+    private final Pattern scanExcludeClasses;
+    private final Pattern scanExcludePackages;
 
     /**
      * Constructor.
@@ -49,30 +50,149 @@ public class FilteredIndexView implements IndexView {
      * 
      * @param className
      */
-    private boolean accepts(DotName className) {
-        String fqcn = className.toString();
-        int index = fqcn.lastIndexOf('.');
-        String packageName = index > -1 ? fqcn.substring(0, index) : "";
-        boolean accept;
-        // Includes
-        if (scanClasses.isEmpty() && scanPackages.isEmpty()) {
-            accept = true;
-        } else if (!scanClasses.isEmpty() && scanPackages.isEmpty()) {
-            accept = scanClasses.contains(fqcn);
-        } else if (scanClasses.isEmpty() && !scanPackages.isEmpty()) {
-            accept = scanPackages.contains(packageName);
-        } else {
-            accept = scanClasses.contains(fqcn) || scanPackages.contains(packageName);
-        }
-        // Excludes override includes
-        if (!scanExcludeClasses.isEmpty() && scanExcludeClasses.contains(fqcn)) {
-            accept = false;
-        }
-        if (!scanExcludePackages.isEmpty() && scanExcludePackages.contains(packageName)) {
-            accept = false;
-        }
-        return accept;
+    public boolean accepts(DotName className) {
+        final boolean accept;
+        final MatchHandler match = new MatchHandler(className);
 
+        if (match.isQualifiedNameExcluded()) {
+            /*
+             * A FQCN or pattern that *fully* matched the FQCN was given in
+             * `mp.openapi.scan.exclude.classes`.
+             */
+            accept = false;
+        } else if (match.isQualifiedNameIncluded()) {
+            /*
+             * A FQCN or pattern that *fully* matched the FQCN was given in
+             * `mp.openapi.scan.classes`.
+             */
+            accept = true;
+        } else if (match.isSimpleNameExcluded()) {
+            /*
+             * A pattern or partial class name was given in `mp.openapi.scan.exclude.classes`
+             * where the matching part of the configuration ends with the simple class name
+             * *AND* no match exists for the simple class name in `mp.openapi.scan.classes`
+             * with a more complete package specified.
+             */
+            accept = false;
+        } else if (match.isSimpleNameIncluded()) {
+            /*
+             * A pattern or partial class name was given in `mp.openapi.scan.classes`
+             * where the matching part of the configuration ends with the simple class name
+             */
+            accept = true;
+        } else if (match.isPackageExcluded()) {
+            /*
+             * A package or package pattern given in `mp.openapi.scan.exclude.packages`
+             * matches the start of the FQCN's package and a more complete match in
+             * `mp.openapi.scan.packages` was not given.
+             */
+            accept = false;
+        } else if (match.isPackageIncluded()) {
+            /*
+             * A package or package pattern given in `mp.openapi.scan.packages`
+             * matches the start of the FQCN's package.
+             */
+            accept = true;
+        } else if (match.isImpliedInclusion()) {
+            /*
+             * No value has been specified for either `mp.openapi.scan.classes`
+             * or `mp.openapi.scan.packages`.
+             */
+            accept = true;
+        } else {
+            /*
+             * A value is specified for `mp.openapi.scan.classes` or `mp.openapi.scan.packages`
+             * which does not match this FQCN in any way.
+             */
+            accept = false;
+        }
+
+        return accept;
+    }
+
+    class MatchHandler {
+        final DotName className;
+        final String fqcn;
+        final String simpleName;
+        final String packageName;
+
+        final String classExclGroup;
+        final String classInclGroup;
+        final String pkgExclGroup;
+        final String pkgInclGroup;
+
+        public MatchHandler(DotName className) {
+            this.className = className;
+            this.fqcn = className.toString();
+            this.simpleName = className.withoutPackagePrefix();
+            final int index = fqcn.lastIndexOf('.');
+            this.packageName = index > -1 ? fqcn.substring(0, index) : "";
+
+            this.classExclGroup = matchingGroup(fqcn, scanExcludeClasses);
+            this.classInclGroup = matchingGroup(fqcn, scanClasses);
+            this.pkgExclGroup = matchingGroup(packageName, scanExcludePackages);
+            this.pkgInclGroup = matchingGroup(packageName, scanPackages);
+        }
+
+        public boolean isQualifiedNameExcluded() {
+            return fqcn.equals(classExclGroup);
+        }
+
+        public boolean isQualifiedNameIncluded() {
+            return fqcn.equals(classInclGroup);
+        }
+
+        public boolean isSimpleNameExcluded() {
+            if (classExclGroup.endsWith(simpleName)) {
+                if (isSimpleNameIncluded()) {
+                    return classExclGroup.length() >= classInclGroup.length();
+                }
+                return true;
+            }
+            return false;
+        }
+
+        public boolean isSimpleNameIncluded() {
+            return classInclGroup.endsWith(simpleName);
+        }
+
+        public boolean isPackageExcluded() {
+            if (pkgExclGroup.isEmpty()) {
+                return false;
+            }
+            if (packageName.equals(pkgExclGroup)) {
+                return true;
+            }
+            if (packageName.startsWith(pkgExclGroup)) {
+                if (isPackageIncluded()) {
+                    return (pkgExclGroup.length() >= pkgInclGroup.length());
+                }
+                return true;
+            }
+            return false;
+        }
+
+        public boolean isPackageIncluded() {
+            if (pkgInclGroup.isEmpty()) {
+                return false;
+            }
+            if (packageName.equals(pkgInclGroup)) {
+                return true;
+            }
+            return packageName.startsWith(pkgInclGroup);
+        }
+
+        public boolean isImpliedInclusion() {
+            return scanClasses.pattern().isEmpty() && scanPackages.pattern().isEmpty();
+        }
+    }
+
+    String matchingGroup(String value, Pattern pattern) {
+        if (pattern.pattern().isEmpty() || value.isEmpty()) {
+            return "";
+        }
+        Matcher m = pattern.matcher(value);
+        return m.find() ? m.group() : "";
     }
 
     /**

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/FilteredIndexViewTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/FilteredIndexViewTest.java
@@ -1,0 +1,198 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.OASConfig;
+import org.jboss.jandex.DotName;
+import org.junit.Test;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+
+public class FilteredIndexViewTest {
+
+    @Test
+    public void testAcceptsEmptyConfig() {
+        Map<String, Object> properties = new HashMap<>();
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+    }
+
+    @Test
+    public void testAccepts_IncludedClass_ExcludedPackage() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "com.example.pkgA.MyBean,com.example.pkgA.MyClass");
+        properties.put(OASConfig.SCAN_EXCLUDE_PACKAGES, "com.example.pkgA");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+    }
+
+    @Test
+    public void testAccepts_ExcludedClass_IncludedClassPattern() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "^(?:com.example.pkgA.My.*)$");
+        properties.put(OASConfig.SCAN_EXCLUDE_CLASSES, "com.example.pkgA.MyImpl");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_IncludedClassPattern_ExcludedPackage() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "^(?:com.example.pkgA.My.*)$");
+        properties.put(OASConfig.SCAN_EXCLUDE_PACKAGES, "com.example.pkgA");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_ExcludedSimpleClassPattern_NotIncludedClassMatch() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_EXCLUDE_CLASSES, "example.pkgA.MyImpl$");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_ExcludedSimpleClassPattern_IncludedClassShorterMatch() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "(?:pkgA.My.*)$");
+        properties.put(OASConfig.SCAN_EXCLUDE_CLASSES, "example.pkgA.MyImpl$");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_ExcludedSimpleClassPattern_IncludedClassLongerMatch() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "(?:example.pkgA.My.*)$");
+        properties.put(OASConfig.SCAN_EXCLUDE_CLASSES, "pkgA.MyImpl$");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_IncludedSimpleClassPattern_ExcludedPackage() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "(?:pkgA.My(Bean|Class))$");
+        properties.put(OASConfig.SCAN_EXCLUDE_PACKAGES, "com.example.pkgA");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_IncludedSimpleClassPattern_ExcludedPackagePrefix() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "(?:pkgA.My(Bean|Class))$");
+        properties.put(OASConfig.SCAN_EXCLUDE_PACKAGES, "com.example");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_IncludedSimpleClassPattern_ExcludedPackagePatternDoesNotMatch() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "(?:pkgA.MyBean)$");
+        properties.put(OASConfig.SCAN_EXCLUDE_PACKAGES, "example.pkg[AB]$");
+        properties.put(OASConfig.SCAN_PACKAGES, "^(com|org).example");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertTrue(view.accepts(DotName.createSimple("org.example.pkgB.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_ExcludedPackageOverridesIncludedPackage() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_PACKAGES, "com.example");
+        properties.put(OASConfig.SCAN_EXCLUDE_PACKAGES, "com.example");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertFalse(view.accepts(DotName.createSimple("com.example.TopLevelClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_IncludedPackageDoesNotMatch() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_PACKAGES, "example.pkgA$");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_IncludedPackageOverridesExcludedPackage() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_PACKAGES, "com.example.pkgA");
+        properties.put(OASConfig.SCAN_EXCLUDE_PACKAGES, "com.example");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertFalse(view.accepts(DotName.createSimple("com.example.TopLevelClass")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_IncludedPackageExcludesOtherPackage() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_PACKAGES, "com.example.pkgA");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgB.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_IncludedClassesImpliesOtherClassesExcluded() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OASConfig.SCAN_CLASSES, "^com.example.pkgA.My(Bean|Class)$");
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyBean")));
+        assertTrue(view.accepts(DotName.createSimple("com.example.pkgA.MyClass")));
+        assertFalse(view.accepts(DotName.createSimple("com.example.pkgB.MyImpl")));
+    }
+
+    @Test
+    public void testAccepts_EmptyPackage() {
+        Map<String, Object> properties = new HashMap<>();
+        OpenApiConfig config = IndexScannerTestBase.dynamicConfig(properties);
+        FilteredIndexView view = new FilteredIndexView(null, config);
+        assertTrue(view.accepts(DotName.createSimple("int")));
+    }
+}

--- a/tck/src/test/java/test/io/smallrye/openapi/tck/ArchiveUtil.java
+++ b/tck/src/test/java/test/io/smallrye/openapi/tck/ArchiveUtil.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
@@ -24,6 +25,7 @@ import io.smallrye.openapi.api.OpenApiConfigImpl;
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.runtime.OpenApiStaticFile;
 import io.smallrye.openapi.runtime.io.Format;
+import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
 import io.smallrye.openapi.runtime.scanner.OpenApiAnnotationScanner;
 
 /**
@@ -132,12 +134,13 @@ public class ArchiveUtil {
      * @param archive
      */
     private static void indexArchive(OpenApiConfig config, Indexer indexer, Archive<?> archive) {
+        FilteredIndexView filter = new FilteredIndexView(null, config);
         Map<ArchivePath, Node> c = archive.getContent();
         try {
             for (Map.Entry<ArchivePath, Node> each : c.entrySet()) {
                 ArchivePath archivePath = each.getKey();
                 if (archivePath.get().endsWith(OpenApiConstants.CLASS_SUFFIX)
-                        && acceptClassForScanning(config, archivePath.get())) {
+                        && acceptClassForScanning(filter, archivePath.get())) {
                     try (InputStream contentStream = each.getValue().getAsset().openStream()) {
                         LOG.debugv("Indexing asset: {0} from archive: {1}", archivePath.get(), archive.getName());
                         indexer.index(contentStream);
@@ -185,51 +188,21 @@ public class ArchiveUtil {
      * @param config
      * @param archivePath
      */
-    private static boolean acceptClassForScanning(OpenApiConfig config, String archivePath) {
+    private static boolean acceptClassForScanning(FilteredIndexView filter, String archivePath) {
         if (archivePath == null) {
             return false;
-        }
-
-        Set<String> scanClasses = config.scanClasses();
-        Set<String> scanPackages = config.scanPackages();
-        Set<String> scanExcludeClasses = config.scanExcludeClasses();
-        Set<String> scanExcludePackages = config.scanExcludePackages();
-        if (scanClasses.isEmpty() && scanPackages.isEmpty() && scanExcludeClasses.isEmpty() && scanExcludePackages.isEmpty()) {
-            return true;
         }
 
         if (archivePath.startsWith(OpenApiConstants.WEB_ARCHIVE_CLASS_PREFIX)) {
             archivePath = archivePath.substring(OpenApiConstants.WEB_ARCHIVE_CLASS_PREFIX.length());
         }
+
         String fqcn = archivePath.replaceAll("/", ".").substring(0, archivePath.lastIndexOf(OpenApiConstants.CLASS_SUFFIX));
-        String packageName = "";
+
         if (fqcn.startsWith(".")) {
             fqcn = fqcn.substring(1);
         }
-        if (fqcn.contains(".")) {
-            int idx = fqcn.lastIndexOf(".");
-            packageName = fqcn.substring(0, idx);
-        }
 
-        boolean accept;
-        // Includes
-        if (scanClasses.isEmpty() && scanPackages.isEmpty()) {
-            accept = true;
-        } else if (!scanClasses.isEmpty() && scanPackages.isEmpty()) {
-            accept = scanClasses.contains(fqcn);
-        } else if (scanClasses.isEmpty() && !scanPackages.isEmpty()) {
-            accept = scanPackages.contains(packageName);
-        } else {
-            accept = scanClasses.contains(fqcn) || scanPackages.contains(packageName);
-        }
-        // Excludes override includes
-        if (!scanExcludeClasses.isEmpty() && scanExcludeClasses.contains(fqcn)) {
-            accept = false;
-        }
-        if (!scanExcludePackages.isEmpty() && scanExcludePackages.contains(packageName)) {
-            accept = false;
-        }
-        return accept;
+        return filter.accepts(DotName.createSimple(fqcn));
     }
-
 }


### PR DESCRIPTION
Fixes #289 

This is my attempt to implement what was discussed in eclipse/microprofile-open-api#422. Without using regex, it adds support for package matching using `startsWith`, which aligns SR more closely with other implementations. Beyond that, it gives some additional control using regex as suggested in the hangout on 4/30. If anything could use some additional comments I'm happy to add them to make this as clear as possible for future research/debugging.

If this looks good, it might be a good idea to apply these changes to `1.x` as well for immediate downstream use.