### PR TITLE
Preemptive scan of classes with Schema annotation into components (2.0.x)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,11 +88,17 @@
             <artifactId>jsonassert</artifactId>
             <scope>test</scope>
         </dependency>
-        
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/CurrentScannerInfo.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/CurrentScannerInfo.java
@@ -1,5 +1,7 @@
 package io.smallrye.openapi.runtime.io;
 
+import org.jboss.jandex.Type;
+
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner;
 
 /**
@@ -16,7 +18,8 @@ public class CurrentScannerInfo {
     }
 
     public static AnnotationScanner getCurrentAnnotationScanner() {
-        return current.get().annotationScanner;
+        CurrentScannerInfo info = current.get();
+        return info != null ? info.annotationScanner : null;
     }
 
     public static void setCurrentConsumes(final String[] currentConsumes) {
@@ -37,6 +40,16 @@ public class CurrentScannerInfo {
 
     public static void remove() {
         current.remove();
+    }
+
+    public static boolean isWrapperType(Type type) {
+        AnnotationScanner scanner = getCurrentAnnotationScanner();
+        return scanner != null && scanner.isWrapperType(type);
+    }
+
+    public static boolean isScannerInternalResponse(Type type) {
+        AnnotationScanner scanner = getCurrentAnnotationScanner();
+        return scanner != null && scanner.isScannerInternalResponse(type);
     }
 
     private String[] currentConsumes;

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -36,7 +36,6 @@ import io.smallrye.openapi.runtime.io.externaldocs.ExternalDocsReader;
 import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
 import io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner;
 import io.smallrye.openapi.runtime.scanner.SchemaRegistry;
-import io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 import io.smallrye.openapi.runtime.util.ModelUtil;
 import io.smallrye.openapi.runtime.util.TypeUtil;
@@ -369,14 +368,12 @@ public class SchemaFactory {
     public static Schema typeToSchema(IndexView index, ClassLoader cl, Type type, List<AnnotationScannerExtension> extensions) {
         Schema schema = null;
 
-        AnnotationScanner annotationScanner = CurrentScannerInfo.getCurrentAnnotationScanner();
-
         if (TypeUtil.isOptional(type)) {
             // Recurse using the optional's type
             return typeToSchema(index, cl, TypeUtil.getOptionalType(type), extensions);
-        } else if (annotationScanner.isWrapperType(type)) {
+        } else if (CurrentScannerInfo.isWrapperType(type)) {
             // Recurse using the wrapped type
-            return typeToSchema(index, cl, annotationScanner.unwrapType(type), extensions);
+            return typeToSchema(index, cl, CurrentScannerInfo.getCurrentAnnotationScanner().unwrapType(type), extensions);
         } else if (type.kind() == Type.Kind.ARRAY) {
             schema = new SchemaImpl().type(SchemaType.ARRAY);
             ArrayType array = type.asArrayType();
@@ -450,9 +447,8 @@ public class SchemaFactory {
      */
     private static Schema introspectClassToSchema(IndexView index, ClassLoader cl, ClassType ctype,
             boolean schemaReferenceSupported) {
-        AnnotationScanner annotationScanner = CurrentScannerInfo.getCurrentAnnotationScanner();
 
-        if (annotationScanner.isScannerInternalResponse(ctype)) {
+        if (CurrentScannerInfo.isScannerInternalResponse(ctype)) {
             return null;
         }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiAnnotationScanner.java
@@ -4,12 +4,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.constants.OpenApiConstants;
@@ -19,6 +21,8 @@ import io.smallrye.openapi.api.util.MergeUtil;
 import io.smallrye.openapi.runtime.io.CurrentScannerInfo;
 import io.smallrye.openapi.runtime.io.definition.DefinitionConstant;
 import io.smallrye.openapi.runtime.io.definition.DefinitionReader;
+import io.smallrye.openapi.runtime.io.schema.SchemaConstant;
+import io.smallrye.openapi.runtime.io.schema.SchemaFactory;
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner;
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerFactory;
@@ -134,6 +138,8 @@ public class OpenApiAnnotationScanner {
         ScannerLogging.log.scanning("OpenAPI");
         processPackageOpenAPIDefinitions(annotationScannerContext, openApi);
 
+        processClassSchemas(annotationScannerContext);
+
         return openApi;
     }
 
@@ -148,7 +154,7 @@ public class OpenApiAnnotationScanner {
         List<AnnotationInstance> packageDefs = context.getIndex()
                 .getAnnotations(DefinitionConstant.DOTNAME_OPEN_API_DEFINITION)
                 .stream()
-                .filter(annotation -> annotation.target().kind() == AnnotationTarget.Kind.CLASS)
+                .filter(this::annotatedClasses)
                 .filter(annotation -> annotation.target().asClass().name().withoutPackagePrefix().equals("package-info"))
                 .collect(Collectors.toList());
 
@@ -176,5 +182,21 @@ public class OpenApiAnnotationScanner {
             }
 
         }
+    }
+
+    private void processClassSchemas(final AnnotationScannerContext context) {
+        CurrentScannerInfo.register(null);
+
+        context.getIndex()
+                .getAnnotations(SchemaConstant.DOTNAME_SCHEMA)
+                .stream()
+                .filter(this::annotatedClasses)
+                .map(annotation -> Type.create(annotation.target().asClass().name(), Type.Kind.CLASS))
+                .forEach(type -> SchemaFactory.typeToSchema(context.getIndex(), context.getClassLoader(), type,
+                        context.getExtensions()));
+    }
+
+    private boolean annotatedClasses(AnnotationInstance annotation) {
+        return Objects.equals(annotation.target().kind(), AnnotationTarget.Kind.CLASS);
     }
 }

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -1,0 +1,39 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.junit.Test;
+
+public class StandaloneSchemaScanTest extends IndexScannerTestBase {
+
+    @Test
+    public void testUnreferencedSchemasInComponents() throws Exception {
+        Index index = indexOf(Cat.class, Dog.class, Class.forName(getClass().getPackage().getName() + ".package-info"));
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.unreferenced.json", result);
+    }
+
+    /****************************************************************/
+
+    static class Cat {
+        public String name;
+        @Schema(minimum = "1", maximum = "20")
+        public int age;
+        @Schema(nullable = true)
+        public String color;
+    }
+
+    @Schema(name = "DogType")
+    static class Dog {
+        public String name;
+        public int age;
+        @Schema(required = true)
+        public int volume;
+    }
+
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/package-info.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/package-info.java
@@ -1,0 +1,4 @@
+@org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition(info = @org.eclipse.microprofile.openapi.annotations.info.Info(title = "Test", version = "1.0"), components = @org.eclipse.microprofile.openapi.annotations.Components(schemas = {
+        @org.eclipse.microprofile.openapi.annotations.media.Schema(name = "CatType", implementation = io.smallrye.openapi.runtime.scanner.StandaloneSchemaScanTest.Cat.class)
+}))
+package io.smallrye.openapi.runtime.scanner;

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.unreferenced.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.unreferenced.json
@@ -1,0 +1,46 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Test",
+    "version": "1.0"
+  },
+  "components": {
+    "schemas": {
+      "CatType": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "format": "int32",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20
+          },
+          "color": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "DogType": {
+        "type": "object",
+        "required": [ "volume" ],
+        "properties": {
+          "age": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "volume": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-vertx/pom.xml
+++ b/extension-vertx/pom.xml
@@ -77,6 +77,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes #554 for `2.0.x` releases.

Conflicts:
	core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java