### PR TITLE
Allow reuse of a component response's status code on operations (2.0.x)

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/models/responses/APIResponseImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/responses/APIResponseImpl.java
@@ -23,6 +23,7 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
     private Map<String, Header> headers;
     private Content content;
     private Map<String, Link> links;
+    private String responseCode;
 
     /**
      * @see org.eclipse.microprofile.openapi.models.Reference#getRef()
@@ -143,4 +144,11 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
         ModelUtil.remove(this.links, name);
     }
 
+    public String getResponseCode() {
+        return responseCode;
+    }
+
+    public void setResponseCode(String responseCode) {
+        this.responseCode = responseCode;
+    }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -89,7 +89,8 @@ public class OpenApiAnnotationScanner {
             filteredIndexView = new FilteredIndexView(index, config);
         }
 
-        this.annotationScannerContext = new AnnotationScannerContext(filteredIndexView, loader, extensions, config);
+        this.annotationScannerContext = new AnnotationScannerContext(filteredIndexView, loader, extensions, config,
+                new OpenAPIImpl());
         this.annotationScannerFactory = new AnnotationScannerFactory(loader);
     }
 
@@ -119,7 +120,7 @@ public class OpenApiAnnotationScanner {
     private OpenAPI scanMicroProfileOpenApiAnnotations() {
 
         // Initialize a new OAI document.  Even if nothing is found, this will be returned.
-        OpenAPI openApi = new OpenAPIImpl();
+        OpenAPI openApi = this.annotationScannerContext.getOpenApi();
         openApi.setOpenapi(OpenApiConstants.OPEN_API_VERSION);
 
         // Creating a new instance of a registry which will be set on the thread context.

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -328,7 +328,8 @@ public interface AnnotationScanner {
             if (exceptionAnnotationMap != null && !exceptionAnnotationMap.isEmpty()
                     && exceptionAnnotationMap.keySet().contains(exceptionDotName)) {
                 AnnotationInstance exMapperApiResponseAnnotation = exceptionAnnotationMap.get(exceptionDotName);
-                if (!this.responseCodeExistInMethodAnnotations(exMapperApiResponseAnnotation, apiResponseAnnotations)) {
+                if (!this.responseCodeExistInMethodAnnotations(context, exMapperApiResponseAnnotation,
+                        apiResponseAnnotations)) {
                     addApiReponseFromAnnotation(context, exMapperApiResponseAnnotation, operation);
                 }
             }
@@ -414,8 +415,6 @@ public interface AnnotationScanner {
 
             if (responses.hasAPIResponse(code)) {
                 APIResponse responseFromAnnotations = responses.getAPIResponse(code);
-                responses.removeAPIResponse(code);
-
                 // Overlay the information from the annotations (2nd arg) onto the generated details (1st)
                 response = MergeUtil.mergeObjects(response, responseFromAnnotations);
             }
@@ -491,7 +490,7 @@ public interface AnnotationScanner {
      */
     default void addApiReponseFromAnnotation(final AnnotationScannerContext context, AnnotationInstance apiResponseAnnotation,
             Operation operation) {
-        String responseCode = ResponseReader.getResponseName(apiResponseAnnotation);
+        String responseCode = ResponseReader.getResponseName(context, apiResponseAnnotation);
         if (responseCode == null) {
             responseCode = APIResponses.DEFAULT;
         }
@@ -517,7 +516,7 @@ public interface AnnotationScanner {
             return;
         }
 
-        String responseCode = ResponseReader.getResponseName(annotation);
+        String responseCode = ResponseReader.getResponseName(context, annotation);
         final int status;
 
         if (responseCode != null && responseCode.matches("\\d{3}")) {
@@ -546,17 +545,16 @@ public interface AnnotationScanner {
      * @param methodApiResponseAnnotations List of ApiResponse annotations declared in the jax-rs/spring method.
      * @return response code exist or not
      */
-    default boolean responseCodeExistInMethodAnnotations(AnnotationInstance exMapperApiResponseAnnotation,
+    default boolean responseCodeExistInMethodAnnotations(AnnotationScannerContext context,
+            AnnotationInstance exMapperApiResponseAnnotation,
             List<AnnotationInstance> methodApiResponseAnnotations) {
 
-        String exMapperResponseCode = ResponseReader.getResponseName(exMapperApiResponseAnnotation);
+        String exMapperResponseCode = ResponseReader.getResponseName(context, exMapperApiResponseAnnotation);
 
         return methodApiResponseAnnotations.stream()
-                .map(ResponseReader::getResponseName)
+                .map(a -> ResponseReader.getResponseName(context, a))
                 .filter(Objects::nonNull)
-                .filter(code -> code.equals(exMapperResponseCode))
-                .findFirst()
-                .isPresent();
+                .anyMatch(code -> code.equals(exMapperResponseCode));
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
@@ -2,6 +2,8 @@ package io.smallrye.openapi.runtime.scanner.spi;
 
 import java.util.List;
 
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
 import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
@@ -16,14 +18,17 @@ public class AnnotationScannerContext {
     private final List<AnnotationScannerExtension> extensions;
     private final OpenApiConfig config;
     private final ClassLoader classLoader;
+    private final OpenAPI openApi;
 
     public AnnotationScannerContext(FilteredIndexView index, ClassLoader classLoader,
             List<AnnotationScannerExtension> extensions,
-            OpenApiConfig config) {
+            OpenApiConfig config,
+            OpenAPI openApi) {
         this.index = index;
         this.classLoader = classLoader;
         this.extensions = extensions;
         this.config = config;
+        this.openApi = openApi;
     }
 
     public FilteredIndexView getIndex() {
@@ -40,5 +45,9 @@ public class AnnotationScannerContext {
 
     public ClassLoader getClassLoader() {
         return classLoader;
+    }
+
+    public OpenAPI getOpenApi() {
+        return openApi;
     }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
@@ -11,8 +11,12 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 
+import org.eclipse.microprofile.openapi.annotations.Components;
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -85,6 +89,12 @@ public class ApiResponseTests extends IndexScannerTestBase {
     public void testVoidAsyncResponseGeneration() throws IOException, JSONException {
         test("responses.void-async-response-generation.json",
                 VoidAsyncResponseGenerationTestResource.class);
+    }
+
+    @Test
+    public void testReferenceResponse() throws IOException, JSONException {
+        test("responses.component-status-reuse.json",
+                ReferenceResponseTestApp.class, ReferenceResponseTestResource.class);
     }
 
     /***************** Test models and resources below. ***********************/
@@ -190,6 +200,28 @@ public class ApiResponseTests extends IndexScannerTestBase {
         @APIResponse(responseCode = "200")
         @APIResponse(responseCode = "400", description = "Description 400")
         public void getPet(@PathParam("id") String id, @Suspended AsyncResponse response) {
+        }
+    }
+
+    @OpenAPIDefinition(info = @Info(title = "Test title", version = "0.1"), components = @Components(responses = {
+            @APIResponse(responseCode = "404", description = "Not Found!", name = "NotFound"),
+            @APIResponse(responseCode = "500", description = "Server Error!", name = "ServerError") }))
+    static class ReferenceResponseTestApp extends Application {
+
+    }
+
+    @Path("pets")
+    static class ReferenceResponseTestResource {
+        @SuppressWarnings("unused")
+        @Path("{id}")
+        @GET
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        @APIResponse(responseCode = "200")
+        @APIResponse(ref = "NotFound")
+        @APIResponse(ref = "ServerError")
+        public Object getPet(@PathParam("id") String id) {
+            return null;
         }
     }
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.component-status-reuse.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.component-status-reuse.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Test title",
+    "version": "0.1"
+  },
+  "paths": {
+    "/pets/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "NotFound": {
+        "description": "Not Found!"
+      },
+      "ServerError": {
+        "description": "Server Error!"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #487 on branch `2.0.x`