### PR TITLE
Support XmlElement

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -196,9 +196,9 @@ public class AnnotationTargetProcessor implements RequirementHandler {
     }
 
     private void processFieldAnnotations(Schema fieldSchema, TypeResolver typeResolver) {
+        String name = typeResolver.getBeanPropertyName();
         FieldInfo field = typeResolver.getField();
         if (field != null) {
-            String name = field.name();
             if (processXmlAttr(name,
                     fieldSchema,
                     field.annotation(XML_ATTRIBUTE),
@@ -209,7 +209,6 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         }
         MethodInfo readMethod = typeResolver.getReadMethod();
         if (readMethod != null) {
-            String name = removePrefix(readMethod.name(), "get");
             if (processXmlAttr(name,
                     fieldSchema,
                     readMethod.annotation(XML_ATTRIBUTE),
@@ -220,7 +219,6 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         }
         MethodInfo writeMethod = typeResolver.getWriteMethod();
         if (writeMethod != null) {
-            String name = removePrefix(writeMethod.name(), "set");
             if (processXmlAttr(name,
                     fieldSchema,
                     writeMethod.annotation(XML_ATTRIBUTE),
@@ -277,15 +275,6 @@ public class AnnotationTargetProcessor implements RequirementHandler {
                 fieldSchema.getXml().name(annName);
             }
         }
-    }
-
-    private String removePrefix(String name, String prefix) {
-        if (!name.startsWith(prefix)) {
-            return name;
-        }
-        name = name.substring(prefix.length());
-        name = name.substring(0, 1).toLowerCase() + name.substring(1);
-        return name;
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -95,7 +95,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
     /**
      * This method will generate a schema for the {@link #annotationTarget} containing one
      * of the following :
-     * 
+     *
      * <ol>
      * <li>A schema composed (using {@link Schema#allOf(List) allOf}) of a <code>$ref</code> to the schema of the
      * {@link #entityType}
@@ -112,7 +112,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
      * {@link SchemaRegistry#registerReference(Type, TypeResolver, Schema) checkRegistration}.
      * </li>
      * </ol>
-     * 
+     *
      * @return the individual or composite schema for the annotationTarget used to create this {@link AnnotationTargetProcessor}
      */
     Schema processField() {
@@ -197,44 +197,95 @@ public class AnnotationTargetProcessor implements RequirementHandler {
 
     private void processFieldAnnotations(Schema fieldSchema, TypeResolver typeResolver) {
         FieldInfo field = typeResolver.getField();
-        if (field != null && processXmlAttr(fieldSchema, field.annotation(XML_ATTRIBUTE),
-                field.annotation(XML_WRAPPERELEMENT))) {
-            return;
+        if (field != null) {
+            String name = field.name();
+            if (processXmlAttr(name,
+                    fieldSchema,
+                    field.annotation(XML_ATTRIBUTE),
+                    field.annotation(XML_ELEMENT),
+                    field.annotation(XML_WRAPPERELEMENT))) {
+                return;
+            }
         }
         MethodInfo readMethod = typeResolver.getReadMethod();
-        if (readMethod != null && processXmlAttr(fieldSchema, readMethod.annotation(XML_ATTRIBUTE),
-                readMethod.annotation(XML_WRAPPERELEMENT))) {
-            return;
+        if (readMethod != null) {
+            String name = removePrefix(readMethod.name(), "get");
+            if (processXmlAttr(name,
+                    fieldSchema,
+                    readMethod.annotation(XML_ATTRIBUTE),
+                    readMethod.annotation(XML_ELEMENT),
+                    readMethod.annotation(XML_WRAPPERELEMENT))) {
+                return;
+            }
         }
         MethodInfo writeMethod = typeResolver.getWriteMethod();
-        if (writeMethod != null && processXmlAttr(fieldSchema, writeMethod.annotation(XML_ATTRIBUTE),
-                writeMethod.annotation(XML_WRAPPERELEMENT))) {
-            return;
+        if (writeMethod != null) {
+            String name = removePrefix(writeMethod.name(), "set");
+            if (processXmlAttr(name,
+                    fieldSchema,
+                    writeMethod.annotation(XML_ATTRIBUTE),
+                    writeMethod.annotation(XML_ELEMENT),
+                    writeMethod.annotation(XML_WRAPPERELEMENT))) {
+                return;
+            }
         }
     }
 
-    private boolean processXmlAttr(Schema fieldSchema, AnnotationInstance xmlAttr, AnnotationInstance xmlWrapper) {
-        if (xmlAttr == null && xmlWrapper == null) {
+    private boolean processXmlAttr(
+            String name,
+            Schema fieldSchema,
+            AnnotationInstance xmlAttr,
+            AnnotationInstance xmlElement,
+            AnnotationInstance xmlWrapper) {
+        if (xmlAttr == null && xmlWrapper == null && xmlElement == null) {
             return false;
         }
 
-        fieldSchema.setXml(new XMLImpl());
         if (xmlAttr != null) {
+            setXmlIfEmpty(fieldSchema);
             fieldSchema.getXml().attribute(true);
-            setXmlName(fieldSchema, xmlAttr);
+            setXmlName(fieldSchema, name, xmlAttr);
         }
         if (xmlWrapper != null) {
+            setXmlIfEmpty(fieldSchema);
             fieldSchema.getXml().wrapped(true);
-            setXmlName(fieldSchema, xmlWrapper);
+            setXmlName(fieldSchema, name, xmlWrapper);
+            if (xmlElement != null) {
+                setXmlName(fieldSchema.getItems(), name, xmlElement);
+                return true;
+            }
+        }
+        if (xmlElement != null) {
+            setXmlName(fieldSchema, name, xmlElement);
         }
         return true;
     }
 
-    private void setXmlName(Schema fieldSchema, AnnotationInstance xmlAttr) {
+    private void setXmlIfEmpty(Schema schema) {
+        if (schema.getXml() != null) {
+            return;
+        }
+        schema.setXml(new XMLImpl());
+    }
+
+    private void setXmlName(Schema fieldSchema, String realName, AnnotationInstance xmlAttr) {
         AnnotationValue name = xmlAttr.value(PROP_NAME);
         if (name != null) {
-            fieldSchema.getXml().name(name.asString());
+            String annName = name.asString();
+            if (!annName.equals(realName)) {
+                setXmlIfEmpty(fieldSchema);
+                fieldSchema.getXml().name(annName);
+            }
         }
+    }
+
+    private String removePrefix(String name, String prefix) {
+        if (!name.startsWith(prefix)) {
+            return name;
+        }
+        name = name.substring(prefix.length());
+        name = name.substring(0, 1).toLowerCase() + name.substring(1);
+        return name;
     }
 
     /**
@@ -275,7 +326,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
     /**
      * Determine if the fieldSchema defines any attributes that are not present or
      * different from the attributes in the typeSchema.
-     * 
+     *
      * @param fieldSchema
      * @param typeSchema
      * @return true if fieldSchema defines new attributes or different attributes from typeSchema, otherwise false
@@ -302,7 +353,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
     /**
      * Get accessors/suppliers for all schema attributes that are relevant to comparing two
      * schemas.
-     * 
+     *
      * @param schema the schema
      * @return a list of suppliers (i.e. getters) for the schema's attributes
      */

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -207,6 +207,10 @@ public class TypeResolver {
         return this.propertyName;
     }
 
+    public String getBeanPropertyName() {
+        return this.propertyName;
+    }
+
     /**
      * Retrieves the field associated with this property. May be null.
      *

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -204,18 +204,6 @@ public class TypeResolver {
             return name;
         }
 
-        if ((name = TypeUtil.getAnnotationValue(target,
-                JaxbConstants.XML_ELEMENT,
-                JaxbConstants.PROP_NAME)) != null) {
-            return name;
-        }
-
-        if ((name = TypeUtil.getAnnotationValue(target,
-                JaxbConstants.XML_ATTRIBUTE,
-                JaxbConstants.PROP_NAME)) != null) {
-            return name;
-        }
-
         return this.propertyName;
     }
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -184,10 +184,10 @@ public class TypeResolverTests extends IndexScannerTestBase {
                 null);
         assertEquals(4, properties.size());
         Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
-        assertEquals("theName", iter.next().getValue().getPropertyName());
-        assertEquals("comment2ActuallyFirst", iter.next().getValue().getPropertyName());
         assertEquals("comment", iter.next().getValue().getPropertyName());
         assertEquals("name2", iter.next().getValue().getPropertyName());
+        assertEquals("comment2", iter.next().getValue().getPropertyName());
+        assertEquals("name", iter.next().getValue().getPropertyName());
     }
 
     @Test

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JaxbWithNameGreeting.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/JaxbWithNameGreeting.java
@@ -3,6 +3,7 @@ package test.io.smallrye.openapi.runtime.scanner.entities;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -12,8 +13,9 @@ public class JaxbWithNameGreeting {
     @XmlAttribute
     private final String message;
 
-    public JaxbWithNameGreeting(String message, List<String> items) {
+    public JaxbWithNameGreeting(String message, String title, List<String> items) {
         this.message = message;
+        this.title = title;
         this.books = items;
     }
 
@@ -22,10 +24,17 @@ public class JaxbWithNameGreeting {
     }
 
     @XmlElementWrapper(name = "books-array")
+    @XmlElement(name = "item")
     private final List<String> books;
 
     public List<String> getBooks() {
         return books;
     }
 
+    @XmlElement(name = "xml-title")
+    private String title;
+
+    public String getTitle() {
+        return title;
+    }
 }

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/JaxbGreetingGetResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/JaxbGreetingGetResource.java
@@ -33,7 +33,7 @@ public class JaxbGreetingGetResource {
     @GET
     @Path("/helloPathVariable3/{name}")
     public JaxbWithNameGreeting helloPathVariable3(@PathParam("name") String name) {
-        return new JaxbWithNameGreeting("Hello " + name, null);
+        return new JaxbWithNameGreeting("Hello " + name, "Title!", null);
     }
 
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testBasicJaxbJaxRsGetDefinitionScanning.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testBasicJaxbJaxRsGetDefinitionScanning.json
@@ -98,7 +98,10 @@
           "books" : {
             "type" : "array",
             "items" : {
-              "type" : "string"
+              "type" : "string",
+              "xml": {
+                "name": "item"
+              }
             },
             "xml": {
               "wrapped": true,
@@ -109,6 +112,12 @@
             "type" : "string",
             "xml" : {
               "attribute" : true
+            }
+          },
+          "title" : {
+            "type" : "string",
+            "xml": {
+              "name": "xml-title"
             }
           }
         },


### PR DESCRIPTION
Added support XmlElement

for field
```
    book:
      type: object
      properties:
        id:
          type: integer
        title:
          type: string
          xml:                <--
            name: 'xml-title' <--
        author: 
          type: string
```

for wrapped element
```
books:
  type: array
  items: 
    type: string 
    xml:           <--
      name: 'item' <--
  xml:
    wrapped : true
    name: books-array
```

https://swagger.io/docs/specification/data-models/representing-xml/