### PR TITLE
Set empty security array for empty `@SecurityRequirements`

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
@@ -17,6 +17,7 @@ import io.smallrye.openapi.api.models.security.SecurityRequirementImpl;
 import io.smallrye.openapi.runtime.io.IoLogging;
 import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.util.JandexUtil;
+import io.smallrye.openapi.runtime.util.TypeUtil;
 
 /**
  * Reading the Security from annotations or json
@@ -119,6 +120,11 @@ public class SecurityRequirementReader {
             return requirement;
         }
         return null;
+    }
+
+    // helper methods for scanners
+    public static AnnotationInstance getSecurityRequirementsAnnotation(final AnnotationTarget target) {
+        return TypeUtil.getAnnotation(target, SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS);
     }
 
     // helper methods for scanners

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
@@ -40,6 +40,7 @@ import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.api.models.media.SchemaImpl;
 import io.smallrye.openapi.runtime.io.Format;
 import io.smallrye.openapi.runtime.io.OpenApiParser;
+import test.io.smallrye.openapi.runtime.scanner.resources.EmptySecurityRequirementsResource;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -275,12 +276,8 @@ public class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
 
     @Test
     public void testEmptySecurityRequirements() throws IOException, JSONException {
-        Indexer indexer = new Indexer();
-
-        // Test samples
-        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/EmptySecurityRequirementsResource.class");
-
-        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), indexer.complete());
+        Index index = indexOf(EmptySecurityRequirementsResource.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
 
         OpenAPI result = scanner.scan();
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
@@ -272,4 +272,19 @@ public class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
             @Tag(name = "tag1") })
     static class TagTestApp extends Application {
     }
+
+    @Test
+    public void testEmptySecurityRequirements() throws IOException, JSONException {
+        Indexer indexer = new Indexer();
+
+        // Test samples
+        index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/EmptySecurityRequirementsResource.class");
+
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), indexer.complete());
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("resource.testEmptySecurityRequirements.json", result);
+    }
 }

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/EmptySecurityRequirementsResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/EmptySecurityRequirementsResource.java
@@ -1,0 +1,15 @@
+package test.io.smallrye.openapi.runtime.scanner.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirements;
+
+@Path("/public")
+public class EmptySecurityRequirementsResource {
+
+    @GET
+    @SecurityRequirements
+    public String getPublicResponse() {
+        return "response value";
+    }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testEmptySecurityRequirements.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testEmptySecurityRequirements.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/public": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #382 

@phillip-kruger , @EricWittmann - what are your thoughts on this behavior? 

1. Set `security` to an empty array if the user gives an empty `@SecurityRequirements` at either the resource method or class level
2. Do not combine method and class level security requirements. Allow method level to override the class level, if given