### PR TITLE
Fix MergeUtil for empty arrays

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/util/MergeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/api/util/MergeUtil.java
@@ -224,7 +224,7 @@ public class MergeUtil {
         if (values1 != null && values2 == null) {
             return Optional.of(values1);
         }
-        if (values1 == null && values2 != null) {
+        if ((values1 == null || values1.isEmpty()) && values2 != null) {
             return Optional.of(values2);
         }
         if (values1.equals(values2)) {

--- a/core/src/test/java/io/smallrye/openapi/api/util/MergeUtilTest.java
+++ b/core/src/test/java/io/smallrye/openapi/api/util/MergeUtilTest.java
@@ -150,4 +150,12 @@ public class MergeUtilTest {
         doTest("_opTags/opTags1.json", "_opTags/opTags2.json", "_opTags/merged.json");
     }
 
+    /**
+     * Test method for
+     * {@link MergeUtil#merge(io.smallrye.openapi.api.models.OpenAPIImpl, io.smallrye.openapi.api.models.OpenAPIImpl)}.
+     */
+    @Test
+    public void testMerge_EmptyQueryParam() throws IOException, ParseException, JSONException {
+        doTest("_pathEmpty/pathEmpty1.json", "_pathEmpty/pathEmpty2.json", "_pathEmpty/merged.json");
+    }
 }

--- a/core/src/test/resources/io/smallrye/openapi/api/util/_pathEmpty/merged.json
+++ b/core/src/test/resources/io/smallrye/openapi/api/util/_pathEmpty/merged.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "parameters": [
+          {
+            "name": "pet_id",
+            "in": "query",
+            "description": "the ID of the pet to filter",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/api/util/_pathEmpty/pathEmpty1.json
+++ b/core/src/test/resources/io/smallrye/openapi/api/util/_pathEmpty/pathEmpty1.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "parameters": [
+        ]
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/api/util/_pathEmpty/pathEmpty2.json
+++ b/core/src/test/resources/io/smallrye/openapi/api/util/_pathEmpty/pathEmpty2.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "parameters": [
+          {
+            "name": "pet_id",
+            "in": "query",
+            "description": "the ID of the pet to filter",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Description:**
* In MergeUtils:235, when merging lists, if the first collection is empty, an unchecked OutOfBoundsException is being thrown.

**Exception thrown:**
* To verify the exception checkout the first commit (to undo the fix) and run the test MergeUtilTest.testMerge_EmptyQueryParam.
```java
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0

	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
	at java.base/java.util.Objects.checkIndex(Objects.java:373)
	at java.base/java.util.ArrayList.get(ArrayList.java:425)
	at java.base/java.util.Collections$UnmodifiableList.get(Collections.java:1310)
	at io.smallrye.openapi.api.util.MergeUtil.mergeLists(MergeUtil.java:235)
	at io.smallrye.openapi.api.util.MergeUtil.mergeObjects(MergeUtil.java:124)
	at io.smallrye.openapi.api.util.MergeUtil.mergeObjects(MergeUtil.java:104)
	at io.smallrye.openapi.api.util.MergeUtil.mergeMaps(MergeUtil.java:179)
	at io.smallrye.openapi.api.util.MergeUtil.mergeObjects(MergeUtil.java:115)
	at io.smallrye.openapi.api.util.MergeUtil.mergeObjects(MergeUtil.java:104)
	at io.smallrye.openapi.api.util.MergeUtil.merge(MergeUtil.java:57)
	at io.smallrye.openapi.api.util.MergeUtilTest.doTest(MergeUtilTest.java:65)
	at io.smallrye.openapi.api.util.MergeUtilTest.testMerge_EmptyQueryParam(MergeUtilTest.java:159)
```

**How to reproduce:**
* Using Quarkus 1.8.3.Final, create an endpoint that uses @BeanParam to aggregate the input parameters of an endpoint. This should result in the exception above.

```java
@Path("/pet")
@Consumes(APPLICATION_JSON)
@Produces(APPLICATION_JSON)
class PetEndpoint {
  @GET
  public Response endpoint(@Valid @BeanParam final PetParams userParams) {
    return Response.ok().build();
  }
}

class PetParams {
  @Parameter(
        name = "pet_id",
        description = "the id of the pet to filter",
        example = "123",
        required = true,
        schema = @Schema(implementation = Integer.class, required = true)
    @NotNull
    @QueryParam("user_id")
    private Integer user_id;
}
```

**Known workaround:**
* Add a dummy parameter to the endpoint method signature or extract one param from BeanParam class to the method signature.