### PR TITLE
Ignore @RegisterRestClient interfaces, but still scan others

### DIFF
--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -478,7 +478,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
                 .map(AnnotationInstance::target)
                 .filter(target -> target.kind() == AnnotationTarget.Kind.CLASS)
                 .map(AnnotationTarget::asClass)
-                .filter(classInfo -> !Modifier.isInterface(classInfo.flags()) ||
+                .filter(classInfo -> !classInfo.annotations().containsKey(JaxRsConstants.REGISTER_REST_CLIENT) ||
                         index.getAllKnownImplementors(classInfo.name()).stream()
                                 .anyMatch(info -> !Modifier.isAbstract(info.flags())))
                 .distinct() // CompositeIndex instances may return duplicates

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsConstants.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsConstants.java
@@ -33,6 +33,9 @@ public class JaxRsConstants {
     static final DotName RESPONSE = DotName.createSimple("javax.ws.rs.core.Response");
     static final DotName PATH_SEGMENT = DotName.createSimple("javax.ws.rs.core.PathSegment");
 
+    static final DotName REGISTER_REST_CLIENT = DotName
+            .createSimple("org.eclipse.microprofile.rest.client.inject.RegisterRestClient");
+
     static final DotName GET = DotName.createSimple("javax.ws.rs.GET");
     static final DotName PUT = DotName.createSimple("javax.ws.rs.PUT");
     static final DotName POST = DotName.createSimple("javax.ws.rs.POST");


### PR DESCRIPTION
Fix #449. F.y.i @jglink

Also contains small Sonatype suggested fixes

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>