### PR TITLE
Re-factor exception mapper scanning to avoid NPE when missing toResponse (2.0.x)

### DIFF
--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
@@ -30,13 +30,13 @@ public class ExceptionMapperScanTests extends IndexScannerTestBase {
     @Test
     public void testExceptionMapper() throws IOException, JSONException {
         test("responses.exception-mapper-generation.json", TestResource.class, ExceptionHandler1.class,
-                ExceptionHandler2.class);
+                ExceptionHandler2.class, ResteasyReactiveExceptionMapper.class);
     }
 
     @Test
     public void testMethodAnnotationOverrideExceptionMapper() throws IOException, JSONException {
         test("responses.exception-mapper-overridden-by-method-annotation-generation.json", TestResource2.class,
-                ExceptionHandler1.class, ExceptionHandler2.class);
+                ExceptionHandler1.class, ExceptionHandler2.class, ResteasyReactiveExceptionMapper.class);
     }
 
     @Path("/resources")
@@ -88,6 +88,11 @@ public class ExceptionMapperScanTests extends IndexScannerTestBase {
         public Response toResponse(NotFoundException e) {
             return null;
         }
+    }
+
+    // Mimic org.jboss.resteasy.reactive.server.spi.ResteasyReactiveExceptionMapper
+    interface ResteasyReactiveExceptionMapper<E extends Throwable> extends ExceptionMapper<E> {
+        Response toResponse(E exception, Object context);
     }
 
 }


### PR DESCRIPTION
Fixes #601
