### PR TITLE
Scan sibling `@Extension` annotations for extensible models

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/callback/CallbackReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/callback/CallbackReader.java
@@ -108,6 +108,7 @@ public class CallbackReader {
         String expression = JandexUtil.stringValue(annotation, CallbackConstant.PROP_CALLBACK_URL_EXPRESSION);
         callback.addPathItem(expression,
                 PathsReader.readPathItem(context, annotation.value(CallbackConstant.PROP_OPERATIONS), null));
+        callback.setExtensions(ExtensionReader.readExtensions(context, annotation));
         return callback;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/components/ComponentsReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/components/ComponentsReader.java
@@ -63,7 +63,7 @@ public class ComponentsReader {
                 ResponseReader.readResponsesMap(context, nested.value(ComponentsConstant.PROP_RESPONSES)));
         components.setSchemas(SchemaReader.readSchemas(context, nested.value(ComponentsConstant.PROP_SCHEMAS)));
         components.setSecuritySchemes(
-                SecuritySchemeReader.readSecuritySchemes(nested.value(ComponentsConstant.PROP_SECURITY_SCHEMES)));
+                SecuritySchemeReader.readSecuritySchemes(context, nested.value(ComponentsConstant.PROP_SECURITY_SCHEMES)));
 
         return components;
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
@@ -46,16 +46,17 @@ public class DefinitionReader {
         IoLogging.logger.annotation("@OpenAPIDefinition");
 
         openApi.setInfo(InfoReader.readInfo(annotationInstance.value(DefinitionConstant.PROP_INFO)));
-        openApi.setTags(TagReader.readTags(annotationInstance.value(DefinitionConstant.PROP_TAGS)).orElse(null));
+        openApi.setTags(TagReader.readTags(context, annotationInstance.value(DefinitionConstant.PROP_TAGS)).orElse(null));
         openApi.setServers(
                 ServerReader.readServers(annotationInstance.value(DefinitionConstant.PROP_SERVERS)).orElse(null));
         openApi.setSecurity(SecurityRequirementReader
                 .readSecurityRequirements(annotationInstance.value(DefinitionConstant.PROP_SECURITY)).orElse(null));
         openApi.setExternalDocs(
                 ExternalDocsReader
-                        .readExternalDocs(annotationInstance.value(ExternalDocsConstant.PROP_EXTERNAL_DOCS)));
+                        .readExternalDocs(context, annotationInstance.value(ExternalDocsConstant.PROP_EXTERNAL_DOCS)));
         openApi.setComponents(ComponentsReader.readComponents(context,
                 annotationInstance.value(DefinitionConstant.PROP_COMPONENTS)));
+        openApi.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/extension/ExtensionReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/extension/ExtensionReader.java
@@ -74,6 +74,16 @@ public class ExtensionReader {
         return e;
     }
 
+    public static Map<String, Object> readExtensions(final AnnotationScannerContext context,
+            final AnnotationInstance extensible) {
+        AnnotationTarget target = extensible.target();
+        // target may be null - checked by JandexUtil methods
+        List<AnnotationInstance> extensions = JandexUtil.getRepeatableAnnotation(target,
+                ExtensionConstant.DOTNAME_EXTENSION,
+                ExtensionConstant.DOTNAME_EXTENSIONS);
+        return extensions.isEmpty() ? null : readExtensions(context, extensions);
+    }
+
     /**
      * Reads a single Extension annotation. If the value must be parsed (as indicated by the
      * 'parseValue' attribute of the annotation), the parsing is delegated to the extensions

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/externaldocs/ExternalDocsReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/externaldocs/ExternalDocsReader.java
@@ -10,6 +10,7 @@ import io.smallrye.openapi.api.models.ExternalDocumentationImpl;
 import io.smallrye.openapi.runtime.io.IoLogging;
 import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -32,11 +33,12 @@ public class ExternalDocsReader {
      * @param annotationValue the {@literal @}ExternalDocumentation annotation
      * @return ExternalDocumentation model
      */
-    public static ExternalDocumentation readExternalDocs(final AnnotationValue annotationValue) {
+    public static ExternalDocumentation readExternalDocs(final AnnotationScannerContext context,
+            final AnnotationValue annotationValue) {
         if (annotationValue == null) {
             return null;
         }
-        return readExternalDocs(annotationValue.asNested());
+        return readExternalDocs(context, annotationValue.asNested());
     }
 
     /**
@@ -45,7 +47,8 @@ public class ExternalDocsReader {
      * @param annotationInstance the {@literal @}ExternalDocumentation annotation
      * @return ExternalDocumentation model
      */
-    public static ExternalDocumentation readExternalDocs(AnnotationInstance annotationInstance) {
+    public static ExternalDocumentation readExternalDocs(AnnotationScannerContext context,
+            AnnotationInstance annotationInstance) {
         if (annotationInstance == null) {
             return null;
         }
@@ -54,6 +57,7 @@ public class ExternalDocsReader {
         externalDoc.setDescription(
                 JandexUtil.stringValue(annotationInstance, ExternalDocsConstant.PROP_DESCRIPTION));
         externalDoc.setUrl(JandexUtil.stringValue(annotationInstance, ExternalDocsConstant.PROP_URL));
+        externalDoc.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return externalDoc;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/externaldocs/ExternalDocsReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/externaldocs/ExternalDocsReader.java
@@ -30,6 +30,7 @@ public class ExternalDocsReader {
     /**
      * Reads an ExternalDocumentation annotation.
      * 
+     * @param context scanning context
      * @param annotationValue the {@literal @}ExternalDocumentation annotation
      * @return ExternalDocumentation model
      */
@@ -44,6 +45,7 @@ public class ExternalDocsReader {
     /**
      * Reads an ExternalDocumentation annotation.
      * 
+     * @param context scanning context
      * @param annotationInstance the {@literal @}ExternalDocumentation annotation
      * @return ExternalDocumentation model
      */

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/header/HeaderReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/header/HeaderReader.java
@@ -100,9 +100,7 @@ public class HeaderReader {
         Header header = new HeaderImpl();
         header.setRef(JandexUtil.refValue(annotationInstance, JandexUtil.RefType.HEADER));
         header.setDescription(JandexUtil.stringValue(annotationInstance, Parameterizable.PROP_DESCRIPTION));
-        header.setSchema(
-                SchemaFactory.readSchema(context.getIndex(), context.getClassLoader(),
-                        annotationInstance.value(Parameterizable.PROP_SCHEMA)));
+        header.setSchema(SchemaFactory.readSchema(context, annotationInstance.value(Parameterizable.PROP_SCHEMA)));
         header.setRequired(JandexUtil.booleanValue(annotationInstance, Parameterizable.PROP_REQUIRED).orElse(null));
         header.setDeprecated(JandexUtil.booleanValue(annotationInstance, Parameterizable.PROP_DEPRECATED).orElse(null));
         header.setAllowEmptyValue(

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/mediatype/MediaTypeReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/mediatype/MediaTypeReader.java
@@ -46,11 +46,8 @@ public class MediaTypeReader {
         MediaType mediaType = new MediaTypeImpl();
         mediaType.setExamples(ExampleReader.readExamples(annotationInstance.value(MediaTypeConstant.PROP_EXAMPLES)));
         mediaType.setExample(JandexUtil.stringValue(annotationInstance, MediaTypeConstant.PROP_EXAMPLE));
-        mediaType.setSchema(SchemaFactory.readSchema(context.getIndex(),
-                context.getClassLoader(),
-                annotationInstance.value(MediaTypeConstant.PROP_SCHEMA)));
-        mediaType.setEncoding(
-                EncodingReader.readEncodings(context, annotationInstance.value(MediaTypeConstant.PROP_ENCODING)));
+        mediaType.setSchema(SchemaFactory.readSchema(context, annotationInstance.value(MediaTypeConstant.PROP_SCHEMA)));
+        mediaType.setEncoding(EncodingReader.readEncodings(context, annotationInstance.value(MediaTypeConstant.PROP_ENCODING)));
         return mediaType;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationReader.java
@@ -52,7 +52,8 @@ public class OperationReader {
             operation.setSummary(JandexUtil.stringValue(annotationInstance, OperationConstant.PROP_SUMMARY));
             operation.setDescription(JandexUtil.stringValue(annotationInstance, OperationConstant.PROP_DESCRIPTION));
             operation.setExternalDocs(
-                    ExternalDocsReader.readExternalDocs(annotationInstance.value(ExternalDocsConstant.PROP_EXTERNAL_DOCS)));
+                    ExternalDocsReader.readExternalDocs(context,
+                            annotationInstance.value(ExternalDocsConstant.PROP_EXTERNAL_DOCS)));
             operation.setParameters(ParameterReader.readParametersList(context,
                     annotationInstance.value(OperationConstant.PROP_PARAMETERS)).orElse(null));
             operation.setRequestBody(RequestBodyReader.readRequestBody(context,
@@ -69,6 +70,7 @@ public class OperationReader {
                     .orElse(getOperationId(context, methodInfo)));
             operation
                     .setDeprecated(JandexUtil.booleanValue(annotationInstance, OperationConstant.PROP_DEPRECATED).orElse(null));
+            // TODO: for non-callbacks: operation.setExtensions(ExtensionReader.readExtendsions(context, annotationInstance));
 
             return operation;
         } else if (shouldDoAutoGenerate(context)) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/parameter/ParameterReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/parameter/ParameterReader.java
@@ -176,16 +176,25 @@ public class ParameterReader {
                 org.eclipse.microprofile.openapi.annotations.enums.Explode.class)).orElse(null));
         parameter.setAllowReserved(
                 JandexUtil.booleanValue(annotationInstance, ParameterConstant.PROP_ALLOW_RESERVED).orElse(null));
-        parameter.setSchema(
-                SchemaFactory.readSchema(context.getIndex(),
-                        context.getClassLoader(),
-                        annotationInstance.value(Parameterizable.PROP_SCHEMA)));
+        parameter.setSchema(SchemaFactory.readSchema(context, annotationInstance.value(Parameterizable.PROP_SCHEMA)));
         parameter.setContent(
                 ContentReader.readContent(context, annotationInstance.value(Parameterizable.PROP_CONTENT),
                         ContentDirection.PARAMETER));
         parameter.setExamples(ExampleReader.readExamples(annotationInstance.value(Parameterizable.PROP_EXAMPLES)));
         parameter.setExample(JandexUtil.stringValue(annotationInstance, Parameterizable.PROP_EXAMPLE));
         parameter.setRef(JandexUtil.refValue(annotationInstance, JandexUtil.RefType.PARAMETER));
+
+        if (annotationInstance.target() != null) {
+            switch (annotationInstance.target().kind()) {
+                case FIELD:
+                case METHOD_PARAMETER:
+                    parameter.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
+                    break;
+                default:
+                    break;
+            }
+        }
+
         return parameter;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/parameter/ParameterReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/parameter/ParameterReader.java
@@ -188,6 +188,11 @@ public class ParameterReader {
             switch (annotationInstance.target().kind()) {
                 case FIELD:
                 case METHOD_PARAMETER:
+                    /*
+                     * Limit to field and parameter. Extensions on methods are ambiguous and pertain
+                     * instead to the operation.
+                     *
+                     */
                     parameter.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
                     break;
                 default:

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/requestbody/RequestBodyReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/requestbody/RequestBodyReader.java
@@ -126,6 +126,7 @@ public class RequestBodyReader {
                         ContentDirection.INPUT));
         requestBody.setRequired(JandexUtil.booleanValue(annotationInstance, RequestBodyConstant.PROP_REQUIRED).orElse(null));
         requestBody.setRef(JandexUtil.refValue(annotationInstance, JandexUtil.RefType.REQUEST_BODY));
+        requestBody.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return requestBody;
     }
 
@@ -147,8 +148,7 @@ public class RequestBodyReader {
 
         for (String mediaType : CurrentScannerInfo.getCurrentConsumes()) {
             MediaType type = new MediaTypeImpl();
-            type.setSchema(SchemaFactory.typeToSchema(context.getIndex(),
-                    context.getClassLoader(),
+            type.setSchema(SchemaFactory.typeToSchema(context,
                     JandexUtil.value(annotation, RequestBodyConstant.PROP_VALUE),
                     context.getExtensions()));
             content.addMediaType(mediaType, type);

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
@@ -164,6 +164,7 @@ public class ResponseReader {
                 ContentReader.readContent(context, annotationInstance.value(ResponseConstant.PROP_CONTENT),
                         ContentDirection.OUTPUT));
         response.setRef(JandexUtil.refValue(annotationInstance, JandexUtil.RefType.RESPONSE));
+        response.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return response;
     }
 
@@ -185,8 +186,7 @@ public class ResponseReader {
 
         for (String mediaType : CurrentScannerInfo.getCurrentProduces()) {
             MediaType type = new MediaTypeImpl();
-            type.setSchema(SchemaFactory.typeToSchema(context.getIndex(),
-                    context.getClassLoader(),
+            type.setSchema(SchemaFactory.typeToSchema(context,
                     JandexUtil.value(annotation, ResponseConstant.PROP_VALUE),
                     context.getExtensions()));
             content.addMediaType(mediaType, type);

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -54,8 +54,7 @@ public class SchemaFactory {
     /**
      * Reads a Schema annotation into a model.
      *
-     * @param index the index
-     * @param cl the classLoader to use
+     * @param context scanning context
      * @param value the annotation value
      * @return Schema model
      */
@@ -78,8 +77,7 @@ public class SchemaFactory {
      * on the provided class. If the schema has already been registered (in components), the existing
      * registration will be replaced.
      * 
-     * @param index application class index
-     * @param cl the classLoader to use
+     * @param context scanning context
      * @param schema schema model to populate
      * @param annotation schema annotation to read
      * @param clazz the class annotated with {@link org.eclipse.microprofile.openapi.annotations.media.Schema @Schema}
@@ -97,8 +95,7 @@ public class SchemaFactory {
      * on the provided class. If the schema has already been registered (in components), the existing
      * registration will be replaced.
      * 
-     * @param index application class index
-     * @param cl the classLoader to use
+     * @param context scanning context
      * @param schema schema model to populate
      * @param annotation schema annotation to read
      * @param clazz the class annotated with {@link org.eclipse.microprofile.openapi.annotations.media.Schema @Schema}
@@ -331,7 +328,7 @@ public class SchemaFactory {
      * Introspect into the given Class to generate a Schema model. The boolean indicates
      * whether this class type should be turned into a reference.
      *
-     * @param index the index of classes being scanned
+     * @param context scanning context
      * @param type the implementation type of the item to scan
      * @param schemaReferenceSupported
      */
@@ -365,7 +362,7 @@ public class SchemaFactory {
     /**
      * Converts a Jandex type to a {@link Schema} model.
      * 
-     * @param index the index of classes being scanned
+     * @param context scanning context
      * @param type the implementation type of the item to scan
      * @param extensions list of AnnotationScannerExtensions
      * @return Schema model
@@ -412,7 +409,7 @@ public class SchemaFactory {
      * 
      * The given type must be found in the index.
      *
-     * @param index Jandex index containing the ClassInfo for the given enum type
+     * @param context scanning context
      * @param enumType type containing Java Enum constants
      * @return Schema model
      *
@@ -449,7 +446,7 @@ public class SchemaFactory {
      * Introspect the given class type to generate a Schema model. The boolean indicates
      * whether this class type should be turned into a reference.
      *
-     * @param index the index of classes being scanned
+     * @param context scanning context
      * @param ctype
      * @param schemaReferenceSupported
      */
@@ -481,7 +478,7 @@ public class SchemaFactory {
     /**
      * Register the provided schema in the SchemaRegistry if allowed.
      * 
-     * @param index the index of classes being scanned
+     * @param context scanning context
      * @param type the type of the schema to register
      * @param schema a schema
      * @return a reference to the registered schema or the input schema when registration is not allowed/possible
@@ -504,7 +501,7 @@ public class SchemaFactory {
      * is not already in the registry or the schema being registered is not already a
      * reference that has been registered.
      * 
-     * @param index
+     * @param context scanning context
      * @param registry
      * @param type
      * @param schema
@@ -525,7 +522,7 @@ public class SchemaFactory {
     /**
      * Reads an array of Class annotations to produce a list of {@link Schema} models.
      * 
-     * @param index the index of classes being scanned
+     * @param context scanning context
      * @param types the implementation types of the items to scan, never null
      */
     private static List<Schema> readClassSchemas(final AnnotationScannerContext context, Type[] types) {
@@ -575,7 +572,7 @@ public class SchemaFactory {
      * {@link org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping @DiscriminatorMapping}
      * annotations into a {@link Discriminator} model.
      *
-     * @param index set of scanned classes to be used for further introspection
+     * @param context scanning context
      * @param propertyName the OAS required value specified by the
      *        {@link org.eclipse.microprofile.openapi.annotations.media.Schema#discriminatorProperty() discriminatorProperty}
      *        attribute.

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaReader.java
@@ -69,8 +69,7 @@ public class SchemaReader {
              * {@link org.eclipse.microprofile.openapi.annotations.Components}.
              */
             if (name != null) {
-                map.put(name, SchemaFactory.readSchema(context.getIndex(), context.getClassLoader(), new SchemaImpl(name),
-                        nested, Collections.emptyMap()));
+                map.put(name, SchemaFactory.readSchema(context, new SchemaImpl(name), nested, Collections.emptyMap()));
             }
         }
         return map;

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityscheme/SecuritySchemeReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityscheme/SecuritySchemeReader.java
@@ -1,14 +1,13 @@
 package io.smallrye.openapi.runtime.io.securityscheme;
 
-import static org.eclipse.microprofile.openapi.models.security.SecurityScheme.In;
-import static org.eclipse.microprofile.openapi.models.security.SecurityScheme.Type;
-
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme.In;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme.Type;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
@@ -21,6 +20,7 @@ import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.Referenceable;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
 import io.smallrye.openapi.runtime.io.oauth.OAuthReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -43,7 +43,8 @@ public class SecuritySchemeReader {
      * @param annotationValue Map of {@literal @}SecurityScheme annotations
      * @return Map of SecurityScheme models
      */
-    public static Map<String, SecurityScheme> readSecuritySchemes(final AnnotationValue annotationValue) {
+    public static Map<String, SecurityScheme> readSecuritySchemes(final AnnotationScannerContext context,
+            final AnnotationValue annotationValue) {
         if (annotationValue == null) {
             return null;
         }
@@ -56,7 +57,7 @@ public class SecuritySchemeReader {
                 name = JandexUtil.nameFromRef(nested);
             }
             if (name != null) {
-                securitySchemes.put(name, readSecurityScheme(nested));
+                securitySchemes.put(name, readSecurityScheme(context, nested));
             }
         }
         return securitySchemes;
@@ -88,7 +89,8 @@ public class SecuritySchemeReader {
      * @param annotationInstance the {@literal @}SecurityScheme annotation
      * @return SecurityScheme model
      */
-    public static SecurityScheme readSecurityScheme(final AnnotationInstance annotationInstance) {
+    public static SecurityScheme readSecurityScheme(final AnnotationScannerContext context,
+            final AnnotationInstance annotationInstance) {
         if (annotationInstance == null) {
             return null;
         }
@@ -108,6 +110,7 @@ public class SecuritySchemeReader {
                 .setOpenIdConnectUrl(
                         JandexUtil.stringValue(annotationInstance, SecuritySchemeConstant.PROP_OPEN_ID_CONNECT_URL));
         securityScheme.setRef(JandexUtil.refValue(annotationInstance, JandexUtil.RefType.SECURITY_SCHEME));
+        securityScheme.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return securityScheme;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityscheme/SecuritySchemeReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityscheme/SecuritySchemeReader.java
@@ -40,6 +40,7 @@ public class SecuritySchemeReader {
     /**
      * Reads a map of SecurityScheme annotations.
      * 
+     * @param context scanning context
      * @param annotationValue Map of {@literal @}SecurityScheme annotations
      * @return Map of SecurityScheme models
      */
@@ -86,6 +87,7 @@ public class SecuritySchemeReader {
     /**
      * Reads a SecurityScheme annotation into a model.
      * 
+     * @param context scanning context
      * @param annotationInstance the {@literal @}SecurityScheme annotation
      * @return SecurityScheme model
      */

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/tag/TagReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/tag/TagReader.java
@@ -40,6 +40,7 @@ public class TagReader {
      * Reads any Tag annotations.The annotation
      * value is an array of Tag annotations.
      * 
+     * @param context scanning context
      * @param annotationValue an array of {@literal @}Tag annotations
      * @return List of Tag models
      */
@@ -80,6 +81,7 @@ public class TagReader {
     /**
      * Reads a single Tag annotation.
      * 
+     * @param context scanning context
      * @param annotationInstance {@literal @}Tag annotation, must not be null
      * @return Tag model
      */

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/tag/TagReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/tag/TagReader.java
@@ -19,6 +19,7 @@ import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
 import io.smallrye.openapi.runtime.io.externaldocs.ExternalDocsConstant;
 import io.smallrye.openapi.runtime.io.externaldocs.ExternalDocsReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 import io.smallrye.openapi.runtime.util.TypeUtil;
 
@@ -42,14 +43,14 @@ public class TagReader {
      * @param annotationValue an array of {@literal @}Tag annotations
      * @return List of Tag models
      */
-    public static Optional<List<Tag>> readTags(final AnnotationValue annotationValue) {
+    public static Optional<List<Tag>> readTags(final AnnotationScannerContext context, final AnnotationValue annotationValue) {
         if (annotationValue != null) {
             IoLogging.logger.annotationsArray("@Tag");
             AnnotationInstance[] nestedArray = annotationValue.asNestedArray();
             List<Tag> tags = new ArrayList<>();
             for (AnnotationInstance tagAnno : nestedArray) {
                 if (!JandexUtil.isRef(tagAnno)) {
-                    tags.add(readTag(tagAnno));
+                    tags.add(readTag(context, tagAnno));
                 }
             }
             return Optional.of(tags);
@@ -82,14 +83,16 @@ public class TagReader {
      * @param annotationInstance {@literal @}Tag annotation, must not be null
      * @return Tag model
      */
-    public static Tag readTag(final AnnotationInstance annotationInstance) {
+    public static Tag readTag(final AnnotationScannerContext context, final AnnotationInstance annotationInstance) {
         Objects.requireNonNull(annotationInstance, "Tag annotation must not be null");
         IoLogging.logger.singleAnnotation("@Tag");
         Tag tag = new TagImpl();
         tag.setName(JandexUtil.stringValue(annotationInstance, TagConstant.PROP_NAME));
         tag.setDescription(JandexUtil.stringValue(annotationInstance, TagConstant.PROP_DESCRIPTION));
         tag.setExternalDocs(
-                ExternalDocsReader.readExternalDocs(annotationInstance.value(ExternalDocsConstant.PROP_EXTERNAL_DOCS)));
+                ExternalDocsReader.readExternalDocs(context,
+                        annotationInstance.value(ExternalDocsConstant.PROP_EXTERNAL_DOCS)));
+        tag.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return tag;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -140,6 +140,7 @@ public class OpenApiAnnotationScanner {
      * Scans all <code>@OpenAPIDefinition</code> annotations present on <code>package-info</code>
      * classes known to the scanner's index.
      * 
+     * @param context scanning context
      * @param oai the current OpenAPI result
      * @return the created OpenAPI
      */

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -19,13 +19,13 @@ import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
 
 import io.smallrye.openapi.api.models.media.SchemaImpl;
-import io.smallrye.openapi.api.util.ClassLoaderUtil;
 import io.smallrye.openapi.runtime.io.schema.SchemaFactory;
 import io.smallrye.openapi.runtime.scanner.dataobject.AnnotationTargetProcessor;
 import io.smallrye.openapi.runtime.scanner.dataobject.AugmentedIndexView;
 import io.smallrye.openapi.runtime.scanner.dataobject.DataObjectDeque;
 import io.smallrye.openapi.runtime.scanner.dataobject.IgnoreResolver;
 import io.smallrye.openapi.runtime.scanner.dataobject.TypeResolver;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.TypeUtil;
 
 /**
@@ -115,22 +115,10 @@ public class OpenApiDataObjectScanner {
     private AnnotationTarget rootAnnotationTarget;
     private final Type rootClassType;
     private final ClassInfo rootClassInfo;
+    private final AnnotationScannerContext context;
     private final AugmentedIndexView index;
-    private final ClassLoader cl;
     private final DataObjectDeque objectStack;
     private final IgnoreResolver ignoreResolver;
-
-    /**
-     * Constructor for data object scanner.
-     * <p>
-     * Call {@link #process()} to build and return the {@link Schema}.
-     *
-     * @param index index of types to scan
-     * @param classType root to begin scan
-     */
-    public OpenApiDataObjectScanner(IndexView index, Type classType) {
-        this(index, ClassLoaderUtil.getDefaultClassLoader(), null, classType);
-    }
 
     /**
      * Constructor for data object scanner.
@@ -141,17 +129,13 @@ public class OpenApiDataObjectScanner {
      * @param cl the classloader to use
      * @param classType root to begin scan
      */
-    public OpenApiDataObjectScanner(IndexView index, ClassLoader cl, Type classType) {
-        this(index, cl, null, classType);
+    public OpenApiDataObjectScanner(final AnnotationScannerContext context, Type classType) {
+        this(context, null, classType);
     }
 
-    public OpenApiDataObjectScanner(IndexView index, AnnotationTarget annotationTarget, Type classType) {
-        this(index, ClassLoaderUtil.getDefaultClassLoader(), annotationTarget, classType);
-    }
-
-    public OpenApiDataObjectScanner(IndexView index, ClassLoader cl, AnnotationTarget annotationTarget, Type classType) {
-        this.index = AugmentedIndexView.augment(index);
-        this.cl = cl;
+    public OpenApiDataObjectScanner(final AnnotationScannerContext context, AnnotationTarget annotationTarget, Type classType) {
+        this.context = context;
+        this.index = context.getAugmentedIndex();
         this.objectStack = new DataObjectDeque(this.index);
         this.ignoreResolver = new IgnoreResolver(this.index);
         this.rootClassType = classType;
@@ -167,8 +151,8 @@ public class OpenApiDataObjectScanner {
      * @param type root to begin scan
      * @return the OAI schema
      */
-    public static Schema process(IndexView index, ClassLoader cl, Type type) {
-        return new OpenApiDataObjectScanner(index, cl, type).process();
+    public static Schema process(final AnnotationScannerContext context, Type type) {
+        return new OpenApiDataObjectScanner(context, type).process();
     }
 
     /**
@@ -199,7 +183,7 @@ public class OpenApiDataObjectScanner {
         }
 
         if (isA(rootClassType, ENUM_TYPE) && index.containsClass(rootClassType)) {
-            return SchemaFactory.enumToSchema(index, cl, rootClassType);
+            return SchemaFactory.enumToSchema(context, rootClassType);
         }
 
         // If top level item is not indexed
@@ -245,7 +229,7 @@ public class OpenApiDataObjectScanner {
                 currentSchema.setType(Schema.SchemaType.OBJECT);
             } else {
                 // Ignore the returned ref, the currentSchema will be further modified with added properties
-                SchemaFactory.schemaRegistration(index, currentType, currentSchema);
+                SchemaFactory.schemaRegistration(context, currentType, currentSchema);
             }
 
             if (currentSchema.getType() != Schema.SchemaType.OBJECT) {
@@ -266,7 +250,7 @@ public class OpenApiDataObjectScanner {
             properties.values()
                     .stream()
                     .filter(resolver -> !resolver.isIgnored())
-                    .forEach(resolver -> AnnotationTargetProcessor.process(index, cl, objectStack, resolver, currentPathEntry));
+                    .forEach(resolver -> AnnotationTargetProcessor.process(context, objectStack, resolver, currentPathEntry));
         }
     }
 
@@ -276,9 +260,9 @@ public class OpenApiDataObjectScanner {
         AnnotationInstance annotation = TypeUtil.getSchemaAnnotation(currentClass);
         if (annotation != null) {
             // Because of implementation= field, *may* return a new schema rather than modify.
-            return SchemaFactory.readSchema(index, cl, currentSchema, annotation, currentClass);
+            return SchemaFactory.readSchema(context, currentSchema, annotation, currentClass);
         } else if (isA(currentType, ENUM_TYPE)) {
-            return SchemaFactory.enumToSchema(index, cl, currentType);
+            return SchemaFactory.enumToSchema(context, currentType);
         }
         return currentSchema;
     }
@@ -290,11 +274,11 @@ public class OpenApiDataObjectScanner {
     }
 
     private Schema preProcessSpecial(Type type, TypeResolver typeResolver, DataObjectDeque.PathEntry currentPathEntry) {
-        return AnnotationTargetProcessor.process(index, cl, objectStack, typeResolver, currentPathEntry, type);
+        return AnnotationTargetProcessor.process(context, objectStack, typeResolver, currentPathEntry, type);
     }
 
     private boolean isA(Type testSubject, Type test) {
-        return TypeUtil.isA(index, cl, testSubject, test);
+        return TypeUtil.isA(context, testSubject, test);
     }
 
     // Is Map, Collection, etc.

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -125,8 +125,7 @@ public class OpenApiDataObjectScanner {
      * <p>
      * Call {@link #process()} to build and return the {@link Schema}.
      *
-     * @param index index of types to scan
-     * @param cl the classloader to use
+     * @param context scanning context
      * @param classType root to begin scan
      */
     public OpenApiDataObjectScanner(final AnnotationScannerContext context, Type classType) {
@@ -147,7 +146,7 @@ public class OpenApiDataObjectScanner {
     /**
      * Build a Schema with ClassType as root.
      *
-     * @param index index of types to scan
+     * @param context scanning context
      * @param type root to begin scan
      * @return the OAI schema
      */

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -232,7 +232,6 @@ public class SchemaRegistry {
         }
     }
 
-    private final OpenApiConfig config;
     private final OpenAPI oai;
     private final IndexView index;
 
@@ -240,7 +239,6 @@ public class SchemaRegistry {
     private final Set<String> names = new LinkedHashSet<>();
 
     private SchemaRegistry(OpenApiConfig config, OpenAPI oai, IndexView index) {
-        this.config = config;
         this.oai = oai;
         this.index = index;
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -422,7 +422,7 @@ public abstract class AbstractParameterProcessor {
             }
 
             if (!ModelUtil.parameterHasSchema(param) && context.targetType != null) {
-                Schema schema = SchemaFactory.typeToSchema(index, cl, context.targetType, extensions);
+                Schema schema = SchemaFactory.typeToSchema(scannerContext, context.targetType, extensions);
                 ModelUtil.setParameterSchema(param, schema);
             }
 
@@ -486,7 +486,7 @@ public abstract class AbstractParameterProcessor {
             AnnotationTarget paramTarget = param.getValue().target();
             addEncoding(encodings, paramName, paramTarget);
             Type paramType = getType(paramTarget);
-            Schema paramSchema = SchemaFactory.typeToSchema(index, cl, paramType, extensions);
+            Schema paramSchema = SchemaFactory.typeToSchema(scannerContext, paramType, extensions);
             Object defaultValue = getDefaultValue(paramTarget);
 
             if (paramSchema.getDefaultValue() == null) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
@@ -1,10 +1,14 @@
 package io.smallrye.openapi.runtime.scanner.spi;
 
+import java.util.Collections;
 import java.util.List;
+
+import org.jboss.jandex.IndexView;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
 import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
+import io.smallrye.openapi.runtime.scanner.dataobject.AugmentedIndexView;
 
 /**
  * Context for scanners.
@@ -13,6 +17,7 @@ import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
  */
 public class AnnotationScannerContext {
     private final FilteredIndexView index;
+    private final AugmentedIndexView augmentedIndex;
     private final List<AnnotationScannerExtension> extensions;
     private final OpenApiConfig config;
     private final ClassLoader classLoader;
@@ -21,13 +26,23 @@ public class AnnotationScannerContext {
             List<AnnotationScannerExtension> extensions,
             OpenApiConfig config) {
         this.index = index;
+        this.augmentedIndex = AugmentedIndexView.augment(index);
         this.classLoader = classLoader;
         this.extensions = extensions;
         this.config = config;
     }
 
+    public AnnotationScannerContext(IndexView index, ClassLoader classLoader,
+            OpenApiConfig config) {
+        this(new FilteredIndexView(index, config), classLoader, Collections.emptyList(), config);
+    }
+
     public FilteredIndexView getIndex() {
         return index;
+    }
+
+    public AugmentedIndexView getAugmentedIndex() {
+        return augmentedIndex;
     }
 
     public List<AnnotationScannerExtension> getExtensions() {

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -40,6 +40,7 @@ import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.api.models.ExternalDocumentationImpl;
 import io.smallrye.openapi.runtime.io.externaldocs.ExternalDocsConstant;
 import io.smallrye.openapi.runtime.io.schema.SchemaConstant;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
@@ -271,11 +272,11 @@ public class TypeUtil {
      * @param classType the type to check
      * @return true if the type may be registered in the SchemaRegistry, false otherwise.
      */
-    public static boolean allowRegistration(IndexView index, Type classType) {
+    public static boolean allowRegistration(final AnnotationScannerContext context, Type classType) {
         TypeWithFormat typeFormat = getTypeFormat(classType);
 
         if (typeFormat.isSchemaType(SchemaType.ARRAY, SchemaType.OBJECT)) {
-            return index.getClassByName(classType.name()) != null;
+            return context.getIndex().getClassByName(classType.name()) != null;
         }
         return typeFormat.getProperties().size() > 2;
     }
@@ -375,7 +376,10 @@ public class TypeUtil {
      * @param testObject type to test against
      * @return true if is of type
      */
-    public static boolean isA(IndexView index, ClassLoader cl, Type testSubject, Type testObject) {
+    public static boolean isA(final AnnotationScannerContext context, Type testSubject, Type testObject) {
+        IndexView index = context.getIndex();
+        ClassLoader cl = context.getClassLoader();
+
         // The types may be the same -- short circuit looking in the index
         if (getName(testSubject).equals(getName(testObject))) {
             return true;

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -268,7 +268,7 @@ public class TypeUtil {
      * those types with defined properties beyond 'type' and 'format' are
      * eligible.
      * 
-     * @param index index of classes to consider
+     * @param context scanning context
      * @param classType the type to check
      * @return true if the type may be registered in the SchemaRegistry, false otherwise.
      */
@@ -371,7 +371,7 @@ public class TypeUtil {
      * <p>
      * Attempts to work with both Jandex and using standard class.
      *
-     * @param index Jandex index
+     * @param context scanning context
      * @param testSubject type to test
      * @param testObject type to test against
      * @return true if is of type

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/schema/SchemaFactoryTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/schema/SchemaFactoryTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import io.smallrye.openapi.api.util.ClassLoaderUtil;
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 
 public class SchemaFactoryTest extends IndexScannerTestBase {
 
@@ -23,8 +24,9 @@ public class SchemaFactoryTest extends IndexScannerTestBase {
         Type target = ParameterizedType.create(DotName.createSimple(CompletableFuture.class.getName()),
                 new Type[] { STRING_TYPE },
                 null);
-        Type result = SchemaFactory.resolveAsyncType(index, ClassLoaderUtil.getDefaultClassLoader(), target,
-                Collections.emptyList());
+        AnnotationScannerContext context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(),
+                emptyConfig());
+        Type result = SchemaFactory.resolveAsyncType(context, target, Collections.emptyList());
         assertEquals(STRING_TYPE, result);
     }
 

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -178,7 +178,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         processDefinitionAnnotation(context, applicationClass, openApi);
 
         // Process @SecurityScheme annotations
-        processSecuritySchemeAnnotation(applicationClass, openApi);
+        processSecuritySchemeAnnotation(context, applicationClass, openApi);
 
         // Process @Server annotations
         processServerAnnotation(applicationClass, openApi);
@@ -208,7 +208,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         JaxRsLogging.log.processingClass(resourceClass.simpleName());
 
         // Process @SecurityScheme annotations.
-        processSecuritySchemeAnnotation(resourceClass, openApi);
+        processSecuritySchemeAnnotation(context, resourceClass, openApi);
 
         // Process Java security
         processJavaSecurity(resourceClass, openApi);
@@ -231,7 +231,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             List<Parameter> locatorPathParameters) {
 
         // Process tags (both declarations and references).
-        Set<String> tagRefs = processTags(resourceClass, openApi, false);
+        Set<String> tagRefs = processTags(context, resourceClass, openApi, false);
 
         // Process exception mapper to auto generate api response based on method exceptions
         Map<DotName, AnnotationInstance> exceptionAnnotationMap = processExceptionMappers(context);
@@ -385,7 +385,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         final Operation operation = maybeOperation.get();
 
         // Process tags - @Tag and @Tags annotations combines with the resource tags we've already found (passed in)
-        processOperationTags(method, openApi, resourceTags, operation);
+        processOperationTags(context, method, openApi, resourceTags, operation);
 
         // Process @Parameter annotations.
         Function<AnnotationInstance, Parameter> reader = t -> ParameterReader.readParameter(context, t);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
@@ -28,7 +28,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testUnresolvable() throws IOException, JSONException {
         DotName bar = createSimple(Bar.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, ClassType.create(bar, Type.Kind.CLASS));
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, ClassType.create(bar, Type.Kind.CLASS));
 
         Schema result = scanner.process();
 
@@ -42,7 +42,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testCycle() throws IOException, JSONException {
         DotName buzz = createSimple(BuzzLinkedList.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, ClassType.create(buzz, Type.Kind.CLASS));
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, ClassType.create(buzz, Type.Kind.CLASS));
 
         Schema result = scanner.process();
 
@@ -53,7 +53,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testBareEnum() throws IOException, JSONException {
         DotName baz = createSimple(EnumContainer.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, ClassType.create(baz, Type.Kind.CLASS));
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, ClassType.create(baz, Type.Kind.CLASS));
 
         Schema result = scanner.process();
 
@@ -64,7 +64,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testRequiredEnum() throws IOException, JSONException {
         DotName baz = createSimple(EnumRequiredContainer.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, ClassType.create(baz, Type.Kind.CLASS));
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, ClassType.create(baz, Type.Kind.CLASS));
 
         Schema result = scanner.process();
 
@@ -76,7 +76,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     public void testNestedGenerics() throws IOException, JSONException {
         String name = GenericTypeTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "nesting").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -88,7 +88,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     public void testComplexNestedGenerics() throws IOException, JSONException {
         String name = GenericTypeTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "complexNesting").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -100,7 +100,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     public void testComplexInheritanceGenerics() throws IOException, JSONException {
         String name = GenericTypeTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "complexInheritance").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -112,7 +112,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     public void testGenericsWithBounds() throws IOException, JSONException {
         String name = GenericTypeTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "genericWithBounds").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -124,7 +124,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     public void genericFieldTest() throws IOException, JSONException {
         String name = GenericTypeTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "genericContainer").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -136,7 +136,7 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     public void fieldNameOverrideTest() throws IOException, JSONException {
         String name = GenericTypeTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "overriddenNames").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
@@ -1,7 +1,6 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
-import java.util.HashMap;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassType;
@@ -29,13 +28,13 @@ public class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
     @Before
     public void setupRegistry() {
         oai = new OpenAPIImpl();
-        registry = SchemaRegistry.newInstance(dynamicConfig(new HashMap<String, Object>()), oai, index);
+        registry = SchemaRegistry.newInstance(context.getConfig(), oai, context.getIndex());
     }
 
     private void testAssertion(Class<?> target, String expectedResourceName) throws IOException, JSONException {
         DotName name = componentize(target.getName());
         Type type = ClassType.create(name, Type.Kind.CLASS);
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, type);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, type);
 
         Schema result = scanner.process();
         registry.register(type, result);
@@ -51,7 +50,7 @@ public class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
         String containerName = containerClass.getName();
         Type parentType = getFieldFromKlazz(containerName, targetField).type();
 
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, parentType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, parentType);
 
         Schema result = scanner.process();
         registry.register(parentType, result);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExtensionParsingTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExtensionParsingTests.java
@@ -3,9 +3,11 @@ package io.smallrye.openapi.runtime.scanner;
 import java.io.IOException;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.openapi.annotations.callbacks.Callback;
@@ -15,6 +17,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.json.JSONException;
 import org.junit.Test;
@@ -28,7 +31,7 @@ public class ExtensionParsingTests extends IndexScannerTestBase {
     @Test
     public void testAllExpectedParseTypes() throws IOException, JSONException {
         assertJsonEquals("extensions.parsing.expected.json",
-                ExtensionParsingTestResource.class);
+                         ExtensionParsingTestResource.class);
     }
 
     /* Test models and resources below. */
@@ -39,21 +42,66 @@ public class ExtensionParsingTests extends IndexScannerTestBase {
         @Consumes(MediaType.TEXT_PLAIN)
         @Produces(MediaType.TEXT_PLAIN)
         @Callbacks({
-                @Callback(name = "extendedCallback", callbackUrlExpression = "http://localhost:8080/resources/ext-callback", operations = @CallbackOperation(summary = "Get results", extensions = {
-                        @Extension(name = "x-object", value = "{ \"key\":\"value\" }", parseValue = true),
-                        @Extension(name = "x-object-unparsed", value = "{ \"key\":\"value\" }"),
-                        @Extension(name = "x-array", value = "[ \"val1\",\"val2\" ]", parseValue = true),
-                        @Extension(name = "x-booltrue", value = "true", parseValue = true),
-                        @Extension(name = "x-boolfalse", value = "false", parseValue = true),
-                        @Extension(name = "x-number", value = "42", parseValue = true),
-                        @Extension(name = "x-number-sci", value = "42e55", parseValue = true),
-                        @Extension(name = "x-positive-number-remains-string", value = "+42", parseValue = true),
-                        @Extension(name = "x-negative-number", value = "-42", parseValue = true),
-                        @Extension(name = "x-unparsable-number", value = "-Not.A.Number", parseValue = true)
-                }, method = "get", responses = @APIResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.ARRAY, implementation = String.class)))))
+                     @Callback(
+                             name = "extendedCallback",
+                             callbackUrlExpression = "http://localhost:8080/resources/ext-callback",
+                             operations = @CallbackOperation(
+                                     summary = "Get results",
+                                     extensions = {
+                                                    @Extension(name = "x-object", value = "{ \"key\":\"value\" }", parseValue = true),
+                                                    @Extension(name = "x-object-unparsed", value = "{ \"key\":\"value\" }"),
+                                                    @Extension(name = "x-array", value = "[ \"val1\",\"val2\" ]", parseValue = true),
+                                                    @Extension(name = "x-booltrue", value = "true", parseValue = true),
+                                                    @Extension(name = "x-boolfalse", value = "false", parseValue = true),
+                                                    @Extension(name = "x-number", value = "42", parseValue = true),
+                                                    @Extension(name = "x-number-sci", value = "42e55", parseValue = true),
+                                                    @Extension(name = "x-positive-number-remains-string", value = "+42", parseValue = true),
+                                                    @Extension(name = "x-negative-number", value = "-42", parseValue = true),
+                                                    @Extension(name = "x-unparsable-number", value = "-Not.A.Number", parseValue = true)
+                                     },
+                                     method = "get",
+                                     responses = @APIResponse(
+                                             responseCode = "200",
+                                             description = "successful operation",
+                                             content = @Content(
+                                                     mediaType = "application/json",
+                                                     schema = @Schema(type = SchemaType.ARRAY, implementation = String.class)))))
         })
         public String get(String data) {
             return data;
+        }
+    }
+
+    @Test
+    public void testSiblingExtensionAnnotations() throws IOException, JSONException {
+        assertJsonEquals("extensions.scan-siblings.expected.json",
+                         ExtensionPlacementTestResource.class,
+                         ExtensionPlacementTestResource.Model.class);
+    }
+
+    @Path("/ext")
+    static class ExtensionPlacementTestResource {
+        @Schema
+        @Extension(name = "model-schema-ext", value = "{ \"key\":\"value\" }", parseValue = true)
+        static class Model {
+            @Schema
+            @Extension(name = "value1-ext", value = "plain string", parseValue = true)
+            String value1;
+            @Schema
+            @Extension(name = "value2-ext", value = "plain string", parseValue = false)
+            Integer value2;
+        }
+
+        @GET
+        @Path("segment1")
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.TEXT_PLAIN)
+        @Extension(name = "operation-ext", value = "plain string")
+        public Model get(@QueryParam("data") @Parameter() @Extension(
+                name = "qparam-data-ext",
+                value = "1",
+                parseValue = true) String data) {
+            return null;
         }
     }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExtensionParsingTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExtensionParsingTests.java
@@ -31,7 +31,7 @@ public class ExtensionParsingTests extends IndexScannerTestBase {
     @Test
     public void testAllExpectedParseTypes() throws IOException, JSONException {
         assertJsonEquals("extensions.parsing.expected.json",
-                         ExtensionParsingTestResource.class);
+                ExtensionParsingTestResource.class);
     }
 
     /* Test models and resources below. */
@@ -42,30 +42,18 @@ public class ExtensionParsingTests extends IndexScannerTestBase {
         @Consumes(MediaType.TEXT_PLAIN)
         @Produces(MediaType.TEXT_PLAIN)
         @Callbacks({
-                     @Callback(
-                             name = "extendedCallback",
-                             callbackUrlExpression = "http://localhost:8080/resources/ext-callback",
-                             operations = @CallbackOperation(
-                                     summary = "Get results",
-                                     extensions = {
-                                                    @Extension(name = "x-object", value = "{ \"key\":\"value\" }", parseValue = true),
-                                                    @Extension(name = "x-object-unparsed", value = "{ \"key\":\"value\" }"),
-                                                    @Extension(name = "x-array", value = "[ \"val1\",\"val2\" ]", parseValue = true),
-                                                    @Extension(name = "x-booltrue", value = "true", parseValue = true),
-                                                    @Extension(name = "x-boolfalse", value = "false", parseValue = true),
-                                                    @Extension(name = "x-number", value = "42", parseValue = true),
-                                                    @Extension(name = "x-number-sci", value = "42e55", parseValue = true),
-                                                    @Extension(name = "x-positive-number-remains-string", value = "+42", parseValue = true),
-                                                    @Extension(name = "x-negative-number", value = "-42", parseValue = true),
-                                                    @Extension(name = "x-unparsable-number", value = "-Not.A.Number", parseValue = true)
-                                     },
-                                     method = "get",
-                                     responses = @APIResponse(
-                                             responseCode = "200",
-                                             description = "successful operation",
-                                             content = @Content(
-                                                     mediaType = "application/json",
-                                                     schema = @Schema(type = SchemaType.ARRAY, implementation = String.class)))))
+                @Callback(name = "extendedCallback", callbackUrlExpression = "http://localhost:8080/resources/ext-callback", operations = @CallbackOperation(summary = "Get results", extensions = {
+                        @Extension(name = "x-object", value = "{ \"key\":\"value\" }", parseValue = true),
+                        @Extension(name = "x-object-unparsed", value = "{ \"key\":\"value\" }"),
+                        @Extension(name = "x-array", value = "[ \"val1\",\"val2\" ]", parseValue = true),
+                        @Extension(name = "x-booltrue", value = "true", parseValue = true),
+                        @Extension(name = "x-boolfalse", value = "false", parseValue = true),
+                        @Extension(name = "x-number", value = "42", parseValue = true),
+                        @Extension(name = "x-number-sci", value = "42e55", parseValue = true),
+                        @Extension(name = "x-positive-number-remains-string", value = "+42", parseValue = true),
+                        @Extension(name = "x-negative-number", value = "-42", parseValue = true),
+                        @Extension(name = "x-unparsable-number", value = "-Not.A.Number", parseValue = true)
+                }, method = "get", responses = @APIResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.ARRAY, implementation = String.class)))))
         })
         public String get(String data) {
             return data;
@@ -75,8 +63,8 @@ public class ExtensionParsingTests extends IndexScannerTestBase {
     @Test
     public void testSiblingExtensionAnnotations() throws IOException, JSONException {
         assertJsonEquals("extensions.scan-siblings.expected.json",
-                         ExtensionPlacementTestResource.class,
-                         ExtensionPlacementTestResource.Model.class);
+                ExtensionPlacementTestResource.class,
+                ExtensionPlacementTestResource.Model.class);
     }
 
     @Path("/ext")
@@ -97,10 +85,8 @@ public class ExtensionParsingTests extends IndexScannerTestBase {
         @Consumes(MediaType.TEXT_PLAIN)
         @Produces(MediaType.TEXT_PLAIN)
         @Extension(name = "operation-ext", value = "plain string")
-        public Model get(@QueryParam("data") @Parameter() @Extension(
-                name = "qparam-data-ext",
-                value = "1",
-                parseValue = true) String data) {
+        public Model get(
+                @QueryParam("data") @Parameter() @Extension(name = "qparam-data-ext", value = "1", parseValue = true) String data) {
             return null;
         }
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
@@ -27,7 +27,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
     public void testIgnore_jsonIgnorePropertiesOnClass() throws IOException, JSONException {
         String name = IgnoreTestContainer.class.getName();
         Type type = getFieldFromKlazz(name, "jipOnClassTest").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, type);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, type);
 
         Schema result = scanner.process();
 
@@ -40,7 +40,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
     public void testIgnore_jsonIgnorePropertiesOnField() throws IOException, JSONException {
         String name = IgnoreTestContainer.class.getName();
         FieldInfo fieldInfo = getFieldFromKlazz(name, "jipOnFieldTest");
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, fieldInfo, fieldInfo.type());
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, fieldInfo, fieldInfo.type());
 
         Schema result = scanner.process();
 
@@ -52,7 +52,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testIgnore_jsonIgnoreField() throws IOException, JSONException {
         DotName name = DotName.createSimple(JsonIgnoreOnFieldExample.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
 
         Schema result = scanner.process();
@@ -65,7 +65,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testIgnore_jsonIgnoreType() throws IOException, JSONException {
         DotName name = DotName.createSimple(JsonIgnoreTypeExample.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
 
         Schema result = scanner.process();
@@ -78,7 +78,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testIgnore_jsonbTransientField() throws IOException, JSONException {
         DotName name = DotName.createSimple(JsonbTransientOnFieldExample.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
 
         Schema result = scanner.process();
@@ -91,7 +91,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testIgnore_schemaHiddenField() throws IOException, JSONException {
         DotName name = DotName.createSimple(IgnoreSchemaOnFieldExample.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
 
         Schema result = scanner.process();
@@ -103,7 +103,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testIgnore_transientField() throws IOException, JSONException {
         DotName name = DotName.createSimple(TransientFieldExample.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
 
         Schema result = scanner.process();

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsDataObjectScannerTestBase.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsDataObjectScannerTestBase.java
@@ -7,11 +7,15 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.junit.BeforeClass;
 
+import io.smallrye.openapi.api.util.ClassLoaderUtil;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
+
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
  */
 public class JaxRsDataObjectScannerTestBase extends IndexScannerTestBase {
 
+    protected static AnnotationScannerContext context;
     protected static Index index;
 
     @BeforeClass
@@ -37,6 +41,7 @@ public class JaxRsDataObjectScannerTestBase extends IndexScannerTestBase {
         //indexDirectory(indexer, "test/io/smallrye/openapi/runtime/scanner/entities/");
 
         index = indexer.complete();
+        context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(), emptyConfig());
     }
 
     public FieldInfo getFieldFromKlazz(String containerName, String fieldName) {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
@@ -1,7 +1,6 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
-import java.util.HashMap;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassType;
@@ -32,7 +31,7 @@ public class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testKitchenSink() throws IOException {
         DotName kitchenSink = DotName.createSimple(KitchenSink.class.getName());
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index,
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(kitchenSink, Type.Kind.CLASS));
 
         LOG.debugv("Scanning top-level entity: {0}", KitchenSink.class.getName());
@@ -50,7 +49,7 @@ public class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
         Type pType = getFieldFromKlazz(KitchenSink.class.getName(), "simpleParameterizedType").type();
 
         LOG.debugv("Scanning top-level entity: {0}", pType);
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
         printToConsole("KustomPair", scanner.process());
     }
 
@@ -58,9 +57,9 @@ public class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
     public void testKitchenSinkWithRefs() throws IOException, JSONException {
         DotName name = componentize(KitchenSink.class.getName());
         Type type = ClassType.create(name, Type.Kind.CLASS);
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, type);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, type);
         OpenAPIImpl oai = new OpenAPIImpl();
-        SchemaRegistry registry = SchemaRegistry.newInstance(dynamicConfig(new HashMap<String, Object>()), oai, index);
+        SchemaRegistry registry = SchemaRegistry.newInstance(context.getConfig(), oai, index);
 
         Schema result = scanner.process();
         registry.register(type, result);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
@@ -29,7 +29,7 @@ public class NestedSchemaReferenceTests extends JaxRsDataObjectScannerTestBase {
         OpenAPIImpl oai = new OpenAPIImpl();
         SchemaRegistry registry = SchemaRegistry.newInstance(dynamicConfig(new HashMap<String, Object>()), oai, index);
 
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, parentType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, parentType);
 
         Schema result = scanner.process();
         registry.register(parentType, result);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
@@ -3,7 +3,6 @@ package io.smallrye.openapi.runtime.scanner;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.HashMap;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassInfo;
@@ -15,8 +14,11 @@ import org.jboss.jandex.Type;
 import org.json.JSONException;
 import org.junit.Test;
 
+import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.models.OpenAPIImpl;
 import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.api.util.ClassLoaderUtil;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.ModelUtil;
 
 /**
@@ -113,14 +115,16 @@ public class SchemaRegistryTests extends IndexScannerTestBase {
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$NamedNestable.class");
         Index index = indexer.complete();
 
+        OpenApiConfig config = emptyConfig();
         OpenAPIImpl oai = new OpenAPIImpl();
-        SchemaRegistry registry = SchemaRegistry.newInstance(dynamicConfig(new HashMap<String, Object>()), oai, index);
+        SchemaRegistry registry = SchemaRegistry.newInstance(config, oai, index);
 
         DotName cName = componentize(Container.class.getName());
         ClassInfo cInfo = index.getClassByName(cName);
 
         Type n6Type = cInfo.field("n6").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, n6Type);
+        AnnotationScannerContext context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(), config);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, n6Type);
 
         Schema result = scanner.process();
         registry.register(n6Type, result);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SpecialCaseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SpecialCaseTests.java
@@ -18,7 +18,7 @@ public class SpecialCaseTests extends JaxRsDataObjectScannerTestBase {
     public void testCollection_SimpleTerminalType() throws IOException, JSONException {
         String name = SpecialCaseTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "listOfString").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -30,7 +30,7 @@ public class SpecialCaseTests extends JaxRsDataObjectScannerTestBase {
     public void testCollection_DataObjectList() throws IOException, JSONException {
         String name = SpecialCaseTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "ccList").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -42,7 +42,7 @@ public class SpecialCaseTests extends JaxRsDataObjectScannerTestBase {
     public void testCollection_WildcardWithSuperBound() throws IOException, JSONException {
         String name = SpecialCaseTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "listSuperFlight").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -54,7 +54,7 @@ public class SpecialCaseTests extends JaxRsDataObjectScannerTestBase {
     public void testCollection_WildcardWithExtendBound() throws IOException, JSONException {
         String name = SpecialCaseTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "listExtendsFoo").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
@@ -66,7 +66,7 @@ public class SpecialCaseTests extends JaxRsDataObjectScannerTestBase {
     public void testCollection_Wildcard() throws IOException, JSONException {
         String name = SpecialCaseTestContainer.class.getName();
         Type pType = getFieldFromKlazz(name, "listOfAnything").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(index, pType);
+        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/util/TypeUtilTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/util/TypeUtilTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import io.smallrye.openapi.api.util.ClassLoaderUtil;
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
 import io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 
 public class TypeUtilTest extends IndexScannerTestBase {
 
@@ -135,7 +136,9 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     private boolean isA(Index index, Type testSubject, Type testObject) {
-        return TypeUtil.isA(index, ClassLoaderUtil.getDefaultClassLoader(), testSubject, testObject);
+        AnnotationScannerContext context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(),
+                emptyConfig());
+        return TypeUtil.isA(context, testSubject, testObject);
     }
 
     static class ArrayCollection extends ArrayList<String> {

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/extensions.scan-siblings.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/extensions.scan-siblings.expected.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/ext/segment1": {
+      "get": {
+        "parameters": [
+          {
+            "name": "data",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "qparam-data-ext": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Model"
+                }
+              }
+            }
+          }
+        },
+        "operation-ext": "plain string"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Model": {
+        "type": "object",
+        "properties": {
+          "value1": {
+            "type": "string",
+            "value1-ext": "plain string"
+          },
+          "value2": {
+            "format": "int32",
+            "type": "integer",
+            "value2-ext": "plain string"
+          }
+        },
+        "model-schema-ext": {
+          "key": "value"
+        }
+      }
+    }
+  }
+}

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -200,7 +200,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
         processDefinitionAnnotation(context, controllerClass, openApi);
 
         // Process @SecurityScheme annotations
-        processSecuritySchemeAnnotation(controllerClass, openApi);
+        processSecuritySchemeAnnotation(context, controllerClass, openApi);
 
         // Process @Server annotations
         processServerAnnotation(controllerClass, openApi);
@@ -228,7 +228,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
             List<Parameter> locatorPathParameters) {
 
         // Process tags (both declarations and references).
-        Set<String> tagRefs = processTags(resourceClass, openApi, false);
+        Set<String> tagRefs = processTags(context, resourceClass, openApi, false);
 
         for (MethodInfo methodInfo : getResourceMethods(context, resourceClass)) {
             if (!methodInfo.annotations().isEmpty()) {
@@ -303,7 +303,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
         final Operation operation = maybeOperation.get();
 
         // Process tags - @Tag and @Tags annotations combines with the resource tags we've already found (passed in)
-        processOperationTags(method, openApi, resourceTags, operation);
+        processOperationTags(context, method, openApi, resourceTags, operation);
 
         // Process @Parameter annotations.
         PathItem pathItem = new PathItemImpl();

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
@@ -172,7 +172,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
         processDefinitionAnnotation(context, routeClass, openApi);
 
         // Process @SecurityScheme annotations
-        processSecuritySchemeAnnotation(routeClass, openApi);
+        processSecuritySchemeAnnotation(context, routeClass, openApi);
 
         // Process @Server annotations
         processServerAnnotation(routeClass, openApi);
@@ -200,7 +200,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
             List<Parameter> locatorPathParameters) {
 
         // Process tags (both declarations and references).
-        Set<String> tagRefs = processTags(resourceClass, openApi, false);
+        Set<String> tagRefs = processTags(context, resourceClass, openApi, false);
 
         for (MethodInfo methodInfo : getResourceMethods(context, resourceClass)) {
             if (methodInfo.annotations().size() > 0) {
@@ -266,7 +266,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
             final Operation operation = maybeOperation.get();
 
             // Process tags - @Tag and @Tags annotations combines with the resource tags we've already found (passed in)
-            processOperationTags(method, openApi, resourceTags, operation);
+            processOperationTags(context, method, openApi, resourceTags, operation);
 
             // Process @Parameter annotations.
             PathItem pathItem = new PathItemImpl();


### PR DESCRIPTION
Fixes #267 

Basic approach is to match `@Extension`s found on the same target with `Extensible` models generated from the same target (with some limitations, e.g. `@Parameter`).

This is targeted for `2.1.0`