### PR TITLE
Allow Schema ref for implementation prop w/other non-display props

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/models/media/SchemaImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/media/SchemaImpl.java
@@ -23,7 +23,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema, ModelI
 
     private String $ref;
     private String format;
-    private String name;
+    private final String name;
     private String title;
     private String description;
     private Object defaultValue;
@@ -60,20 +60,20 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema, ModelI
     private Boolean writeOnly;
     private Boolean deprecated;
 
-    public SchemaImpl() {
-
+    public static boolean isNamed(Schema schema) {
+        return schema instanceof SchemaImpl && ((SchemaImpl) schema).name != null;
     }
 
     public SchemaImpl(String name) {
         this.name = name;
     }
 
-    public String getName() {
-        return name;
+    public SchemaImpl() {
+        this(null);
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public String getName() {
+        return name;
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaConstant.java
@@ -1,5 +1,9 @@
 package io.smallrye.openapi.runtime.io.schema;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.jboss.jandex.DotName;
 
@@ -64,6 +68,10 @@ public class SchemaConstant {
     public static final String PROP_REQUIRED_PROPERTIES = "requiredProperties";
     public static final String PROP_PROPERTIES = "properties";
     public static final String PROP_NOT = "not";
+
+    public static final List<String> PROPERTIES_NONDISPLAY = Collections.unmodifiableList(Arrays.asList(PROP_IMPLEMENTATION,
+            PROP_NAME,
+            PROP_REQUIRED));
 
     private SchemaConstant() {
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaReader.java
@@ -3,6 +3,7 @@ package io.smallrye.openapi.runtime.io.schema;
 import static io.smallrye.openapi.runtime.io.JsonUtil.readObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -68,22 +69,9 @@ public class SchemaReader {
              * {@link org.eclipse.microprofile.openapi.annotations.Components}.
              */
             if (name != null) {
-                map.put(name, SchemaFactory.readSchema(context.getIndex(), context.getClassLoader(), nested));
-            } /*-
-              //For consideration - be more lenient and attempt to use the name from the implementation's @Schema?
-              else {
-                if (JandexUtil.isSimpleClassSchema(nested)) {
-                    Schema schema = SchemaFactory.readClassSchema(index, nested.value(OpenApiConstants.PROP_IMPLEMENTATION), false);
-              
-                    if (schema instanceof SchemaImpl) {
-                        name = ((SchemaImpl) schema).getName();
-              
-                        if (name != null) {
-                            map.put(name, schema);
-                        }
-                    }
-                }
-              }*/
+                map.put(name, SchemaFactory.readSchema(context.getIndex(), context.getClassLoader(), new SchemaImpl(name),
+                        nested, Collections.emptyMap()));
+            }
         }
         return map;
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -446,6 +447,13 @@ public class JandexUtil {
         return null;
     }
 
+    public static List<AnnotationValue> schemaDisplayValues(AnnotationInstance annotation) {
+        return annotation.values()
+                .stream()
+                .filter(value -> !SchemaConstant.PROPERTIES_NONDISPLAY.contains(value.name()))
+                .collect(Collectors.toList());
+    }
+
     /**
      * Returns true if the given @Schema annotation is a simple class schema. This means that
      * the annotation only has one field defined, and that field is "implementation".
@@ -454,7 +462,7 @@ public class JandexUtil {
      * @return Is it a simple class @Schema
      */
     public static boolean isSimpleClassSchema(AnnotationInstance annotation) {
-        return annotation.values().size() == 1 && hasImplementation(annotation);
+        return schemaDisplayValues(annotation).isEmpty() && hasImplementation(annotation);
     }
 
     /**
@@ -466,7 +474,8 @@ public class JandexUtil {
      * @return Is it a simple array @Schema
      */
     public static boolean isSimpleArraySchema(AnnotationInstance annotation) {
-        if (annotation.values().size() != 2) {
+        // May only have 'type' display property
+        if (schemaDisplayValues(annotation).size() != 1) {
             return false;
         }
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
@@ -554,7 +554,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
         @APIResponse(responseCode = "400", description = "Bad parameter for sorting was passed")
         @APIResponse(responseCode = "404", description = "No policies found for customer")
         @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
-        @APIResponse(responseCode = "200", description = "Policies found", content = @Content(schema = @Schema(implementation = PagedResponse.class)), headers = @Header(name = "TotalCount", description = "Total number of items found", schema = @Schema(type = SchemaType.INTEGER)))
+        @APIResponse(responseCode = "200", description = "Policies found", content = @Content(schema = @Schema(implementation = PagedResponse.class, name = "ignored")), headers = @Header(name = "TotalCount", description = "Total number of items found", schema = @Schema(type = SchemaType.INTEGER)))
         public Response getPoliciesForCustomer() {
             return null;
         }


### PR DESCRIPTION
Fixes #308 

- Construct named SchemaImpls only for `components/schemas` entries
- Consolidate `SchemaFactory` methods