### PR TITLE
Use an empty schema for field annotations when `ref` present (2.0.x)

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -153,6 +153,9 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         if (schemaAnnotation != null) {
             // Handle field annotated with @Schema.
             fieldSchema = readSchemaAnnotatedField(propertyKey, schemaAnnotation, fieldType);
+        } else if (registrationSuccessful(typeSchema, registeredTypeSchema)) {
+            // The type schema was registered, start with empty schema for the field using the type from the field type's schema
+            fieldSchema = new SchemaImpl().type(typeSchema.getType());
         } else {
             // Use the type's schema for the field as a starting point (poor man's clone)
             fieldSchema = MergeUtil.mergeObjects(new SchemaImpl(), typeSchema);
@@ -165,7 +168,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         }
 
         // Only when registration was successful (ref is present and the registered type is a different instance)
-        if (typeSchema != registeredTypeSchema && registeredTypeSchema.getRef() != null) {
+        if (registrationSuccessful(typeSchema, registeredTypeSchema)) {
             // Check if the field specifies something additional or different from the type's schema
             if (fieldOverridesType(fieldSchema, typeSchema)) {
                 TypeUtil.clearMatchingDefaultAttributes(fieldSchema, typeSchema); // Remove duplicates
@@ -183,6 +186,18 @@ public class AnnotationTargetProcessor implements RequirementHandler {
 
         parentPathEntry.getSchema().addProperty(propertyKey, fieldSchema);
         return fieldSchema;
+    }
+
+    /**
+     * A successful registration results in the registered type schema being a distinct
+     * Schema instance containing only a <code>ref</code> to the original type schema.
+     * 
+     * @param typeSchema schema for a type
+     * @param registeredTypeSchema a (potential) reference schema to typeSchema
+     * @return true if the schemas are not the same (i.e. registration occurred), otherwise false
+     */
+    private boolean registrationSuccessful(Schema typeSchema, Schema registeredTypeSchema) {
+        return (typeSchema != registeredTypeSchema);
     }
 
     private Schema readSchemaAnnotatedField(String propertyKey, AnnotationInstance annotation, Type postProcessedField) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java
@@ -38,14 +38,9 @@ public class BeanValidationScanner {
 
     static final DotName BV_CONTRAINTS = createComponentized(BV_BASE, "constraints");
 
-    //static final DotName BV_ASSERT_TRUE = createComponentized(BV_CONTRAINTS, "AssertTrue");
-    //static final DotName BV_ASSERT_FALSE = createComponentized(BV_CONTRAINTS, "AssertFalse");
     static final DotName BV_DECIMAL_MAX = createComponentized(BV_CONTRAINTS, "DecimalMax");
     static final DotName BV_DECIMAL_MIN = createComponentized(BV_CONTRAINTS, "DecimalMin");
     static final DotName BV_DIGITS = createComponentized(BV_CONTRAINTS, "Digits");
-    //static final DotName BV_EMAIL = createComponentized(BV_CONTRAINTS, "Email");
-    //static final DotName BV_FUTURE = createComponentized(BV_CONTRAINTS, "Future");
-    //static final DotName BV_FUTURE_OR_PRESENT = createComponentized(BV_CONTRAINTS, "FutureOrPresent");
     static final DotName BV_MAX = createComponentized(BV_CONTRAINTS, "Max");
     static final DotName BV_MIN = createComponentized(BV_CONTRAINTS, "Min");
     static final DotName BV_NEGATIVE = createComponentized(BV_CONTRAINTS, "Negative");
@@ -53,10 +48,6 @@ public class BeanValidationScanner {
     static final DotName BV_NOT_BLANK = createComponentized(BV_CONTRAINTS, "NotBlank");
     static final DotName BV_NOT_EMPTY = createComponentized(BV_CONTRAINTS, "NotEmpty");
     static final DotName BV_NOT_NULL = createComponentized(BV_CONTRAINTS, "NotNull");
-    //static final DotName BV_NULL = createComponentized(BV_CONTRAINTS, "Null");
-    //static final DotName BV_PAST = createComponentized(BV_CONTRAINTS, "Past");
-    //static final DotName BV_PAST_OR_PRESENT = createComponentized(BV_CONTRAINTS, "PastOrPresent");
-    //static final DotName BV_PATTERN = createComponentized(BV_CONTRAINTS, "Pattern");
     static final DotName BV_POSITIVE = createComponentized(BV_CONTRAINTS, "Positive");
     static final DotName BV_POSITIVE_OR_ZERO = createComponentized(BV_CONTRAINTS, "PositiveOrZero");
     static final DotName BV_SIZE = createComponentized(BV_CONTRAINTS, "Size");

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
@@ -37,7 +37,10 @@ public class BeanValidationResourceTest extends IndexScannerTestBase {
 
     @Before
     public void beforeEach() {
-        index = indexOf(BVTestResource.class, BVTestResourceEntity.class, BeanValidationScannerTest.BVTestContainer.class);
+        index = indexOf(BVTestResource.class,
+                BVTestResourceEntity.class,
+                BeanValidationScannerTest.BVTestContainer.class,
+                TestEnum.class);
     }
 
     @Test
@@ -92,5 +95,16 @@ public class BeanValidationResourceTest extends IndexScannerTestBase {
         @Schema(minProperties = 0, maxProperties = 100, nullable = true, name = "map_no_bean_constraints", required = false)
         @JsonbProperty("map_no_bean_constraints")
         private Map<String, String> mapIgnoreBvContraints;
+
+        @NotNull
+        TestEnum enumValue;
+
     }
+
+    @Schema
+    enum TestEnum {
+        ABC,
+        DEF
+    }
+
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
@@ -38,8 +38,13 @@
   },
   "components": {
     "schemas": {
+      "TestEnum" : {
+        "enum" : [ "ABC", "DEF" ],
+        "type" : "string"
+      },
       "BVTestResourceEntity": {
         "type": "object",
+        "required" : [ "enumValue" ],
         "properties": {
           "string_no_bean_constraints": {
             "type": "string",
@@ -71,6 +76,13 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "enumValue" : {
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/TestEnum"
+            }, {
+              "nullable" : false
+            } ]
           }
         }
       },


### PR DESCRIPTION
Fixes #520