### PR TITLE
Make sure filters can work in maven plugin (Classloader issue) (master)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
         name: checkout
 
-      - uses: actions/setup-java@v1.3.0
+      - uses: actions/setup-java@v1.4.3
         name: set up jdk ${{matrix.java}}
         with:
           java-version: ${{matrix.java}}
@@ -50,7 +50,7 @@ jobs:
       - run: |
           git fetch --prune --unshallow --tags --force
 
-      - uses: actions/setup-java@v1.3.0
+      - uses: actions/setup-java@v1.4.3
         with:
           java-version: 11
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           token: ${{secrets.RELEASE_TOKEN}}
 
-      - uses: actions/setup-java@v1.3.0
+      - uses: actions/setup-java@v1.4.3
         with:
           java-version: 8
 


### PR DESCRIPTION
Partially fix #554. We can still discuss allow always including files annotated with `@Schema`. This just fix the maven plugin to allow filters to work.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>