### PR TITLE
Fix -ui-forms backport .gitignore interaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ tags
 /bin/
 .cache
 **/node_modules/
-**/dist/
+# Node.JS' dist/ directories should be ignored with trailing **/* to allow override rules for possible dist/index.html
+**/dist/**/*
 /ui/open-api-ui/nbproject/

--- a/ui/open-api-ui-forms/.gitignore
+++ b/ui/open-api-ui-forms/.gitignore
@@ -1,6 +1,6 @@
 .cache/
 coverage/
-dist/*
+dist/**/*
 !dist/index.html
 node_modules/
 *.log

--- a/ui/open-api-ui-forms/dist/index.html
+++ b/ui/open-api-ui-forms/dist/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+ 
+    <title>OpenAPI as Forms</title>
+  </head>
+  <body>
+    <nav class="navbar navbar-dark bg-dark">
+      <a class="navbar-brand" href="#">
+      OpenAPI as Forms
+      </a>
+    </nav>
+    <div class="container" id="rrr"></div>
+    <script src="bundle.js"></script>
+    
+  </body>
+</html>


### PR DESCRIPTION
When I did the backport of the `open-api-ui-forms` single page application to branch `2.0.x` with https://github.com/smallrye/smallrye-open-api/pull/497
I didn't fully realise an interaction between `.gitignore` files(s).

The `dist/index.html` it is required to be under source control.

With this PR I fix the problem on the branch `2.0.x` which inadvertently resulted in missing it and I didn't realise earlier, sorry :) 