### PR TITLE
Support `@Schema` on non-JavaBeans accessor/mutator methods (2.0.x)

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -646,7 +646,8 @@ public class TypeResolver {
             return false;
         }
 
-        return METHOD_PREFIX_SET.equals(methodNamePrefix(method)) || TypeUtil.hasAnnotation(method, SchemaConstant.DOTNAME_SCHEMA);
+        return METHOD_PREFIX_SET.equals(methodNamePrefix(method))
+                || TypeUtil.hasAnnotation(method, SchemaConstant.DOTNAME_SCHEMA);
     }
 
     private static String methodNamePrefix(MethodInfo method) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -42,6 +42,9 @@ import io.smallrye.openapi.runtime.util.TypeUtil;
 public class TypeResolver {
 
     private static final Type BOOLEAN_TYPE = Type.create(DotName.createSimple(Boolean.class.getName()), Type.Kind.CLASS);
+    static final String METHOD_PREFIX_GET = "get";
+    static final String METHOD_PREFIX_IS = "is";
+    static final String METHOD_PREFIX_SET = "set";
 
     private final Deque<Map<String, Type>> resolutionStack;
     private final String propertyName;
@@ -92,7 +95,7 @@ public class TypeResolver {
         if (t2.kind() == Kind.FIELD) {
             return +1;
         }
-        if (t1.asMethod().name().startsWith("get") && !t2.asMethod().name().startsWith("get")) {
+        if (isAccessor(t1.asMethod()) && !isAccessor(t2.asMethod())) {
             return -1;
         }
 
@@ -558,23 +561,23 @@ public class TypeResolver {
             Deque<Map<String, Type>> stack,
             MethodInfo method,
             Type propertyType) {
-        String methodName = method.name();
-        boolean isWriteMethod = isMutator(method);
-        String propertyName;
-        int nameStart;
 
-        if (isWriteMethod) {
-            nameStart = 3;
-        } else {
-            nameStart = methodName.startsWith("is") ? 2 : 3;
-        }
+        final String methodName = method.name();
+        final int nameStart = methodNamePrefix(method).length();
+        final boolean isWriteMethod = isMutator(method);
+        final String propertyName;
 
         if (methodName.length() == nameStart) {
             // The method's name is "get", "set", or "is" without the property name
             return null;
         }
 
-        propertyName = Character.toLowerCase(methodName.charAt(nameStart)) + methodName.substring(nameStart + 1);
+        if (nameStart > 0) {
+            propertyName = Character.toLowerCase(methodName.charAt(nameStart)) + methodName.substring(nameStart + 1);
+        } else {
+            propertyName = methodName;
+        }
+
         TypeResolver resolver;
 
         if (properties.containsKey(propertyName)) {
@@ -617,13 +620,16 @@ public class TypeResolver {
             return false;
         }
 
-        String methodName = method.name();
+        String namePrefix = methodNamePrefix(method);
 
-        if (methodName.startsWith("get")) {
+        if (METHOD_PREFIX_GET.equals(namePrefix)) {
+            return true;
+        }
+        if (METHOD_PREFIX_IS.equals(namePrefix) && TypeUtil.equalTypes(returnType, BOOLEAN_TYPE)) {
             return true;
         }
 
-        return methodName.startsWith("is") && TypeUtil.equalTypes(returnType, BOOLEAN_TYPE);
+        return TypeUtil.hasAnnotation(method, SchemaConstant.DOTNAME_SCHEMA);
     }
 
     /**
@@ -640,7 +646,25 @@ public class TypeResolver {
             return false;
         }
 
-        return method.name().startsWith("set");
+        return METHOD_PREFIX_SET.equals(methodNamePrefix(method)) || TypeUtil.hasAnnotation(method, SchemaConstant.DOTNAME_SCHEMA);
+    }
+
+    private static String methodNamePrefix(MethodInfo method) {
+        String methodName = method.name();
+
+        if (methodName.startsWith(METHOD_PREFIX_GET)) {
+            return METHOD_PREFIX_GET;
+        }
+
+        if (methodName.startsWith(METHOD_PREFIX_IS)) {
+            return METHOD_PREFIX_IS;
+        }
+
+        if (methodName.startsWith(METHOD_PREFIX_SET)) {
+            return METHOD_PREFIX_SET;
+        }
+
+        return "";
     }
 
     private static boolean isHigherPriority(MethodInfo newMethod, MethodInfo oldMethod) {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -187,7 +187,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
 
     @Test
     public void testNonJavaBeansPropertyAccessor() {
-        AugmentedIndexView index = AugmentedIndexView.augment(indexOf(NonJavaBeanAccessorProperty.class));
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(NonJavaBeanAccessorProperty.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(NonJavaBeanAccessorProperty.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
         Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
@@ -198,13 +198,13 @@ public class TypeResolverTests extends IndexScannerTestBase {
         assertEquals("name", property.getPropertyName());
         assertEquals(property.getReadMethod(), property.getAnnotationTarget());
         assertEquals("Name of the property", TypeUtil.getAnnotationValue(property.getAnnotationTarget(),
-                                                     SchemaConstant.DOTNAME_SCHEMA,
-                                                     SchemaConstant.PROP_TITLE));
+                SchemaConstant.DOTNAME_SCHEMA,
+                SchemaConstant.PROP_TITLE));
     }
 
     @Test
     public void testNonJavaBeansPropertyMutator() {
-        AugmentedIndexView index = AugmentedIndexView.augment(indexOf(NonJavaBeanMutatorProperty.class));
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(NonJavaBeanMutatorProperty.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(NonJavaBeanMutatorProperty.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
         Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
@@ -215,8 +215,8 @@ public class TypeResolverTests extends IndexScannerTestBase {
         assertEquals("name", property.getPropertyName());
         assertEquals(property.getWriteMethod(), property.getAnnotationTarget());
         assertEquals("Name of the property", TypeUtil.getAnnotationValue(property.getAnnotationTarget(),
-                                                     SchemaConstant.DOTNAME_SCHEMA,
-                                                     SchemaConstant.PROP_TITLE));
+                SchemaConstant.DOTNAME_SCHEMA,
+                SchemaConstant.PROP_TITLE));
     }
 
     /* Test models and resources below. */

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -22,6 +22,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.junit.Test;
 
+import io.smallrye.openapi.runtime.io.schema.SchemaConstant;
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
 import io.smallrye.openapi.runtime.util.TypeUtil;
 
@@ -182,6 +183,40 @@ public class TypeResolverTests extends IndexScannerTestBase {
         assertEquals("comment2ActuallyFirst", iter.next().getValue().getPropertyName());
         assertEquals("comment", iter.next().getValue().getPropertyName());
         assertEquals("name2", iter.next().getValue().getPropertyName());
+    }
+
+    @Test
+    public void testNonJavaBeansPropertyAccessor() {
+        AugmentedIndexView index = AugmentedIndexView.augment(indexOf(NonJavaBeanAccessorProperty.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(NonJavaBeanAccessorProperty.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
+                null);
+        assertEquals(1, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+        TypeResolver property = iter.next().getValue();
+        assertEquals("name", property.getPropertyName());
+        assertEquals(property.getReadMethod(), property.getAnnotationTarget());
+        assertEquals("Name of the property", TypeUtil.getAnnotationValue(property.getAnnotationTarget(),
+                                                     SchemaConstant.DOTNAME_SCHEMA,
+                                                     SchemaConstant.PROP_TITLE));
+    }
+
+    @Test
+    public void testNonJavaBeansPropertyMutator() {
+        AugmentedIndexView index = AugmentedIndexView.augment(indexOf(NonJavaBeanMutatorProperty.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(NonJavaBeanMutatorProperty.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
+                null);
+        assertEquals(1, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+        TypeResolver property = iter.next().getValue();
+        assertEquals("name", property.getPropertyName());
+        assertEquals(property.getWriteMethod(), property.getAnnotationTarget());
+        assertEquals("Name of the property", TypeUtil.getAnnotationValue(property.getAnnotationTarget(),
+                                                     SchemaConstant.DOTNAME_SCHEMA,
+                                                     SchemaConstant.PROP_TITLE));
     }
 
     /* Test models and resources below. */
@@ -377,6 +412,62 @@ public class TypeResolverTests extends IndexScannerTestBase {
 
         public String getComment2() {
             return comment2;
+        }
+    }
+
+    static class NonJavaBeanAccessorProperty {
+        String name;
+
+        @Schema(title = "Name of the property")
+        String name() {
+            return name;
+        }
+
+        // Should be skipped
+        String anotherValue() {
+            return null;
+        }
+
+        // Should be skipped
+        String get() {
+            return name;
+        }
+
+        // Should be skipped
+        String isNotAnAccessor() {
+            return null;
+        }
+
+        void name(String name) {
+            this.name = name;
+        }
+    }
+
+    static class NonJavaBeanMutatorProperty {
+        String name;
+
+        String name() {
+            return name;
+        }
+
+        // Should be skipped
+        void anotherValue(String value) {
+            return;
+        }
+
+        // Should be skipped
+        String get() {
+            return name;
+        }
+
+        // Should be skipped
+        String isNotAnAccessor() {
+            return null;
+        }
+
+        @Schema(title = "Name of the property")
+        void name(String name) {
+            this.name = name;
         }
     }
 }


### PR DESCRIPTION
For branch `2.0.x`, relates to #421 