### PR TITLE
Run TCK with Arquillian, WELD and RESTEasy.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,12 @@ jobs:
       - name: build with maven
         run: mvn -B formatter:validate verify --file pom.xml
 
+      - uses: actions/upload-artifact@v2
+        name: tck-report
+        with:
+          name: tck-report
+          path: testsuite/tck/target/surefire-reports
+
   quality:
     needs: [build]
     if: github.event_name == 'push' && github.repository == 'smallrye/smallrye-open-api'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,12 @@ jobs:
           git push
           git push --tags
 
+      - uses: actions/upload-artifact@v2
+        name: tck-report
+        with:
+          name: tck-report
+          path: testsuite/tck/target/surefire-reports
+
       - uses: radcortez/milestone-release-action@master
         name: milestone release
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
         <version.maven-resources-plugin>3.2.0</version.maven-resources-plugin>
         <version.com.github.eirslett.frontend-maven-plugin>1.10.4</version.com.github.eirslett.frontend-maven-plugin>
 
+        <version.arquillian.jetty>1.0.0.CR3</version.arquillian.jetty>
+        <version.jetty>9.3.29.v20201019</version.jetty>
+        <version.resteasy>4.5.7.Final</version.resteasy>
+
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/tck/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../tck/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
@@ -57,6 +61,7 @@
         <module>extension-vertx</module>
         <module>implementation</module>
         <module>tck</module>
+        <module>testsuite</module>
         <module>ui</module>
         <module>tools</module>
     </modules>
@@ -137,6 +142,22 @@
                 <artifactId>jsonassert</artifactId>
                 <version>${version.org.skyscreamer}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- TCK -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${version.jetty}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-bom</artifactId>
+                <version>${version.resteasy}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- Dependencies provided by the project -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~  Copyright 2020 Red Hat, Inc.
+ ~
+ ~  Licensed under the Apache License, Version 2.0 (the "License");
+ ~  you may not use this file except in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing, software
+ ~  distributed under the License is distributed on an "AS IS" BASIS,
+ ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~  See the License for the specific language governing permissions and
+ ~  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.smallrye</groupId>
+    <artifactId>smallrye-open-api-parent</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>smallrye-open-api-testsuite</artifactId>
+  <packaging>pom</packaging>
+
+  <name>SmallRye: MicroProfile OpenAPI Test Suite</name>
+
+  <modules>
+    <module>tck</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~  Copyright 2017 Red Hat, Inc.
+ ~
+ ~  Licensed under the Apache License, Version 2.0 (the "License");
+ ~  you may not use this file except in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing, software
+ ~  distributed under the License is distributed on an "AS IS" BASIS,
+ ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~  See the License for the specific language governing permissions and
+ ~  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.smallrye</groupId>
+    <artifactId>smallrye-open-api-testsuite</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>smallrye-open-api-testsuite-tck</artifactId>
+
+  <name>SmallRye: MicroProfile OpenAPI TCK</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <dependenciesToScan>
+            <dependency>org.eclipse.microprofile.openapi:microprofile-openapi-tck</dependency>
+          </dependenciesToScan>
+          <systemProperties>
+            <test.url>http://localhost:8080</test.url>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-tck</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-jetty-embedded-9</artifactId>
+      <version>${version.arquillian.jetty}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.resolver</groupId>
+      <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.resolver</groupId>
+      <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-deploy</artifactId>
+      <version>${version.jetty}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-plus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld.servlet</groupId>
+      <artifactId>weld-servlet-core</artifactId>
+      <version>${version.weld.core}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-servlet-initializer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-cdi</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-json-binding-provider</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client-microprofile</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>coverage</id>
+      <properties>
+        <argLine>@{jacocoArgLine}</argLine>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/AfterDeployObserver.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/AfterDeployObserver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.tck;
+
+import org.jboss.arquillian.container.spi.event.container.AfterDeploy;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+import io.restassured.RestAssured;
+
+/**
+ * This sets the RestAssured.basePath to the Arquillian generated archive name, mapped to the context root.
+ */
+public class AfterDeployObserver {
+    public void afterDeploy(@Observes final AfterDeploy afterDeploy) {
+        RestAssured.basePath = afterDeploy.getDeployment().getArchive().getName();
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/ArquillianExtension.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/ArquillianExtension.java
@@ -1,0 +1,12 @@
+package io.smallrye.openapi.tck;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class ArquillianExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.service(ApplicationArchiveProcessor.class, DeploymentProcessor.class)
+                .observer(AfterDeployObserver.class);
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/DeploymentProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/DeploymentProcessor.java
@@ -1,0 +1,195 @@
+package io.smallrye.openapi.tck;
+
+import static io.smallrye.openapi.runtime.OpenApiProcessor.getFilter;
+import static io.smallrye.openapi.runtime.OpenApiProcessor.modelFromAnnotations;
+import static io.smallrye.openapi.runtime.OpenApiProcessor.modelFromReader;
+import static io.smallrye.openapi.runtime.io.Format.JSON;
+import static io.smallrye.openapi.runtime.io.Format.YAML;
+import static io.smallrye.openapi.runtime.io.OpenApiSerializer.serialize;
+import static java.lang.Thread.currentThread;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Optional.ofNullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConfigImpl;
+import io.smallrye.openapi.api.OpenApiDocument;
+import io.smallrye.openapi.runtime.OpenApiProcessor;
+import io.smallrye.openapi.runtime.OpenApiStaticFile;
+import io.smallrye.openapi.runtime.io.Format;
+import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
+
+public class DeploymentProcessor implements ApplicationArchiveProcessor {
+    public static volatile ClassLoader classLoader;
+
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+        if (classLoader == null) {
+            classLoader = Thread.currentThread().getContextClassLoader();
+        }
+
+        if (archive instanceof WebArchive) {
+            WebArchive war = (WebArchive) archive;
+            war.addClass(OpenApiRegistration.class);
+            war.addClass(OpenApiApplication.class);
+            war.addClass(OpenApiEndpoint.class);
+            war.addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"));
+
+            // This sets the war name as the context root
+            war.addAsWebInfResource(
+                    new StringAsset("<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
+                            "  <Set name=\"contextPath\">/" + war.getName() + "</Set>\n" +
+                            "  ...\n" +
+                            "</Configure>"),
+                    ArchivePaths.create("jetty-web.xml"));
+
+            // Add the required dependencies
+            String[] deps = {
+                    "org.jboss.resteasy:resteasy-servlet-initializer",
+                    "org.jboss.resteasy:resteasy-cdi",
+                    "org.jboss.resteasy:resteasy-json-binding-provider",
+                    "io.smallrye:smallrye-open-api-core",
+                    "io.smallrye:smallrye-open-api-jaxrs"
+            };
+            File[] dependencies = Maven.configureResolver()
+                    .workOffline()
+                    .loadPomFromFile(new File("pom.xml"))
+                    .resolve(deps)
+                    .withoutTransitivity()
+                    .asFile();
+            war.addAsLibraries(dependencies);
+
+            generateOpenAPI(war);
+
+            System.out.println(war.toString(true));
+        }
+    }
+
+    /**
+     * Builds the OpenAPI file and copies it to the deployed application.
+     */
+    private static void generateOpenAPI(final WebArchive war) {
+        OpenApiConfig openApiConfig = config(war);
+        Index index = index(war, openApiConfig);
+        ClassLoader contextClassLoader = currentThread().getContextClassLoader();
+
+        Optional<OpenAPI> annotationModel = ofNullable(modelFromAnnotations(openApiConfig, contextClassLoader, index));
+        Optional<OpenAPI> readerModel = ofNullable(modelFromReader(openApiConfig, contextClassLoader));
+        Optional<OpenAPI> staticFileModel = Stream.of(modelFromFile(war, "/META-INF/openapi.json", JSON),
+                modelFromFile(war, "/META-INF/openapi.yaml", YAML),
+                modelFromFile(war, "/META-INF/openapi.yml", YAML))
+                .filter(Optional::isPresent)
+                .findFirst()
+                .flatMap(openAPI -> openAPI);
+
+        OpenApiDocument document = OpenApiDocument.INSTANCE;
+        document.reset();
+        document.config(openApiConfig);
+        annotationModel.ifPresent(document::modelFromAnnotations);
+        readerModel.ifPresent(document::modelFromReader);
+        staticFileModel.ifPresent(document::modelFromStaticFile);
+        document.filter(getFilter(openApiConfig, contextClassLoader));
+        document.initialize();
+        OpenAPI openAPI = document.get();
+
+        try {
+            war.addAsManifestResource(new ByteArrayAsset(serialize(openAPI, JSON).getBytes(UTF_8)), "openapi.json");
+            war.addAsManifestResource(new ByteArrayAsset(serialize(openAPI, JSON).getBytes(UTF_8)), "openapi.yaml");
+        } catch (IOException e) {
+            // Ignore
+        }
+
+        document.reset();
+    }
+
+    /**
+     * Provides the Jandex index.
+     */
+    private static Index index(final WebArchive war, final OpenApiConfig config) {
+        FilteredIndexView filteredIndexView = new FilteredIndexView(null, config);
+        Indexer indexer = new Indexer();
+        Collection<Node> classes = war.getContent(object -> object.get().endsWith(".class")).values();
+        for (Node value : classes) {
+            try {
+                String resource = value.getPath().get().replaceAll("/WEB-INF/classes/", "");
+                // We remove the OpenApinEndpoint so the /openapi is not generated
+                if (resource.contains(OpenApiEndpoint.class.getSimpleName())) {
+                    continue;
+                }
+
+                DotName dotName = DotName.createSimple(resource.replaceAll("/", ".").substring(0, resource.length() - 6));
+                if (filteredIndexView.accepts(dotName)) {
+                    indexer.index(DeploymentProcessor.class.getClassLoader().getResourceAsStream(resource));
+                }
+            } catch (IOException e) {
+                // Ignore
+            }
+        }
+        return indexer.complete();
+    }
+
+    /**
+     * Creates the config from the microprofile-config.properties file in the application. The spec defines that the
+     * config file may be present in two locations.
+     */
+    private static OpenApiConfig config(final WebArchive war) {
+        Optional<Node> microprofileConfig = Stream.of(ofNullable(war.get("/META-INF/microprofile-config.properties")),
+                ofNullable(war.get("/WEB-INF/classes/META-INF/microprofile-config.properties")))
+                .filter(Optional::isPresent)
+                .findFirst()
+                .flatMap(node -> node);
+
+        if (!microprofileConfig.isPresent()) {
+            return new OpenApiConfigImpl(ConfigProvider.getConfig());
+        }
+
+        Properties properties = new Properties();
+        try (InputStreamReader reader = new InputStreamReader(microprofileConfig.get().getAsset().openStream(), UTF_8)) {
+            properties.load(reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultSources()
+                .addDefaultInterceptors()
+                .withSources(new PropertiesConfigSource(properties, "microprofile-config.properties"))
+                .build();
+
+        return new OpenApiConfigImpl(config);
+    }
+
+    private static Optional<OpenAPI> modelFromFile(final WebArchive war, final String location,
+            final Format format) {
+        return ofNullable(war.get(location))
+                .map(Node::getAsset)
+                .map(asset -> new OpenApiStaticFile(asset.openStream(), format))
+                .map(OpenApiProcessor::modelFromStaticFile);
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiApplication.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiApplication.java
@@ -1,0 +1,12 @@
+package io.smallrye.openapi.tck;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * RESTEasy Servlet initializer requires a REST Application to start. Some TCKs don't have an Application class, so we
+ * add one to make sure that RESTEasy is able to deploy the application.
+ */
+@ApplicationPath("/")
+public class OpenApiApplication extends Application {
+}

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiEndpoint.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiEndpoint.java
@@ -1,0 +1,52 @@
+package io.smallrye.openapi.tck;
+
+import static io.smallrye.openapi.runtime.io.Format.JSON;
+import static io.smallrye.openapi.runtime.io.Format.YAML;
+import static io.smallrye.openapi.runtime.io.OpenApiSerializer.serialize;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+import java.util.stream.Stream;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import io.smallrye.openapi.runtime.io.Format;
+
+@Path("/openapi")
+public class OpenApiEndpoint {
+    @Context
+    ServletContext servletContext;
+    @Context
+    HttpHeaders httpHeaders;
+
+    OpenAPI openAPI;
+
+    @PostConstruct
+    public void init() {
+        this.openAPI = (OpenAPI) servletContext.getAttribute("OpenAPI");
+    }
+
+    @GET
+    public Response openApi(@QueryParam("format") final String format) throws Exception {
+        final Format formatOpenApi = getOpenApiFormat(httpHeaders, format);
+        return Response.ok(serialize(openAPI, formatOpenApi).getBytes(UTF_8))
+                .type(formatOpenApi.getMimeType())
+                .build();
+    }
+
+    private Format getOpenApiFormat(final HttpHeaders httpHeaders, final String format) {
+        return Stream.of(Format.values())
+                .filter(f -> format != null && f.name().compareToIgnoreCase(format) == 0)
+                .findFirst()
+                .orElse(httpHeaders.getAcceptableMediaTypes().contains(APPLICATION_JSON_TYPE) ? JSON : YAML);
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiRegistration.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiRegistration.java
@@ -1,0 +1,88 @@
+package io.smallrye.openapi.tck;
+
+import static io.smallrye.openapi.runtime.io.Format.JSON;
+import static io.smallrye.openapi.runtime.io.Format.YAML;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConfigImpl;
+import io.smallrye.openapi.api.OpenApiDocument;
+import io.smallrye.openapi.runtime.OpenApiProcessor;
+import io.smallrye.openapi.runtime.OpenApiStaticFile;
+import io.smallrye.openapi.runtime.io.Format;
+
+/**
+ * Just a workaround to register the /openapi endpoint when an Application class is present in the TCK test. JAX-RS
+ * skips registration of scanned resources if the Application class lists the resouces (which happens in some TCKs).
+ *
+ * This also creates the OpenAPI object and sets it in the context to be used by the OpenApiEndpoint.
+ */
+@WebServlet(urlPatterns = "/init", loadOnStartup = 1000)
+public class OpenApiRegistration extends HttpServlet {
+    @SuppressWarnings("unchecked")
+    @Override
+    public void init(final ServletConfig config) throws ServletException {
+        super.init(config);
+        final Map<String, ResteasyDeployment> deployments = (Map<String, ResteasyDeployment>) config.getServletContext()
+                .getAttribute("resteasy.deployments");
+        final ResteasyDeployment deployment = deployments.get("/");
+        deployment.getRegistry().addPerRequestResource(OpenApiEndpoint.class);
+
+        openApi(config.getServletContext());
+    }
+
+    private void openApi(final ServletContext servletContext) {
+        try {
+            Optional<OpenAPI> staticOpenApi = Stream
+                    .of(readOpenApiFile(servletContext, "/META-INF/openapi.json", JSON),
+                            readOpenApiFile(servletContext, "/META-INF/openapi.yaml", YAML),
+                            readOpenApiFile(servletContext, "/META-INF/openapi.yml", YAML))
+                    .filter(Optional::isPresent)
+                    .findFirst()
+                    .flatMap(file -> file);
+
+            staticOpenApi.ifPresent(openAPI -> servletContext.setAttribute("OpenAPI", openAPI));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Optional<OpenAPI> readOpenApiFile(final ServletContext servletContext, final String location, final Format format)
+            throws Exception {
+
+        final URL resource = servletContext.getResource(location);
+        if (resource == null) {
+            return Optional.empty();
+        }
+
+        final OpenApiDocument document = OpenApiDocument.INSTANCE;
+        try (OpenApiStaticFile staticFile = new OpenApiStaticFile(resource.openStream(), format)) {
+            Config config = ConfigProvider.getConfig();
+            OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
+            document.reset();
+            document.config(openApiConfig);
+            document.filter(OpenApiProcessor.getFilter(openApiConfig, Thread.currentThread().getContextClassLoader()));
+            document.modelFromStaticFile(io.smallrye.openapi.runtime.OpenApiProcessor.modelFromStaticFile(staticFile));
+            document.initialize();
+            return Optional.of(document.get());
+        } finally {
+            document.reset();
+        }
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/TestApplication.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/TestApplication.java
@@ -1,0 +1,81 @@
+package io.smallrye.openapi.tck;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestApplication extends Arquillian {
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap
+                .create(WebArchive.class)
+                .addClass(TestEndpoint.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"));
+    }
+
+    @Test
+    @RunAsClient
+    public void rest() {
+        String uri = baseURL.toExternalForm();
+        System.out.println("uri = " + uri);
+        WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri);
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+    }
+
+    @Test
+    @RunAsClient
+    public void openApi() {
+        String uri = baseURL.toExternalForm() + "openapi";
+        System.out.println("uri = " + uri);
+        WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri);
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+    }
+
+    @RequestScoped
+    @Path("/")
+    public static class TestEndpoint {
+        @Inject
+        HelloBean helloBean;
+
+        @GET
+        public String hello() {
+            return helloBean.hello();
+        }
+    }
+
+    @ApplicationScoped
+    public static class HelloBean {
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/testsuite/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testsuite/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+io.smallrye.openapi.tck.ArquillianExtension

--- a/testsuite/tck/src/test/resources/arquillian.xml
+++ b/testsuite/tck/src/test/resources/arquillian.xml
@@ -1,0 +1,16 @@
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+  <container qualifier="jetty" default="true">
+    <configuration>
+      <property name="bindHttpPort">8080</property>
+      <!--
+      <property name="javaVmArguments">
+        -Xmx512m -XX:MaxPermSize=128m -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
+      </property>
+      -->
+    </configuration>
+  </container>
+</arquillian>


### PR DESCRIPTION
This is for us to have a more consistent environment to run the TCK for MP compliance.

The old TCK runner is still around. We can either remove it or keep it.