### PR TITLE
Require a name match for annotations on a method (1.x)

### DIFF
--- a/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/ParameterProcessor.java
+++ b/implementation/src/main/java/io/smallrye/openapi/runtime/scanner/ParameterProcessor.java
@@ -1398,15 +1398,17 @@ public class ParameterProcessor {
     }
 
     boolean haveSameAnnotatedTarget(ParameterContext context, AnnotationTarget target, String name) {
-        boolean nameMatches = Objects.equals(context.name, name);
+        /*
+         * Consider names to match if one is unspecified or they are equal.
+         */
+        boolean nameMatches = (context.name == null || name == null || Objects.equals(context.name, name));
 
         if (target.equals(context.target)) {
             /*
-             * This logic formerly also required that the parameter names matched
-             * (nameMatches == true) or that the kind of the target was not a
-             * method.
+             * The name must match for annotations on a method because it is
+             * ambiguous which parameters is being referenced.
              */
-            return true;
+            return nameMatches || target.kind() != Kind.METHOD;
         }
 
         if (nameMatches && target.kind() == Kind.METHOD && context.target.kind() == Kind.METHOD_PARAMETER) {

--- a/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.method-target-nojaxrs.json
+++ b/implementation/src/test/resources/io/smallrye/openapi/runtime/scanner/params.method-target-nojaxrs.json
@@ -1,0 +1,171 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/policies": {
+      "get": {
+        "summary": "Return all policies for a given account",
+        "parameters": [
+          {
+            "name": "filter:op[description]",
+            "in": "query",
+            "description": "Operations used with the filter",
+            "schema": {
+              "default": "equal",
+              "enum": [
+                "equal",
+                "like",
+                "ilike",
+                "not_equal"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter:op[name]",
+            "in": "query",
+            "description": "Operations used with the filter",
+            "schema": {
+              "default": "equal",
+              "enum": [
+                "equal",
+                "like",
+                "ilike",
+                "not_equal"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description]",
+            "in": "query",
+            "description": "Filtering policies by the description depending on the Filter operator used.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[is_enabled]",
+            "in": "query",
+            "description": "Filtering policies by the is_enabled field.Defaults to true if no operand is given.",
+            "schema": {
+              "default": "true",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "description": "Filtering policies by the name depending on the Filter operator used.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items per page, if not specified uses 10. NO_LIMIT can be used to specify an unlimited page, when specified it ignores the offset",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Page number, starts 0, if not specified uses 0.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sortColumn",
+            "in": "query",
+            "description": "Column to sort the results by",
+            "schema": {
+              "enum": [
+                "name",
+                "description",
+                "is_enabled",
+                "mtime"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "description": "Sort direction used",
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad parameter for sorting was passed"
+          },
+          "404": {
+            "description": "No policies found for customer"
+          },
+          "403": {
+            "description": "Individual permissions missing to complete action"
+          },
+          "200": {
+            "description": "Policies found",
+            "headers": {
+              "TotalCount": {
+                "description": "Total number of items found",
+                "style": "simple",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PagedResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "links": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "meta": {
+            "type": "object",
+            "additionalProperties": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #330 (`1.x` branch). Also see quarkusio/quarkus#9538

- Allow an omitted name to to match a specified name (supports case
where `@Parameter` has no `name` and equivalent JAX-RS annotation has a
name - see smallrye/smallrye-open-api#285)