### PR TITLE
Allow Inheritance for @JsonIgnoreProperties

### DIFF
--- a/tck/src/test/java/io/smallrye/openapi/tck/extra/IgnoreJsonPropertiesTest.java
+++ b/tck/src/test/java/io/smallrye/openapi/tck/extra/IgnoreJsonPropertiesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.tck.extra;
+
+import io.restassured.response.ValidatableResponse;
+import org.eclipse.microprofile.openapi.tck.AppTestBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+import test.io.smallrye.openapi.tck.BaseTckTest;
+import test.io.smallrye.openapi.tck.TckTest;
+
+import static org.hamcrest.Matchers.*;
+
+/**
+ * NOTE: It's not a TCK test, it only leverages the TCK test setup
+ * 
+ */
+@TckTest
+public class IgnoreJsonPropertiesTest extends BaseTckTest<IgnoreJsonPropertiesTest.ExtensionsTestArquillian> {
+
+    public static class ExtensionsTestArquillian extends AppTestBase {
+        @Deployment(name = "jsonignoreproperties")
+        public static WebArchive createDeployment() {
+            return ShrinkWrap.create(WebArchive.class, "airlines.war")
+                    .addPackages(true, new String[] { "io.smallrye.openapi.tck.extra.jsonignoreproperties" })
+                    .addAsManifestResource("openapi.yaml", "openapi.yaml");
+        }
+
+        @RunAsClient
+        @Test(dataProvider = "formatProvider")
+        public void testDirectIgnore(String type) {
+            ValidatableResponse vr = this.callEndpoint(type);
+            String schemaPath = "components.schemas.DirectIgnore.properties";
+            vr.body(schemaPath + ".dontIgnoreMe", notNullValue());
+            vr.body(schemaPath + ".ignoreMe", nullValue());
+        }
+
+        @RunAsClient
+        @Test(dataProvider = "formatProvider")
+        public void testInheritedIgnore(String type) {
+            ValidatableResponse vr = this.callEndpoint(type);
+            String schemaPath = "components.schemas.InheritIgnore.properties";
+            vr.body(schemaPath + ".dontIgnoreMe", notNullValue());
+            vr.body(schemaPath + ".ignoreMe", nullValue());
+        }
+
+        @RunAsClient
+        @Test(dataProvider = "formatProvider")
+        public void testInheritedIgnoreOverride(String type) {
+            ValidatableResponse vr = this.callEndpoint(type);
+            String schemaPath = "components.schemas.InheritIgnoreOverride.properties";
+            vr.body(schemaPath + ".dontIgnoreMe", nullValue());
+            vr.body(schemaPath + ".ignoreMe", notNullValue());
+        }
+    }
+}

--- a/tck/src/test/java/io/smallrye/openapi/tck/extra/jsonignoreproperties/JsonIgnorePropertiesResource.java
+++ b/tck/src/test/java/io/smallrye/openapi/tck/extra/jsonignoreproperties/JsonIgnorePropertiesResource.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.openapi.tck.extra.jsonignoreproperties;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.restassured.assertion.BodyMatcher;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extensions;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@Path("/jsonignoreproperties")
+@Consumes("application/json")
+public class JsonIgnorePropertiesResource {
+
+    @POST
+    @Path("/ignoreProperties")
+    public String getIgnoreProperties(@RequestBody IgnoreProps ignoreProps) {
+        return "Type extension value.";
+    }
+
+    private class IgnoreProps {
+        private DirectIgnore directIgnore;
+        private InheritIgnore inheritIgnore;
+        private InheritIgnoreOverride inheritIgnoreOverride;
+    }
+
+    @JsonIgnoreProperties("ignoreMe")
+    private static class DirectIgnore {
+        private String ignoreMe;
+        private String dontIgnoreMe;
+
+        public String getIgnoreMe() {
+            return ignoreMe;
+        }
+
+        public void setIgnoreMe(String ignoreMe) {
+            this.ignoreMe = ignoreMe;
+        }
+
+        public String getDontIgnoreMe() {
+            return dontIgnoreMe;
+        }
+
+        public void setDontIgnoreMe(String dontIgnoreMe) {
+            this.dontIgnoreMe = dontIgnoreMe;
+        }
+    }
+
+    private static class InheritIgnore extends DirectIgnore {
+
+        @Override
+        public String getIgnoreMe() {
+            return super.getIgnoreMe();
+        }
+
+        @Override
+        public void setIgnoreMe(String ignoreMe) {
+            super.setIgnoreMe(ignoreMe);
+        }
+
+        @Override
+        public String getDontIgnoreMe() {
+            return super.getDontIgnoreMe();
+        }
+
+        @Override
+        public void setDontIgnoreMe(String dontIgnoreMe) {
+            super.setDontIgnoreMe(dontIgnoreMe);
+        }
+    }
+
+    @JsonIgnoreProperties("dontIgnoreMe")
+    private static class InheritIgnoreOverride extends DirectIgnore {
+        @Override
+        public String getIgnoreMe() {
+            return super.getIgnoreMe();
+        }
+
+        @Override
+        public void setIgnoreMe(String ignoreMe) {
+            super.setIgnoreMe(ignoreMe);
+        }
+
+        @Override
+        public String getDontIgnoreMe() {
+            return super.getDontIgnoreMe();
+        }
+
+        @Override
+        public void setDontIgnoreMe(String dontIgnoreMe) {
+            super.setDontIgnoreMe(dontIgnoreMe);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #374 

* Added Tests (Inheritance worked already if the getters/setters are not overriden but i think this is expected.
* Enhance IgnoreResolver for Inherited @JsonIgnoreProperties


