### PR TITLE
Use nested type param names in schema name, resolve types earlier

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -351,16 +351,16 @@ public class SchemaRegistry {
         static void appendParameterNames(StringBuilder name, ParameterizedType type) {
             for (Type param : type.asParameterizedType().arguments()) {
                 switch (param.kind()) {
-                case PARAMETERIZED_TYPE:
-                    name.append(param.name().local());
-                    appendParameterNames(name, param.asParameterizedType());
-                    break;
-                case WILDCARD_TYPE:
-                    name.append(wildcardName(param.asWildcardType()));
-                    break;
-                default:
-                    name.append(param.name().local());
-                    break;
+                    case PARAMETERIZED_TYPE:
+                        name.append(param.name().local());
+                        appendParameterNames(name, param.asParameterizedType());
+                        break;
+                    case WILDCARD_TYPE:
+                        name.append(wildcardName(param.asWildcardType()));
+                        break;
+                    default:
+                        name.append(param.name().local());
+                        break;
                 }
             }
         }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
@@ -138,7 +138,11 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
 
     static class POJO extends BaseModel {
         private String name;
-        public String getName() { return  name; }
+
+        public String getName() {
+            return name;
+        }
+
         public void setName(String name) {
             this.name = name;
         }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
@@ -58,6 +58,7 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
                 ResidentsResource.class,
                 Result.class,
                 ResultList.class,
+                POJO.class,
                 List.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(nestingSupportConfig(), i);
         OpenAPI result = scanner.scan();

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -134,6 +135,14 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
         }
     }
 
+    static class POJO extends BaseModel {
+        private String name;
+        public String getName() { return  name; }
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
     static class KingCrimson extends BaseModel {
         public enum Status {
             unknown,
@@ -260,7 +269,7 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
 
     }
 
-    static class Result<T extends BaseModel> {
+    static class Result<T> {
         private T result;
         private Message error;
         private Integer status;
@@ -277,7 +286,7 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
             return result;
         }
 
-        public static class ResultBuilder<T extends BaseModel> {
+        public static class ResultBuilder<T> {
             private Integer status;
             private Message error = new Message();
             private T result;
@@ -398,6 +407,15 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
                 @QueryParam("offset") int offset,
                 @QueryParam("orderby") List<String> orderBy) {
             return super.getAll1();
+        }
+
+        @GET
+        @Path("/noooooooo")
+        public Result<List<POJO>> getList() {
+            return new Result.ResultBuilder<List<POJO>>()
+                    .status(200)
+                    .result(new ArrayList<>())
+                    .build();
         }
 
         @POST

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
@@ -39,7 +39,7 @@ public class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
     }
 
     /**
-     * Test parameterised type as a top-level entity (i.e. not just a bare class).
+     * Test parameterized type as a top-level entity (i.e. not just a bare class).
      *
      * @see org.jboss.jandex.ParameterizedType
      */

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
@@ -29,11 +29,7 @@ public class SchemaRegistryTests extends IndexScannerTestBase {
 
     @Test
     public void testParameterizedNameCollisionsUseSequence() throws IOException, JSONException {
-        Indexer indexer = new Indexer();
-        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
-        index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
-        Index index = indexer.complete();
-
+        Index index = indexOf(Container.class, Nestable.class);
         OpenAPIImpl oai = new OpenAPIImpl();
         SchemaRegistry registry = SchemaRegistry.newInstance(emptyConfig(), oai, index);
 
@@ -48,9 +44,9 @@ public class SchemaRegistryTests extends IndexScannerTestBase {
         Schema s2 = registry.register(n2.type(), new SchemaImpl());
         Schema s3 = registry.register(n3.type(), new SchemaImpl());
 
-        assertEquals("#/components/schemas/NestableStringNestable", s1.getRef());
-        assertEquals("#/components/schemas/NestableStringNestable1", s2.getRef());
-        assertEquals("#/components/schemas/NestableStringNestable2", s3.getRef());
+        assertEquals("#/components/schemas/NestableStringNestableStringString", s1.getRef());
+        assertEquals("#/components/schemas/NestableStringNestableStringObject", s2.getRef());
+        assertEquals("#/components/schemas/NestableStringNestableStringNestableStringObject", s3.getRef());
     }
 
     @Test

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "schemas": {
-      "KustomPairFuzzObject": {
+      "KustomPairFuzzStringDateObject": {
         "required": [
           "bar",
           "foo"
@@ -50,7 +50,7 @@
           }
         }
       },
-      "FuzzKustomPairDouble": {
+      "FuzzKustomPairFuzzStringDateObjectDouble": {
         "type": "object",
         "properties": {
           "qAgain": {
@@ -67,13 +67,13 @@
             "type": "number"
           },
           "tAgain2": {
-            "$ref": "#/components/schemas/KustomPairFuzzObject"
+            "$ref": "#/components/schemas/KustomPairFuzzStringDateObject"
           },
           "tAgain4": {
-            "$ref": "#/components/schemas/KustomPairFuzzObject"
+            "$ref": "#/components/schemas/KustomPairFuzzStringDateObject"
           },
           "tValue": {
-            "$ref": "#/components/schemas/KustomPairFuzzObject"
+            "$ref": "#/components/schemas/KustomPairFuzzStringDateObject"
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
@@ -17,7 +17,7 @@
           }
         }
       },
-      "KustomPairKustomPairInteger": {
+      "KustomPairKustomPairStringStringInteger": {
         "type": "object",
         "required": [
           "bar",

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
@@ -201,7 +201,7 @@
           }
         }
       },
-      "KustomPairFuzzInteger": {
+      "KustomPairFuzzStringObjectInteger": {
         "required": [
           "bar",
           "foo"
@@ -224,7 +224,7 @@
           }
         }
       },
-      "FuzzKustomPairDouble": {
+      "FuzzKustomPairFuzzStringObjectIntegerDouble": {
         "type": "object",
         "properties": {
           "qAgain": {
@@ -241,13 +241,13 @@
             "type": "number"
           },
           "tAgain2": {
-            "$ref": "#/components/schemas/KustomPairFuzzInteger"
+            "$ref": "#/components/schemas/KustomPairFuzzStringObjectInteger"
           },
           "tAgain4": {
-            "$ref": "#/components/schemas/KustomPairFuzzInteger"
+            "$ref": "#/components/schemas/KustomPairFuzzStringObjectInteger"
           },
           "tValue": {
-            "$ref": "#/components/schemas/KustomPairFuzzInteger"
+            "$ref": "#/components/schemas/KustomPairFuzzStringObjectInteger"
           }
         }
       },
@@ -311,7 +311,7 @@
           }
         }
       },
-      "KustomPairKustomPairInteger": {
+      "KustomPairKustomPairStringStringInteger": {
         "required": [
           "bar",
           "foo"
@@ -444,7 +444,7 @@
             }
           },
           "complexNesting": {
-            "$ref": "#/components/schemas/FuzzKustomPairDouble"
+            "$ref": "#/components/schemas/FuzzKustomPairFuzzStringObjectIntegerDouble"
           },
           "creditCardMap": {
             "type": "object",
@@ -475,7 +475,7 @@
             }
           },
           "nesting": {
-            "$ref": "#/components/schemas/KustomPairKustomPairInteger"
+            "$ref": "#/components/schemas/KustomPairKustomPairStringStringInteger"
           },
           "password": {
             "type": "string",

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types.json
@@ -126,6 +126,22 @@
         }
       }
     },
+    "/v1/kingcrimson/noooooooo": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/magma": {
       "get": {
         "parameters": [
@@ -349,6 +365,14 @@
   },
   "components": {
     "schemas": {
+      "POJO": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "Magma": {
         "type": "object",
         "properties": {
@@ -427,6 +451,27 @@
           },
           "result": {
             "$ref": "#/components/schemas/ListKingCrimson"
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "ListPOJO" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/POJO"
+        }
+      },
+      "ResultList": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "result": {
+            "$ref": "#/components/schemas/ListPOJO"
           },
           "status": {
             "format": "int32",

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types.json
@@ -134,7 +134,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ResultList"
+                  "$ref": "#/components/schemas/ResultListPOJO"
                 }
               }
             }
@@ -368,6 +368,15 @@
       "POJO": {
         "type": "object",
         "properties": {
+          "id": {
+            "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+            "type": "string"
+          },
+          "lastUpdate": {
+            "format": "date-time",
+            "type": "string"
+          },
           "name": {
             "type": "string"
           }
@@ -458,13 +467,13 @@
           }
         }
       },
-      "ListPOJO" : {
-        "type" : "array",
-        "items" : {
-          "$ref" : "#/components/schemas/POJO"
+      "ListPOJO": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/POJO"
         }
       },
-      "ResultList": {
+      "ResultListPOJO": {
         "type": "object",
         "properties": {
           "error": {


### PR DESCRIPTION
Fixes #388 

Creating this PR as a draft so it can be re-based after the other open PRs. The changes here impact the naming of schemas under `#/components/schemas/...` - not sure if that merits a bump to the minor version or not.