### PR TITLE
Include Spring and Vert.x coverage in JaCoCo aggregation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>smallrye-open-api-vertx</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>smallrye-open-api</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -6,7 +6,7 @@
         <version>2.1.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
-    
+
     <artifactId>smallrye-open-api-tck</artifactId>
     <name>SmallRye: OpenAPI TCK</name>
 
@@ -20,6 +20,16 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api-jaxrs</artifactId>
+            <!--<scope>test</scope> This breaks the sonar coverage ?!? -->
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-open-api-spring</artifactId>
+            <!--<scope>test</scope> This breaks the sonar coverage ?!? -->
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-open-api-vertx</artifactId>
             <!--<scope>test</scope> This breaks the sonar coverage ?!? -->
         </dependency>
         <dependency>


### PR DESCRIPTION
This includes the Spring and Vert.x code coverage information in the aggregation that occurs after running the TCK.