### PR TITLE
Restore AirlinesAppTckTest

### DIFF
--- a/tck/src/test/java/io/smallrye/openapi/tck/AirlinesAppTckTest.java
+++ b/tck/src/test/java/io/smallrye/openapi/tck/AirlinesAppTckTest.java
@@ -17,7 +17,6 @@
 package io.smallrye.openapi.tck;
 
 import org.eclipse.microprofile.openapi.tck.AirlinesAppTest;
-import org.junit.Ignore;
 
 import test.io.smallrye.openapi.tck.BaseTckTest;
 import test.io.smallrye.openapi.tck.TckTest;
@@ -27,9 +26,4 @@ import test.io.smallrye.openapi.tck.TckTest;
  */
 @TckTest
 public class AirlinesAppTckTest extends BaseTckTest<AirlinesAppTest> {
-    @Ignore
-    @SuppressWarnings("unused")
-    //FIXME: Remove this Ignored test override when @SchemaProperty support is added
-    public void testSchemaProperty(String type) {
-    }
 }


### PR DESCRIPTION
Related to issue #392.

One `master` (MicroProfile `1.x`) the test is passing. This commits proves it and can be merged.

For MicroProfile `2.0` compliance, support for `@SchemaProperty` must be added, in order to pass this test.