### PR TITLE
Move to MP OpenAPI 2.0-RC3

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/models/PathItemImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/PathItemImpl.java
@@ -234,6 +234,46 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem, 
     }
 
     /**
+     * @see org.eclipse.microprofile.openapi.models.setOperation(PathItem.HttpMethod, Operation)
+     */
+    @Override
+    public void setOperation(PathItem.HttpMethod httpMethod, Operation operation) {
+        switch (httpMethod) {
+            case GET:
+                this.get = operation;
+                break;
+
+            case POST:
+                this.post = operation;
+                break;
+
+            case PUT:
+                this.put = operation;
+                break;
+
+            case DELETE:
+                this.delete = operation;
+                break;
+
+            case PATCH:
+                this.patch = operation;
+                break;
+
+            case OPTIONS:
+                this.options = operation;
+                break;
+
+            case HEAD:
+                this.head = operation;
+                break;
+
+            case TRACE:
+                this.trace = operation;
+                break;
+        } // SWITCH
+    }
+
+    /**
      * @see org.eclipse.microprofile.openapi.models.PathItem#getServers()
      */
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <version.com.fasterxml.jackson>2.11.2</version.com.fasterxml.jackson>
         <version.eclipse.microprofile.config>1.4</version.eclipse.microprofile.config>
         <version.io.smallrye.smallrye-config>1.8.6</version.io.smallrye.smallrye-config>
-        <version.eclipse.microprofile.openapi>2.0-RC2</version.eclipse.microprofile.openapi>
+        <version.eclipse.microprofile.openapi>2.0-RC3</version.eclipse.microprofile.openapi>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>


### PR DESCRIPTION
This PR updates the version of MP OpenAPI in the POM to 2.0-RC3 and implements the PathItem.setOperation method on PathItemImpl.

Fixes: #474 