### PR TITLE
Support java.time.Duration and java.time.Period with examples and tests

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -70,6 +70,12 @@ public class TypeUtil {
     private static final TypeWithFormat DATE_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.DATE).build();
     private static final TypeWithFormat DATE_TIME_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.DATE_TIME)
             .build();
+    private static final TypeWithFormat DURATION_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.DURATION)
+            .example("PT32S")
+            .build();
+    private static final TypeWithFormat PERIOD_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.PERIOD)
+            .example("P1M")
+            .build();
     private static final TypeWithFormat TIME_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.TIME)
             .externalDocumentation("As defined by 'full-time' in RFC3339",
                     "https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14")
@@ -130,6 +136,10 @@ public class TypeUtil {
         TYPE_MAP.put(DotName.createSimple(java.time.LocalDateTime.class.getName()), DATE_TIME_FORMAT);
         TYPE_MAP.put(DotName.createSimple(java.time.ZonedDateTime.class.getName()), DATE_TIME_FORMAT);
         TYPE_MAP.put(DotName.createSimple(java.time.OffsetDateTime.class.getName()), DATE_TIME_FORMAT);
+
+        // Duration
+        TYPE_MAP.put(DotName.createSimple(java.time.Duration.class.getName()), DURATION_FORMAT);
+        TYPE_MAP.put(DotName.createSimple(java.time.Period.class.getName()), PERIOD_FORMAT);
 
         // Time
         TYPE_MAP.put(DotName.createSimple(java.time.LocalTime.class.getName()), TIME_LOCAL_FORMAT);
@@ -776,6 +786,8 @@ public class TypeUtil {
         static final String BYTE = "byte";
         static final String DATE = "date";
         static final String DATE_TIME = "date-time";
+        static final String DURATION = "duration";
+        static final String PERIOD = "period";
         static final String URI = "uri";
         static final String UUID = "uuid";
         static final String TIME = "time";

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -70,11 +70,14 @@ public class TypeUtil {
     private static final TypeWithFormat DATE_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.DATE).build();
     private static final TypeWithFormat DATE_TIME_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.DATE_TIME)
             .build();
+    /*
+     * This is used both for Java Period and Duration according to
+     * https://docs.oracle.com/javase/8/docs/api/java/time/Period.html
+     * As they're both basically https://tools.ietf.org/html/rfc3339#appendix-A
+     * Examples is parsed from both classes
+     */
     private static final TypeWithFormat DURATION_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.DURATION)
-            .example("PT32S")
-            .build();
-    private static final TypeWithFormat PERIOD_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.PERIOD)
-            .example("P1M")
+            .example("P1D")
             .build();
     private static final TypeWithFormat TIME_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.TIME)
             .externalDocumentation("As defined by 'full-time' in RFC3339",
@@ -139,7 +142,7 @@ public class TypeUtil {
 
         // Duration
         TYPE_MAP.put(DotName.createSimple(java.time.Duration.class.getName()), DURATION_FORMAT);
-        TYPE_MAP.put(DotName.createSimple(java.time.Period.class.getName()), PERIOD_FORMAT);
+        TYPE_MAP.put(DotName.createSimple(java.time.Period.class.getName()), DURATION_FORMAT);
 
         // Time
         TYPE_MAP.put(DotName.createSimple(java.time.LocalTime.class.getName()), TIME_LOCAL_FORMAT);
@@ -787,7 +790,6 @@ public class TypeUtil {
         static final String DATE = "date";
         static final String DATE_TIME = "date-time";
         static final String DURATION = "duration";
-        static final String PERIOD = "period";
         static final String URI = "uri";
         static final String UUID = "uuid";
         static final String TIME = "time";

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
@@ -116,4 +116,14 @@ public class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
         testAssertion(GenericTypeTestContainer.class, "overriddenNames",
                 "refsEnabled.generic.fields.overriddenNames.expected.json");
     }
+
+    @Test
+    public void durationContainer() throws IOException, JSONException {
+        testAssertion(GenericTypeTestContainer.class, "durationContainer", "refsEnabled.duration.fields.expected.json");
+    }
+
+    @Test
+    public void periodContainer() throws IOException, JSONException {
+        testAssertion(GenericTypeTestContainer.class, "periodContainer", "refsEnabled.period.fields.expected.json");
+    }
 }

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/GenericTypeTestContainer.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/GenericTypeTestContainer.java
@@ -1,6 +1,8 @@
 package test.io.smallrye.openapi.runtime.scanner.entities;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.Date;
 
 /**
@@ -21,6 +23,12 @@ public class GenericTypeTestContainer {
 
     // Type containing a variety of collections and maps.
     GenericFieldTestContainer<String, LocalDateTime> genericContainer;
+
+    // Type containing a variety of collections against duration
+    GenericFieldTestContainer<String, Duration> durationContainer;
+
+    // Type containing a variety of collections against period
+    GenericFieldTestContainer<String, Period> periodContainer;
 
     // Type containing fields with overridden names.
     FieldNameOverride overriddenNames;

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.duration.fields.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.duration.fields.expected.json
@@ -1,0 +1,64 @@
+{
+  "components": {
+    "schemas": {
+      "Bazzy": {
+        "type": "object",
+        "properties": {
+          "hellofrombazzy": {
+            "type": "string"
+          },
+          "an_integer_value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "theQ": {
+            "type": "string"
+          },
+          "theT": {
+            "$ref": "#/components/schemas/Bazzy"
+          },
+          "ultimateTShouldBeQ": {
+            "type": "string"
+          }
+        }
+      },
+      "GenericFieldTestContainerStringDuration": {
+        "type": "object",
+        "properties": {
+          "arrayListOfV": {
+            "type": "array",
+            "items": {
+              "format": "duration",
+              "type": "string",
+              "example" : "PT32S"
+            }
+          },
+          "genericFieldK": {
+            "format": "duration",
+            "type": "string",
+            "example" : "PT32S"
+          },
+          "mapOfKToFoo": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Foo"
+            }
+          },
+          "mapOfKV": {
+            "type": "object",
+            "additionalProperties": {
+              "format": "duration",
+              "type": "string",
+              "example" : "PT32S"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.duration.fields.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.duration.fields.expected.json
@@ -35,13 +35,13 @@
             "items": {
               "format": "duration",
               "type": "string",
-              "example" : "PT32S"
+              "example" : "P1D"
             }
           },
           "genericFieldK": {
             "format": "duration",
             "type": "string",
-            "example" : "PT32S"
+            "example" : "P1D"
           },
           "mapOfKToFoo": {
             "type": "object",
@@ -54,7 +54,7 @@
             "additionalProperties": {
               "format": "duration",
               "type": "string",
-              "example" : "PT32S"
+              "example" : "P1D"
             }
           }
         }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.period.fields.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.period.fields.expected.json
@@ -33,15 +33,15 @@
           "arrayListOfV": {
             "type": "array",
             "items": {
-              "format": "period",
+              "format": "duration",
               "type": "string",
-              "example" : "P1M"
+              "example" : "P1D"
             }
           },
           "genericFieldK": {
-            "format": "period",
+            "format": "duration",
             "type": "string",
-            "example" : "P1M"
+            "example" : "P1D"
           },
           "mapOfKToFoo": {
             "type": "object",
@@ -52,9 +52,9 @@
           "mapOfKV": {
             "type": "object",
             "additionalProperties": {
-              "format": "period",
+              "format": "duration",
               "type": "string",
-              "example" : "P1M"
+              "example" : "P1D"
             }
           }
         }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.period.fields.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.period.fields.expected.json
@@ -1,0 +1,64 @@
+{
+  "components": {
+    "schemas": {
+      "Bazzy": {
+        "type": "object",
+        "properties": {
+          "hellofrombazzy": {
+            "type": "string"
+          },
+          "an_integer_value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "theQ": {
+            "type": "string"
+          },
+          "theT": {
+            "$ref": "#/components/schemas/Bazzy"
+          },
+          "ultimateTShouldBeQ": {
+            "type": "string"
+          }
+        }
+      },
+      "GenericFieldTestContainerStringPeriod": {
+        "type": "object",
+        "properties": {
+          "arrayListOfV": {
+            "type": "array",
+            "items": {
+              "format": "period",
+              "type": "string",
+              "example" : "P1M"
+            }
+          },
+          "genericFieldK": {
+            "format": "period",
+            "type": "string",
+            "example" : "P1M"
+          },
+          "mapOfKToFoo": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Foo"
+            }
+          },
+          "mapOfKV": {
+            "type": "object",
+            "additionalProperties": {
+              "format": "period",
+              "type": "string",
+              "example" : "P1M"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently `java.time.Period` and `java.time.Duration` fields  are shown in this way 

![openapi-period](https://user-images.githubusercontent.com/454752/84763698-ea75cf80-afcc-11ea-97af-a096a235ec9b.png)

Needless to say, this is not the correct way to provide a Duration or a Period in a REST endpoint.

This patches supports these two datatypes with this output

![Screen Shot 2020-06-16 at 11 45 51](https://user-images.githubusercontent.com/454752/84759417-f9f21a00-afc6-11ea-9e01-e48ea6d1a35c.png)

I  read this shouldn't be the "canonical" way to support custom formats and that they're discussing the way to do in the specification, but as smallrye-open-api supports most of `java.time` classes I think it'd make sense to support all of them.