### PR TITLE
Auto Generation of OperationId .  fixes #265

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -66,4 +66,13 @@ public interface OpenApiConfig {
     public String getInfoLicenseName();
 
     public String getInfoLicenseUrl();
+
+    public OperationIdStrategy getOperationIdStrategy();
+
+    enum OperationIdStrategy {
+        METHOD,
+        CLASS_METHOD,
+        PACKAGE_CLASS_METHOD
+    }
+
 }

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -46,6 +46,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     private String infoContactUrl;
     private String infoLicenseName;
     private String infoLicenseUrl;
+    private OperationIdStrategy operationIdStrategy;
 
     public static OpenApiConfig fromConfig(Config config) {
         return new OpenApiConfigImpl(config);
@@ -327,6 +328,17 @@ public class OpenApiConfigImpl implements OpenApiConfig {
             infoLicenseUrl = getStringConfigValue(OpenApiConstants.INFO_LICENSE_URL);
         }
         return infoLicenseUrl;
+    }
+
+    @Override
+    public OperationIdStrategy getOperationIdStrategy() {
+        if (operationIdStrategy == null) {
+            String strategy = getStringConfigValue(OpenApiConstants.OPERATION_ID_STRAGEGY);
+            if (strategy != null) {
+                return OperationIdStrategy.valueOf(strategy);
+            }
+        }
+        return null;
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
@@ -48,6 +48,7 @@ public final class OpenApiConstants {
     public static final String INFO_CONTACT_URL = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME + "info.contact.url";
     public static final String INFO_LICENSE_NAME = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME + "info.license.name";
     public static final String INFO_LICENSE_URL = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME + "info.license.url";
+    public static final String OPERATION_ID_STRAGEGY = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME + "operationIdStrategy";
 
     /**
      * Set of classes which should never be scanned, regardless of user configuration.

--- a/core/src/main/java/io/smallrye/openapi/runtime/OpenApiProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/OpenApiProcessor.java
@@ -78,7 +78,11 @@ public class OpenApiProcessor {
 
         OpenApiDocument.INSTANCE.initialize();
 
-        return OpenApiDocument.INSTANCE.get();
+        OpenAPI openAPI = OpenApiDocument.INSTANCE.get();
+
+        OpenApiDocument.INSTANCE.reset();
+
+        return openAPI;
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/callback/CallbackReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/callback/CallbackReader.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.openapi.models.callbacks.Callback;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.MethodInfo;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -82,15 +83,22 @@ public class CallbackReader {
         return callbacks;
     }
 
+    public static Callback readCallback(final AnnotationScannerContext context,
+            final AnnotationInstance annotation) {
+        return readCallback(context, annotation, null);
+    }
+
     /**
      * Reads a Callback annotation into a model.
      * 
      * @param annotation the {@literal @}Callback annotation
      * @param context the scanner context
+     * @param methodInfo the method
      * @return Callback model
      */
     public static Callback readCallback(final AnnotationScannerContext context,
-            final AnnotationInstance annotation) {
+            final AnnotationInstance annotation,
+            final MethodInfo methodInfo) {
         if (annotation == null) {
             return null;
         }
@@ -99,7 +107,7 @@ public class CallbackReader {
         callback.setRef(JandexUtil.refValue(annotation, JandexUtil.RefType.Callback));
         String expression = JandexUtil.stringValue(annotation, CallbackConstant.PROP_CALLBACK_URL_EXPRESSION);
         callback.addPathItem(expression,
-                PathsReader.readPathItem(context, annotation.value(CallbackConstant.PROP_OPERATIONS)));
+                PathsReader.readPathItem(context, annotation.value(CallbackConstant.PROP_OPERATIONS), null));
         return callback;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/paths/PathsReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/paths/PathsReader.java
@@ -11,6 +11,7 @@ import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.Paths;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.MethodInfo;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -62,6 +63,12 @@ public class PathsReader {
         return paths;
     }
 
+    public static PathItem readPathItem(final AnnotationScannerContext context,
+            final AnnotationValue annotationValue) {
+
+        return readPathItem(context, annotationValue, null);
+    }
+
     /**
      * Reads the PathItem.
      * Also used in CallbackOperation
@@ -71,7 +78,8 @@ public class PathsReader {
      * @return PathItem model
      */
     public static PathItem readPathItem(final AnnotationScannerContext context,
-            final AnnotationValue annotationValue) {
+            final AnnotationValue annotationValue,
+            final MethodInfo methodInfo) {
         if (annotationValue == null) {
             return null;
         }
@@ -80,10 +88,10 @@ public class PathsReader {
         PathItem pathItem = new PathItemImpl();
         for (AnnotationInstance operationAnno : nestedArray) {
             String method = JandexUtil.stringValue(operationAnno, PathsConstant.PROP_METHOD);
-            Operation operation = OperationReader.readOperation(context, operationAnno);
             if (method == null) {
                 continue;
             }
+            Operation operation = OperationReader.readOperation(context, operationAnno, methodInfo);
             try {
                 PropertyDescriptor descriptor = new PropertyDescriptor(method.toUpperCase(), pathItem.getClass());
                 Method mutator = descriptor.getWriteMethod();

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -160,6 +160,14 @@ public class JandexUtil {
         }
     }
 
+    public static Optional<String> optionalStringValue(AnnotationInstance annotation, String propertyName) {
+        String value = stringValue(annotation, propertyName);
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
+    }
+
     /**
      * Reads a Boolean property value from the given annotation instance. If no value is found
      * this will return null.

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationIdTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationIdTest.java
@@ -1,0 +1,101 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import java.io.IOException;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.json.JSONException;
+import org.junit.Test;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConfigImpl;
+import io.smallrye.openapi.runtime.OpenApiProcessor;
+import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingOperationResource;
+
+/**
+ * Basic tests to check the operation Id autogeneration
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class OperationIdTest extends JaxRsDataObjectScannerTestBase {
+
+    private static final String OPERATION_ID_PROPERTY = "mp.openapi.extensions.smallrye.operationIdStrategy";
+
+    /**
+     * This test a Method naming strategy
+     * 
+     * @throws java.io.IOException
+     * @throws org.json.JSONException
+     */
+    @Test
+    public void testMethodNaming() throws IOException, JSONException {
+        System.setProperty(OPERATION_ID_PROPERTY, "METHOD");
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        try {
+            Index i = indexOf(GreetingGetResource.class, Greeting.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
+
+            printToConsole(result);
+            assertJsonEquals("resource.testOperationIdMethod.json", result);
+
+        } finally {
+            System.clearProperty(OPERATION_ID_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testClassMethodNaming() throws IOException, JSONException {
+        System.setProperty(OPERATION_ID_PROPERTY, "CLASS_METHOD");
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        try {
+            Index i = indexOf(GreetingGetResource.class, Greeting.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
+
+            printToConsole(result);
+            assertJsonEquals("resource.testOperationIdClassMethod.json", result);
+
+        } finally {
+            System.clearProperty(OPERATION_ID_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testPackageClassMethodNaming() throws IOException, JSONException {
+        System.setProperty(OPERATION_ID_PROPERTY, "PACKAGE_CLASS_METHOD");
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        try {
+            Index i = indexOf(GreetingGetResource.class, Greeting.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
+
+            printToConsole(result);
+            assertJsonEquals("resource.testOperationIdPackageClassMethod.json", result);
+
+        } finally {
+            System.clearProperty(OPERATION_ID_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testMethodNamingWhenOperationIsSet() throws IOException, JSONException {
+        System.setProperty(OPERATION_ID_PROPERTY, "METHOD");
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        try {
+            Index i = indexOf(GreetingOperationResource.class, Greeting.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
+
+            printToConsole(result);
+            assertJsonEquals("resource.testOperationIdMethodWithOperation.json", result);
+
+        } finally {
+            System.clearProperty(OPERATION_ID_PROPERTY);
+        }
+    }
+}

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingOperationResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingOperationResource.java
@@ -1,0 +1,41 @@
+package test.io.smallrye.openapi.runtime.scanner.resources;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+
+import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
+
+/**
+ * Test the auto generation of Operation Id in the case that there is an operation annotation
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+@Path("/greeting")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class GreetingOperationResource {
+
+    @GET
+    @Operation(description = "Here some description")
+    @Path("/helloPathVariable/{name}")
+    public Greeting helloPathVariable(@PathParam("name") String name) {
+        return new Greeting("Hello " + name);
+    }
+
+    @GET
+    @Operation(operationId = "myOwnId")
+    @Path("/hellosPathVariable/{name}")
+    public List<Greeting> hellosPathVariable(@PathParam("name") String name) {
+        return Arrays.asList(new Greeting("Hello " + name));
+    }
+
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdClassMethod.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdClassMethod.json
@@ -1,59 +1,17 @@
 {
   "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  },
   "paths" : {
-    "/greeting/defaultGet/{name}" : {
-      "get" : {
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Greeting"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/greeting/helloOptional/{name}" : {
       "get" : {
+        "operationId" : "GreetingGetResource_helloOptional",
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
           "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Greeting"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/greeting/helloPath" : {
-      "get" : {
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "query",
           "schema" : {
             "type" : "string"
           }
@@ -74,6 +32,7 @@
     },
     "/greeting/helloPathVariable/{name}" : {
       "get" : {
+        "operationId" : "GreetingGetResource_helloPathVariable",
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
@@ -98,6 +57,32 @@
     },
     "/greeting/helloPathVariableWithResponse/{name}" : {
       "get" : {
+        "operationId" : "GreetingGetResource_helloPathVariableWithResponse",        
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "operationId" : "GreetingGetResource_helloPathVariableWithResponseTyped",        
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
@@ -122,6 +107,7 @@
     },
     "/greeting/helloRequestParam" : {
       "get" : {
+        "operationId" : "GreetingGetResource_helloRequestParam",        
         "parameters" : [ {
           "name" : "name",
           "in" : "query",
@@ -145,6 +131,7 @@
     },
     "/greeting/hellosPathVariable/{name}" : {
       "get" : {
+        "operationId" : "GreetingGetResource_hellosPathVariable",        
         "parameters" : [ {
           "name" : "name",
           "in" : "path",

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdMethod.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdMethod.json
@@ -1,59 +1,17 @@
 {
   "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  },
   "paths" : {
-    "/greeting/defaultGet/{name}" : {
-      "get" : {
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Greeting"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/greeting/helloOptional/{name}" : {
       "get" : {
+        "operationId" : "helloOptional",
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
           "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Greeting"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/greeting/helloPath" : {
-      "get" : {
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "query",
           "schema" : {
             "type" : "string"
           }
@@ -74,6 +32,7 @@
     },
     "/greeting/helloPathVariable/{name}" : {
       "get" : {
+        "operationId" : "helloPathVariable",
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
@@ -98,6 +57,32 @@
     },
     "/greeting/helloPathVariableWithResponse/{name}" : {
       "get" : {
+        "operationId" : "helloPathVariableWithResponse",        
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "operationId" : "helloPathVariableWithResponseTyped",        
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
@@ -122,6 +107,7 @@
     },
     "/greeting/helloRequestParam" : {
       "get" : {
+        "operationId" : "helloRequestParam",        
         "parameters" : [ {
           "name" : "name",
           "in" : "query",
@@ -145,6 +131,7 @@
     },
     "/greeting/hellosPathVariable/{name}" : {
       "get" : {
+        "operationId" : "hellosPathVariable",        
         "parameters" : [ {
           "name" : "name",
           "in" : "path",

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdMethodWithOperation.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdMethodWithOperation.json
@@ -1,0 +1,75 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  },
+  "paths" : {
+    "/greeting/helloPathVariable/{name}" : {
+      "get" : {
+        "description" : "Here some description",
+        "operationId" : "helloPathVariable",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/hellosPathVariable/{name}" : {
+      "get" : {
+        "operationId" : "myOwnId",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Greeting"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "Greeting" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdPackageClassMethod.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdPackageClassMethod.json
@@ -1,59 +1,17 @@
 {
   "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  },
   "paths" : {
-    "/greeting/defaultGet/{name}" : {
-      "get" : {
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Greeting"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/greeting/helloOptional/{name}" : {
       "get" : {
+        "operationId" : "test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource_helloOptional",
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
           "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Greeting"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/greeting/helloPath" : {
-      "get" : {
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "query",
           "schema" : {
             "type" : "string"
           }
@@ -74,6 +32,7 @@
     },
     "/greeting/helloPathVariable/{name}" : {
       "get" : {
+        "operationId" : "test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource_helloPathVariable",
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
@@ -98,6 +57,32 @@
     },
     "/greeting/helloPathVariableWithResponse/{name}" : {
       "get" : {
+        "operationId" : "test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource_helloPathVariableWithResponse",        
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "operationId" : "test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource_helloPathVariableWithResponseTyped",        
         "parameters" : [ {
           "name" : "name",
           "in" : "path",
@@ -122,6 +107,7 @@
     },
     "/greeting/helloRequestParam" : {
       "get" : {
+        "operationId" : "test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource_helloRequestParam",        
         "parameters" : [ {
           "name" : "name",
           "in" : "query",
@@ -145,6 +131,7 @@
     },
     "/greeting/hellosPathVariable/{name}" : {
       "get" : {
+        "operationId" : "test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource_hellosPathVariable",        
         "parameters" : [ {
           "name" : "name",
           "in" : "path",

--- a/extension-vertx/pom.xml
+++ b/extension-vertx/pom.xml
@@ -87,11 +87,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <environmentVariables>
-                    </environmentVariables>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
@@ -19,6 +19,7 @@ import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
 
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.api.models.OpenAPIImpl;
@@ -78,7 +79,8 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
             if (VertxParameter.isParameter(instance.name())) {
                 return true;
             }
-            if (instance.name().toString().startsWith(VERTX_PACKAGE)) {
+            if (instance.name().toString().startsWith(VERTX_PACKAGE)
+                    && !instance.name().equals(VertxConstants.REQUEST_BODY)) {
                 return true;
             }
             for (AnnotationScannerExtension extension : extensions) {
@@ -87,6 +89,11 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean isScannerInternalParameter(Type parameterType) {
+        return VertxConstants.INTERNAL_PARAMETERS.contains(parameterType.name());
     }
 
     @Override
@@ -218,10 +225,13 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
                             }
                         }
                     } else {
-                        // TODO: Default ? Look at RouteBase
+                        // Default to GET
+                        processRouteMethod(context, resourceClass, methodInfo, PathItem.HttpMethod.GET, openApi, tagRefs,
+                                locatorPathParameters);
                     }
+                } else {
+                    // TODO: Default ? Look at RouteBase
                 }
-
             }
         }
     }

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxConstants.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxConstants.java
@@ -1,5 +1,8 @@
 package io.smallrye.openapi.vertx;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.jboss.jandex.DotName;
 
 /**
@@ -15,6 +18,20 @@ public class VertxConstants {
     public static final DotName REQUEST_BODY = DotName.createSimple("io.quarkus.vertx.web.Body");
     public static final DotName PARAM = DotName.createSimple("io.quarkus.vertx.web.Param");
     public static final DotName HEADER_PARAM = DotName.createSimple("io.quarkus.vertx.web.Header");
+
+    public static final DotName ROUTING_CONTEXT = DotName.createSimple("io.vertx.ext.web.RoutingContext");
+    public static final DotName R_ROUTING_CONTEXT = DotName.createSimple("io.vertx.reactivex.ext.web.RoutingContext");
+    public static final DotName ROUTING_EXCHANGE = DotName.createSimple("io.quarkus.vertx.web.RoutingExchange");
+    public static final DotName HTTP_SERVER_REQUEST = DotName.createSimple("io.vertx.core.http.HttpServerRequest");
+    public static final DotName HTTP_SERVER_RESPONSE = DotName.createSimple("io.vertx.core.http.HttpServerResponse");
+    public static final DotName R_HTTP_SERVER_REQUEST = DotName.createSimple("io.vertx.reactivex.core.http.HttpServerRequest");
+    public static final DotName R_HTTP_SERVER_RESPONSE = DotName
+            .createSimple("io.vertx.reactivex.core.http.HttpServerResponse");
+
+    public static final List<DotName> INTERNAL_PARAMETERS = Arrays.asList(new DotName[] {
+            ROUTING_CONTEXT, R_ROUTING_CONTEXT, ROUTING_EXCHANGE, HTTP_SERVER_REQUEST, HTTP_SERVER_RESPONSE,
+            R_HTTP_SERVER_REQUEST, R_HTTP_SERVER_RESPONSE
+    });
 
     private VertxConstants() {
     }

--- a/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingGetRoute.java
+++ b/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingGetRoute.java
@@ -13,7 +13,11 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import io.quarkus.vertx.web.Param;
 import io.quarkus.vertx.web.Route;
 import io.quarkus.vertx.web.RouteBase;
+import io.quarkus.vertx.web.RoutingExchange;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
 
 /**
@@ -29,38 +33,51 @@ public class GreetingGetRoute {
 
     // 1) Basic path var test
     @Route(path = "/helloPathVariable/:name", methods = HttpMethod.GET)
-    public Greeting helloPathVariable(@Param("name") String name) {
+    public Greeting helloPathVariable(RoutingContext context, @Param("name") String name) {
         return new Greeting("Hello " + name);
     }
 
     // 2) Basic path var test
     @Route(path = "/hellosPathVariable/:name", methods = HttpMethod.GET)
-    public List<Greeting> hellosPathVariable(@Param("name") String name) {
+    public List<Greeting> hellosPathVariable(RoutingExchange routingExchange, @Param("name") String name) {
         return Arrays.asList(new Greeting("Hello " + name));
     }
 
     // 3) Basic path var with Optional test
     @Route(path = "/helloOptional/:name", methods = HttpMethod.GET)
-    public Optional<Greeting> helloOptional(@Param("name") String name) {
+    public Optional<Greeting> helloOptional(HttpServerRequest httpServerRequest, @Param("name") String name) {
         return Optional.of(new Greeting("Hello " + name));
     }
 
     // 4) Basic request param test
     @Route(path = "/helloRequestParam", methods = HttpMethod.GET)
-    public Greeting helloRequestParam(@Param("name") String name) {
+    public Greeting helloRequestParam(HttpServerResponse httpServerResponse, @Param("name") String name) {
         return new Greeting("Hello " + name);
     }
 
     // 5) Void, so without a type specified
     @Route(path = "/helloPathVariableWithResponse/:name", methods = HttpMethod.GET)
     @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(ref = "#/components/schemas/Greeting")))
-    public void helloPathVariableWithResponse(@Param("name") String name) {
+    public void helloPathVariableWithResponse(io.vertx.reactivex.core.http.HttpServerRequest httpServerRequest,
+            @Param("name") String name) {
         // 
     }
 
     // 6) Failure should not end up the schema
     @Route(path = "/helloFailure/:name", methods = HttpMethod.GET, type = Route.HandlerType.FAILURE)
     public Greeting helloFailure(@Param("name") String name) {
+        return new Greeting("Hello " + name);
+    }
+
+    // 7) Default GET
+    @Route(path = "/defaultGet/:name")
+    public Greeting helloDefault(@Param("name") String name) {
+        return new Greeting("Hello " + name);
+    }
+
+    // 8) Default path
+    @Route
+    public Greeting helloPath(@Param("name") String name) {
         return new Greeting("Hello " + name);
     }
 }

--- a/tck/src/test/java/test/io/smallrye/openapi/tck/TckTestRunner.java
+++ b/tck/src/test/java/test/io/smallrye/openapi/tck/TckTestRunner.java
@@ -103,7 +103,7 @@ public class TckTestRunner extends ParentRunner<ProxiedTckTest> {
                 parent.mkdir();
             }
             File file = new File(parent, testClass.getName() + ".json");
-            String content = OpenApiSerializer.serialize(OpenApiDocument.INSTANCE.get(), Format.JSON);
+            String content = OpenApiSerializer.serialize(openAPI, Format.JSON);
             try (FileWriter writer = new FileWriter(file)) {
                 IOUtils.write(content, writer);
             }


### PR DESCRIPTION
Fix #265
This adds the auto generate of Openration Id on annotation scanning, when a config is set.
This also added some more features in the Vert.x scanner, like default to GET and default path.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>