### PR TITLE
Support XmlAccessorType, JSON-P types, option to disable array refs (2.0.x)

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -73,6 +73,10 @@ public interface OpenApiConfig {
         return true;
     }
 
+    default boolean arrayReferencesEnable() {
+        return true;
+    }
+
     default String customSchemaRegistryClass() {
         return null;
     }

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -32,6 +32,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     private Boolean scanDependenciesDisable;
     private Set<String> scanDependenciesJars;
     private Boolean schemaReferencesEnable;
+    private Boolean arrayReferencesEnable;
     private String customSchemaRegistryClass;
     private Boolean applicationPathDisable;
     private Map<String, String> schemas;
@@ -215,6 +216,16 @@ public class OpenApiConfigImpl implements OpenApiConfig {
                             .orElse(true));
         }
         return schemaReferencesEnable;
+    }
+
+    @Override
+    public boolean arrayReferencesEnable() {
+        if (arrayReferencesEnable == null) {
+            arrayReferencesEnable = getConfig()
+                    .getOptionalValue(OpenApiConstants.SMALLRYE_ARRAY_REFERENCES_ENABLE, Boolean.class)
+                    .orElse(true);
+        }
+        return arrayReferencesEnable;
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/openapi/api/constants/JaxbConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/JaxbConstants.java
@@ -16,6 +16,10 @@ public class JaxbConstants {
             .createSimple("javax.xml.bind.annotation.XmlElement");
     public static final DotName XML_ATTRIBUTE = DotName
             .createSimple("javax.xml.bind.annotation.XmlAttribute");
+    public static final DotName XML_ACCESSOR_TYPE = DotName
+            .createSimple("javax.xml.bind.annotation.XmlAccessorType");
+    public static final DotName XML_TRANSIENT = DotName
+            .createSimple("javax.xml.bind.annotation.XmlTransient");
 
     public static final String PROP_NAME = "name";
 

--- a/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
@@ -19,6 +19,7 @@ public final class OpenApiConstants {
     public static final String SUFFIX_SCAN_DEPENDENCIES_DISABLE = "scan-dependencies.disable";
     public static final String SUFFIX_SCAN_DEPENDENCIES_JARS = "scan-dependencies.jars";
     public static final String SUFFIX_SCHEMA_REFERENCES_ENABLE = "schema-references.enable";
+    public static final String SUFFIX_ARRAY_REFERENCES_ENABLE = "array-references.enable";
     public static final String SUFFIX_CUSTOM_SCHEMA_REGISTRY_CLASS = "custom-schema-registry.class";
     public static final String SUFFIX_APP_PATH_DISABLE = "application-path.disable";
 
@@ -34,6 +35,8 @@ public final class OpenApiConstants {
             + SUFFIX_SCAN_DEPENDENCIES_JARS;
     public static final String SMALLRYE_SCHEMA_REFERENCES_ENABLE = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME
             + SUFFIX_SCHEMA_REFERENCES_ENABLE;
+    public static final String SMALLRYE_ARRAY_REFERENCES_ENABLE = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME
+            + SUFFIX_ARRAY_REFERENCES_ENABLE;
     public static final String SMALLRYE_CUSTOM_SCHEMA_REGISTRY_CLASS = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME
             + SUFFIX_CUSTOM_SCHEMA_REGISTRY_CLASS;
     public static final String SMALLRYE_APP_PATH_DISABLE = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME + SUFFIX_APP_PATH_DISABLE;

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -501,7 +501,7 @@ public class SchemaFactory {
      * @return true if the schema may be registered, otherwise false
      */
     static boolean allowRegistration(IndexView index, SchemaRegistry registry, Type type, Schema schema) {
-        if (schema == null || registry == null || !TypeUtil.allowRegistration(index, type)) {
+        if (schema == null || registry == null || !registry.isTypeRegistrationSupported(type, schema)) {
             return false;
         }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
@@ -29,6 +30,7 @@ import io.smallrye.openapi.runtime.io.schema.SchemaConstant;
 import io.smallrye.openapi.runtime.scanner.dataobject.TypeResolver;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 import io.smallrye.openapi.runtime.util.ModelUtil;
+import io.smallrye.openapi.runtime.util.TypeUtil;
 
 /**
  * A simple registry used to track schemas that have been generated and inserted
@@ -128,7 +130,7 @@ public class SchemaRegistry {
 
         SchemaRegistry registry = currentInstance();
 
-        if (registry == null || !registry.schemaReferenceSupported()) {
+        if (registry == null || !registry.isTypeRegistrationSupported(resolvedType, schema)) {
             return schema;
         }
 
@@ -288,8 +290,14 @@ public class SchemaRegistry {
         return has(new TypeKey(instanceType));
     }
 
-    public boolean schemaReferenceSupported() {
-        return config != null && config.schemaReferencesEnable();
+    public boolean isTypeRegistrationSupported(Type type, Schema schema) {
+        if (config == null || !TypeUtil.allowRegistration(index, type)) {
+            return false;
+        }
+        if (!config.arrayReferencesEnable()) {
+            return !SchemaType.ARRAY.equals(schema.getType());
+        }
+        return true;
     }
 
     private Schema lookupRef(TypeKey key) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -130,7 +130,7 @@ public class SchemaRegistry {
 
         SchemaRegistry registry = currentInstance();
 
-        if (registry == null || !registry.isTypeRegistrationSupported(resolvedType, schema)) {
+        if (registry == null) {
             return schema;
         }
 
@@ -138,7 +138,8 @@ public class SchemaRegistry {
 
         if (registry.has(key)) {
             schema = registry.lookupRef(key);
-        } else if (registry.index.getClassByName(resolvedType.name()) == null) {
+        } else if (!registry.isTypeRegistrationSupported(resolvedType, schema)
+                || registry.index.getClassByName(resolvedType.name()) == null) {
             return schema;
         } else {
             schema = registry.register(key, schema, null);

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
@@ -98,13 +98,13 @@ public class TypeProcessor {
             while (arrayType.dimensions() > 1) {
                 Schema parentArrSchema = new SchemaImpl();
                 parentArrSchema.setType(Schema.SchemaType.ARRAY);
-                parentArrSchema.items(arrSchema);
+                parentArrSchema.setItems(arrSchema);
 
                 arrSchema = parentArrSchema;
                 arrayType = ArrayType.create(arrayType.component(), arrayType.dimensions() - 1);
             }
 
-            schema.items(arrSchema);
+            schema.setItems(arrSchema);
 
             return arrayType;
         }
@@ -177,7 +177,7 @@ public class TypeProcessor {
                 arraySchema = resolveParameterizedType(arg, arraySchema);
             }
 
-            schema.items(arraySchema);
+            schema.setItems(arraySchema);
 
             typeRead = ARRAY_TYPE_OBJECT; // Representing collection as JSON array
         } else if (isA(pType, MAP_TYPE)) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -67,6 +67,10 @@ public class TypeUtil {
     // SPECIAL FORMATS
     private static final TypeWithFormat ARRAY_FORMAT = TypeWithFormat.of(SchemaType.ARRAY).build();
     private static final TypeWithFormat OBJECT_FORMAT = TypeWithFormat.of(SchemaType.OBJECT).build();
+
+    private static final TypeWithFormat ARRAY_OPAQUE_FORMAT = TypeWithFormat.of(SchemaType.ARRAY).opaque().build();
+    private static final TypeWithFormat OBJECT_OPAQUE_FORMAT = TypeWithFormat.of(SchemaType.OBJECT).opaque().build();
+
     private static final TypeWithFormat DATE_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.DATE).build();
     private static final TypeWithFormat DATE_TIME_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.DATE_TIME)
             .build();
@@ -147,6 +151,13 @@ public class TypeUtil {
         // Time
         TYPE_MAP.put(DotName.createSimple(java.time.LocalTime.class.getName()), TIME_LOCAL_FORMAT);
         TYPE_MAP.put(DotName.createSimple(java.time.OffsetTime.class.getName()), TIME_FORMAT);
+
+        for (String qualifier : Arrays.asList("jakarta.", "javax.")) {
+            TYPE_MAP.put(DotName.createSimple(qualifier + "json.JsonArray"), ARRAY_OPAQUE_FORMAT);
+            TYPE_MAP.put(DotName.createSimple(qualifier + "json.JsonNumber"), NUMBER_FORMAT);
+            TYPE_MAP.put(DotName.createSimple(qualifier + "json.JsonObject"), OBJECT_OPAQUE_FORMAT);
+            TYPE_MAP.put(DotName.createSimple(qualifier + "json.JsonString"), STRING_FORMAT);
+        }
 
         Indexer indexer = new Indexer();
         index(indexer, java.lang.Enum.class);
@@ -275,7 +286,7 @@ public class TypeUtil {
         TypeWithFormat typeFormat = getTypeFormat(classType);
 
         if (typeFormat.isSchemaType(SchemaType.ARRAY, SchemaType.OBJECT)) {
-            return index.getClassByName(classType.name()) != null;
+            return !typeFormat.isOpaque() && index.getClassByName(classType.name()) != null;
         }
         return typeFormat.getProperties().size() > 2;
     }
@@ -727,10 +738,20 @@ public class TypeUtil {
     static final class TypeWithFormat {
         static class Builder {
             private final Map<String, Object> properties = new HashMap<>();
+            private boolean opaque;
 
             Builder(SchemaType schemaType) {
                 Objects.requireNonNull(schemaType);
                 properties.put(SchemaConstant.PROP_TYPE, schemaType);
+            }
+
+            Builder opaque(boolean opaque) {
+                this.opaque = opaque;
+                return this;
+            }
+
+            Builder opaque() {
+                return opaque(true);
             }
 
             Builder format(String format) {
@@ -757,7 +778,7 @@ public class TypeUtil {
             }
 
             TypeWithFormat build() {
-                return new TypeWithFormat(properties);
+                return new TypeWithFormat(properties, opaque);
             }
         }
 
@@ -766,9 +787,11 @@ public class TypeUtil {
         }
 
         private final Map<String, Object> properties;
+        private final boolean opaque;
 
-        private TypeWithFormat(Map<String, Object> properties) {
+        private TypeWithFormat(Map<String, Object> properties, boolean opaque) {
             this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+            this.opaque = opaque;
         }
 
         boolean isSchemaType(SchemaType... schemaTypes) {
@@ -778,6 +801,10 @@ public class TypeUtil {
 
         Map<String, Object> getProperties() {
             return properties;
+        }
+
+        public boolean isOpaque() {
+            return opaque;
         }
     }
 

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/IndexScannerTestBase.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/IndexScannerTestBase.java
@@ -147,32 +147,18 @@ public class IndexScannerTestBase {
     }
 
     public static OpenApiConfig emptyConfig() {
-        return new OpenApiConfigImpl(new Config() {
-            @Override
-            public <T> T getValue(String propertyName, Class<T> propertyType) {
-                return null;
-            }
-
-            @Override
-            public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Iterable<String> getPropertyNames() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public Iterable<ConfigSource> getConfigSources() {
-                return Collections.emptyList();
-            }
-        });
+        return dynamicConfig(Collections.emptyMap());
     }
 
     public static OpenApiConfig nestingSupportConfig() {
         Map<String, Object> config = new HashMap<>(2);
         config.put(OpenApiConstants.SMALLRYE_SCHEMA_REFERENCES_ENABLE, Boolean.TRUE);
+        return dynamicConfig(config);
+    }
+
+    public static OpenApiConfig dynamicConfig(String key, Object value) {
+        Map<String, Object> config = new HashMap<>(1);
+        config.put(key, value);
         return dynamicConfig(config);
     }
 

--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -65,6 +65,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.json.bind</groupId>
             <artifactId>jakarta.json.bind-api</artifactId>
             <scope>test</scope>

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
@@ -2,6 +2,8 @@ package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
 
+import javax.json.JsonObject;
+import javax.json.JsonString;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -42,28 +44,28 @@ public class ApiResponseTests extends IndexScannerTestBase {
     public void testResponseGenerationSuppressedByApiResourcesAnnotation() throws IOException, JSONException {
         test("responses.generation-suppressed-by-api-responses-annotation.json",
                 ResponseGenerationSuppressedByApiResourcesAnnotationTestResource.class,
-                Pet.class);
+                Pet.class, JsonString.class);
     }
 
     @Test
     public void testResponseGenerationSuppressedBySuppliedDefaultApiResource() throws IOException, JSONException {
         test("responses.generation-suppressed-by-supplied-default-api-response.json",
                 ResponseGenerationSuppressedBySuppliedDefaultApiResourceTestResource.class,
-                Pet.class);
+                Pet.class, JsonString.class);
     }
 
     @Test
     public void testResponseGenerationSuppressedByStatusOmission() throws IOException, JSONException {
         test("responses.generation-suppressed-by-status-omission.json",
                 ResponseGenerationSuppressedByStatusOmissionTestResource.class,
-                Pet.class);
+                Pet.class, JsonString.class);
     }
 
     @Test
     public void testResponseGenerationEnabledByIncompleteApiResponse() throws IOException, JSONException {
         test("responses.generation-enabled-by-incomplete-api-response.json",
                 ResponseGenerationEnabledByIncompleteApiResponseTestResource.class,
-                Pet.class);
+                Pet.class, JsonString.class);
     }
 
     @Test
@@ -76,7 +78,7 @@ public class ApiResponseTests extends IndexScannerTestBase {
     public void testVoidPostResponseGeneration() throws IOException, JSONException {
         test("responses.void-post-response-generation.json",
                 VoidPostResponseGenerationTestResource.class,
-                Pet.class);
+                Pet.class, JsonString.class);
     }
 
     @Test
@@ -94,14 +96,14 @@ public class ApiResponseTests extends IndexScannerTestBase {
     @Test
     public void testReferenceResponse() throws IOException, JSONException {
         test("responses.component-status-reuse.json",
-                ReferenceResponseTestApp.class, ReferenceResponseTestResource.class);
+                ReferenceResponseTestApp.class, ReferenceResponseTestResource.class, JsonObject.class);
     }
 
     /***************** Test models and resources below. ***********************/
 
     public static class Pet {
         String id;
-        String name;
+        JsonString name;
     }
 
     @Path("pets")
@@ -220,7 +222,7 @@ public class ApiResponseTests extends IndexScannerTestBase {
         @APIResponse(responseCode = "200")
         @APIResponse(ref = "NotFound")
         @APIResponse(ref = "ServerError")
-        public Object getPet(@PathParam("id") String id) {
+        public JsonObject getPet(@PathParam("id") String id) {
             return null;
         }
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
@@ -36,6 +36,8 @@ import org.jboss.jandex.Index;
 import org.json.JSONException;
 import org.junit.Test;
 
+import io.smallrye.openapi.api.constants.OpenApiConstants;
+
 public class GenericModelTypesResourceTest extends IndexScannerTestBase {
 
     /*
@@ -64,6 +66,29 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
         OpenAPI result = scanner.scan();
         printToConsole(result);
         assertJsonEquals("resource.generic-model-types.json", result);
+    }
+
+    @Test
+    public void testGenericsApplicationWithoutArrayRefs() throws IOException, JSONException {
+        Index i = indexOf(BaseModel.class,
+                BaseResource.class,
+                KingCrimson.class,
+                KingCrimsonResource.class,
+                Magma.class,
+                MagmaResource.class,
+                Message.class,
+                OpenAPIConfig.class,
+                Residents.class,
+                ResidentsResource.class,
+                Result.class,
+                ResultList.class,
+                POJO.class,
+                List.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(OpenApiConstants.SMALLRYE_ARRAY_REFERENCES_ENABLE,
+                                                                                      Boolean.FALSE), i);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals("resource.generic-model-types-wo-array-refs.json", result);
     }
 
     @OpenAPIDefinition(tags = {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
@@ -84,8 +84,10 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
                 ResultList.class,
                 POJO.class,
                 List.class);
-        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(OpenApiConstants.SMALLRYE_ARRAY_REFERENCES_ENABLE,
-                                                                                      Boolean.FALSE), i);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(
+                dynamicConfig(OpenApiConstants.SMALLRYE_ARRAY_REFERENCES_ENABLE,
+                        Boolean.FALSE),
+                i);
         OpenAPI result = scanner.scan();
         printToConsole(result);
         assertJsonEquals("resource.generic-model-types-wo-array-refs.json", result);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
@@ -383,8 +383,10 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
     @Test
     public void testGenericSetResponseWithSetIndexedWithoutArrayRefs() throws IOException, JSONException {
         Index i = indexOf(FruitResource.class, Fruit.class, Seed.class, Set.class);
-        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(OpenApiConstants.SMALLRYE_ARRAY_REFERENCES_ENABLE,
-                                                                                      Boolean.FALSE), i);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(
+                dynamicConfig(OpenApiConstants.SMALLRYE_ARRAY_REFERENCES_ENABLE,
+                        Boolean.FALSE),
+                i);
         OpenAPI result = scanner.scan();
         printToConsole(result);
         assertJsonEquals("responses.generic-collection.set-indexed-wo-array-refs.json", result);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
@@ -58,6 +58,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.constants.OpenApiConstants;
 import test.io.smallrye.openapi.runtime.scanner.resources.ParameterResource;
 
 /**
@@ -377,6 +378,16 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
         OpenAPI result = scanner.scan();
         printToConsole(result);
         assertJsonEquals("responses.generic-collection.set-indexed.json", result);
+    }
+
+    @Test
+    public void testGenericSetResponseWithSetIndexedWithoutArrayRefs() throws IOException, JSONException {
+        Index i = indexOf(FruitResource.class, Fruit.class, Seed.class, Set.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(OpenApiConstants.SMALLRYE_ARRAY_REFERENCES_ENABLE,
+                                                                                      Boolean.FALSE), i);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals("responses.generic-collection.set-indexed-wo-array-refs.json", result);
     }
 
     @Test

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -12,8 +12,11 @@ import java.util.Map.Entry;
 
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -250,6 +253,108 @@ public class TypeResolverTests extends IndexScannerTestBase {
         TypeResolver prop3 = iter.next().getValue();
         assertEquals("prop3", prop3.getPropertyName());
         assertFalse(prop3.isIgnored());
+    }
+
+    @Test
+    public void testXmlAccessTransientField() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(XmlTransientField.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(XmlTransientField.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
+                null);
+        assertEquals(2, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+        TypeResolver property = iter.next().getValue();
+        assertEquals("prop1Field", property.getPropertyName());
+        assertTrue(property.isIgnored());
+        property = iter.next().getValue();
+        assertEquals("prop2Field", property.getPropertyName());
+        assertFalse(property.isIgnored());
+    }
+
+    @Test
+    public void testXmlAccessTransientClass() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(XmlTransientClass.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(XmlTransientClass.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
+                null);
+        assertEquals(3, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+
+        TypeResolver property = iter.next().getValue();
+        assertEquals("prop1Field", property.getPropertyName());
+        assertTrue(property.isIgnored());
+
+        property = iter.next().getValue();
+        assertEquals("prop2Field", property.getPropertyName());
+        assertTrue(property.isIgnored());
+
+        property = iter.next().getValue();
+        assertEquals("prop3Property", property.getPropertyName());
+        assertTrue(property.isIgnored());
+    }
+
+    @Test
+    public void testXmlAccessPublicMember() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(XmlAccessTypePublicMember.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(XmlAccessTypePublicMember.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
+                null);
+        assertEquals(3, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+
+        TypeResolver property = iter.next().getValue();
+        assertEquals("prop1Field", property.getPropertyName());
+        assertFalse(property.isIgnored());
+
+        property = iter.next().getValue();
+        assertEquals("prop2Field", property.getPropertyName());
+        assertTrue(property.isIgnored());
+
+        property = iter.next().getValue();
+        assertEquals("prop3Property", property.getPropertyName());
+        assertFalse(property.isIgnored());
+    }
+
+    @Test
+    public void testXmlAccessTypeFieldOnly() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(XmlAccessTypeFieldOnly.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(XmlAccessTypeFieldOnly.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
+                null);
+        assertEquals(2, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+
+        TypeResolver property = iter.next().getValue();
+        assertEquals("prop1Field", property.getPropertyName());
+        assertFalse(property.isIgnored());
+
+        property = iter.next().getValue();
+        assertEquals("prop2Property", property.getPropertyName());
+        assertTrue(property.isIgnored());
+    }
+
+    @Test
+    public void testXmlAccessTypePropertyOnly() {
+        AugmentedIndexView index = new AugmentedIndexView(indexOf(XmlAccessTypePropertyOnly.class));
+        ClassInfo leafKlazz = index.getClassByName(componentize(XmlAccessTypePropertyOnly.class.getName()));
+        Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
+        Map<String, TypeResolver> properties = TypeResolver.getAllFields(index, new IgnoreResolver(index), leaf, leafKlazz,
+                null);
+        assertEquals(2, properties.size());
+        Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
+        TypeResolver property;
+
+        property = iter.next().getValue();
+        assertEquals("prop2Field", property.getPropertyName());
+        assertTrue(property.isIgnored());
+
+        property = iter.next().getValue();
+        assertEquals("prop1Property", property.getPropertyName());
+        assertFalse(property.isIgnored());
     }
 
     /* Test models and resources below. */
@@ -540,6 +645,52 @@ public class TypeResolverTests extends IndexScannerTestBase {
         public void setProp2(String prop2) {
             this.prop2 = prop2;
         }
+    }
 
+    ///////////////////////////
+
+    static class XmlTransientField {
+        @XmlTransient
+        String prop1Field;
+        String prop2Field;
+    }
+
+    @XmlTransient
+    static class XmlTransientClass {
+        String prop1Field;
+        String prop2Field;
+
+        public String getProp3Property() {
+            return null;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.PUBLIC_MEMBER)
+    static class XmlAccessTypePublicMember {
+        public String prop1Field;
+        @SuppressWarnings("unused")
+        private String prop2Field;
+
+        public String getProp3Property() {
+            return null;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class XmlAccessTypeFieldOnly {
+        String prop1Field;
+
+        public String getProp2Property() {
+            return null;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.PROPERTY)
+    static class XmlAccessTypePropertyOnly {
+        String prop2Field;
+
+        public String getProp1Property() {
+            return null;
+        }
     }
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types-wo-array-refs.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types-wo-array-refs.json
@@ -1,0 +1,598 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API - Service",
+    "version": "V1"
+  },
+  "security": [
+    {
+      "API-Key": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Test",
+      "description": "Cristian"
+    }
+  ],
+  "paths": {
+    "/v1/kingcrimson": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultListKingCrimson"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KingCrimson"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultKingCrimson"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KingCrimson"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultKingCrimson"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KingCrimson"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/kingcrimson/noooooooo": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultListPOJO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/magma": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultListMagma"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Magma"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultMagma"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Magma"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultMagma"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Magma"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/residents": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultListResidents"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Residents"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Creates a new Chart",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultResidents"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Residents"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Creates a new Chart",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultResidents"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Residents"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Magma": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+            "type": "string"
+          },
+          "lastUpdate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "codename": {
+            "type": "string"
+          },
+          "deployment": {
+            "$ref": "#/components/schemas/KingCrimson"
+          },
+          "tier": {
+            "type": "string"
+          }
+        }
+      },
+      "KingCrimson": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+            "type": "string"
+          },
+          "lastUpdate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "environment": {
+            "$ref": "#/components/schemas/Magma"
+          },
+          "status": {
+            "type": "object"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "Message": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "ResultListKingCrimson": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KingCrimson"
+            }
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "POJO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+            "type": "string"
+          },
+          "lastUpdate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ResultListPOJO": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/POJO"
+            }
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "ResultKingCrimson": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "result": {
+            "$ref": "#/components/schemas/KingCrimson"
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "ResultListMagma": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Magma"
+            }
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "ResultMagma": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "result": {
+            "$ref": "#/components/schemas/Magma"
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "Residents": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+            "type": "string"
+          },
+          "lastUpdate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "bar": {
+            "type": "string"
+          },
+          "foo": {
+            "type": "string"
+          }
+        }
+      },
+      "ResultListResidents": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Residents"
+            }
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "ResultResidents": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "result": {
+            "$ref": "#/components/schemas/Residents"
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "API-Key": {
+        "type": "apiKey",
+        "name": "API-Key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.generic-collection.set-indexed-wo-array-refs.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.generic-collection.set-indexed-wo-array-refs.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/fruits": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Fruit"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Fruit"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Fruit"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Fruit"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Fruit"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Seed": {
+        "type": "object"
+      },
+      "Fruit": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "seeds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Seed"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>
+        <version.resources.plugin>3.2.0</version.resources.plugin>
+        <version.frontend-maven-plugin>1.10.3</version.frontend-maven-plugin>
 
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/tck/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../tck/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
@@ -169,6 +171,16 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${version.resources.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <version>${version.frontend-maven-plugin}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.asciidoctor</groupId>
                     <artifactId>asciidoctor-maven-plugin</artifactId>

--- a/ui/open-api-ui-forms/pom.xml
+++ b/ui/open-api-ui-forms/pom.xml
@@ -76,6 +76,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
Fixes #508 for `2.0.x` branch.

Adds new configuration property: `mp.openapi.extensions.smallrye.array-references.enable` with default `true`.