### PR TITLE
Set required = true in ParameterImpl::setIn when in == In.PATH

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/models/parameters/ParameterImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/parameters/ParameterImpl.java
@@ -275,6 +275,9 @@ public class ParameterImpl extends ExtensibleImpl<Parameter> implements Paramete
      */
     @Override
     public void setIn(In in) {
+        if (in == In.PATH) {
+            this.required = true;
+        }
         this.in = in;
     }
 


### PR DESCRIPTION
This changes simply sets the `required` attribute on `ParameterImpl` to true in the `setIn` method if the input argument equals In.PATH.

Resolves #372