### PR TITLE
Load AnnotationScanner instances from the designated classloader.

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -35,7 +35,7 @@ import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerFactory;
 public class OpenApiAnnotationScanner {
 
     private final AnnotationScannerContext annotationScannerContext;
-    private final AnnotationScannerFactory annotationScannerFactory = new AnnotationScannerFactory();
+    private final AnnotationScannerFactory annotationScannerFactory;
 
     /**
      * Constructor.
@@ -89,6 +89,7 @@ public class OpenApiAnnotationScanner {
         }
 
         this.annotationScannerContext = new AnnotationScannerContext(filteredIndexView, loader, extensions, config);
+        this.annotationScannerFactory = new AnnotationScannerFactory(loader);
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerFactory.java
@@ -15,8 +15,8 @@ import java.util.ServiceLoader;
 public class AnnotationScannerFactory {
     private final Map<String, AnnotationScanner> loadedScanners = new HashMap<>();
 
-    public AnnotationScannerFactory() {
-        ServiceLoader<AnnotationScanner> loader = ServiceLoader.load(AnnotationScanner.class);
+    public AnnotationScannerFactory(ClassLoader cl) {
+        ServiceLoader<AnnotationScanner> loader = ServiceLoader.load(AnnotationScanner.class, cl);
         Iterator<AnnotationScanner> scannerIterator = loader.iterator();
         while (scannerIterator.hasNext()) {
             AnnotationScanner scanner = scannerIterator.next();


### PR DESCRIPTION
Fixes https://github.com/smallrye/smallrye-open-api/issues/404