### PR TITLE
RestEasy Reactive support - new annotations and derived path params

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/ResourceParameters.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/ResourceParameters.java
@@ -3,6 +3,8 @@ package io.smallrye.openapi.runtime.scanner;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.openapi.models.media.Content;
 import org.eclipse.microprofile.openapi.models.media.Schema;
@@ -24,6 +26,8 @@ public class ResourceParameters {
 
     private static final Comparator<Parameter> PARAMETER_COMPARATOR = Comparator.comparing(Parameter::getIn)
             .thenComparing(Parameter::getName);
+
+    static final Pattern TEMPLATE_PARAM_PATTERN = Pattern.compile("\\{(\\w[\\w\\.-]*)\\}");
 
     private String pathItemPath;
     private List<Parameter> pathItemParameters;
@@ -47,6 +51,14 @@ public class ResourceParameters {
 
     public List<Parameter> getOperationParameters() {
         return operationParameters;
+    }
+
+    public void addOperationParameter(Parameter parameter) {
+        if (this.operationParameters == null) {
+            this.operationParameters = new ArrayList<>();
+        }
+
+        this.operationParameters.add(parameter);
     }
 
     public Content getFormBodyContent() {
@@ -101,5 +113,23 @@ public class ResourceParameters {
         if (operationParameters != null) {
             operationParameters.sort(PARAMETER_COMPARATOR);
         }
+    }
+
+    public List<String> getPathParameterTemplateNames() {
+        return getPathParameterTemplateName(this.pathItemPath, this.operationPath);
+    }
+
+    private static List<String> getPathParameterTemplateName(String... paths) {
+        List<String> templateNames = new ArrayList<>();
+
+        for (String path : paths) {
+            Matcher m = TEMPLATE_PARAM_PATTERN.matcher(path);
+
+            while (m.find()) {
+                templateNames.add(m.group(1));
+            }
+        }
+
+        return templateNames;
     }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -118,14 +118,26 @@ public abstract class AbstractParameterProcessor {
      * @author Michael Edgar {@literal <michael@xlate.io>}
      */
     protected static class ParameterContext {
-        public String name;
-        public In location;
-        public Style style;
-        public Parameter oaiParam;
-        public FrameworkParameter frameworkParam;
-        public Object defaultValue;
-        public AnnotationTarget target;
-        public Type targetType;
+        protected String name;
+        protected In location;
+        protected Style style;
+        protected Parameter oaiParam;
+        protected FrameworkParameter frameworkParam;
+        protected Object defaultValue;
+        protected AnnotationTarget target;
+        protected Type targetType;
+
+        ParameterContext() {
+        }
+
+        public ParameterContext(String name, FrameworkParameter frameworkParam, AnnotationTarget target, Type targetType) {
+            this.name = name;
+            this.location = frameworkParam.location;
+            this.style = frameworkParam.style;
+            this.frameworkParam = frameworkParam;
+            this.target = target;
+            this.targetType = targetType;
+        }
 
         @Override
         public String toString() {
@@ -196,10 +208,7 @@ public abstract class AbstractParameterProcessor {
         matrixParams.clear();
     }
 
-    protected ResourceParameters process(ClassInfo resourceClass,
-            MethodInfo resourceMethod,
-            Function<AnnotationInstance, Parameter> reader) {
-
+    protected ResourceParameters process(ClassInfo resourceClass, MethodInfo resourceMethod) {
         ResourceParameters parameters = new ResourceParameters();
 
         processPathParameters(resourceClass, resourceMethod, parameters);
@@ -247,6 +256,14 @@ public abstract class AbstractParameterProcessor {
         parameters.setPathItemPath(generatePath(resourceClass, allParameters));
         parameters.setOperationPath(generatePath(resourceMethod, allParameters));
 
+        parameters.getPathParameterTemplateNames()
+                .stream()
+                .filter(pip -> allParameters.stream().noneMatch(ap -> this.samePathParameter(ap, pip)))
+                .map(pip -> getUnannotatedPathParameter(resourceMethod, pip))
+                .filter(Objects::nonNull)
+                .map(pip -> this.mapParameter(resourceMethod, pip))
+                .forEach(parameters::addOperationParameter);
+
         // Re-sort (names of matrix parameters may have changed)
         parameters.sort();
 
@@ -280,7 +297,7 @@ public abstract class AbstractParameterProcessor {
             String variablePattern = templateMatcher.group(2).trim();
 
             parameters.stream()
-                    .filter(p -> variableName.equals(p.getName()))
+                    .filter(p -> samePathParameter(p, variableName))
                     .filter(this::templateParameterPatternEligible)
                     .forEach(p -> p.getSchema().setPattern(variablePattern));
 
@@ -323,6 +340,12 @@ public abstract class AbstractParameterProcessor {
     }
 
     protected abstract Pattern getTemplateParameterPattern();
+
+    boolean samePathParameter(Parameter param, String name) {
+        return name.equals(param.getName())
+                && Parameter.In.PATH.equals(param.getIn())
+                && !Style.MATRIX.equals(param.getStyle());
+    }
 
     /**
      * Determines if the parameter is eligible to have a pattern constraint
@@ -411,6 +434,16 @@ public abstract class AbstractParameterProcessor {
     }
 
     protected abstract FrameworkParameter getMatrixParameter();
+
+    /**
+     * 
+     * @param resourceMethod method potentially containing an un-annotated path parameter argument
+     * @param name name of the path parameter without any associated annotations
+     * @return a new ParameterContext if the parameter is found, otherwise null
+     */
+    protected ParameterContext getUnannotatedPathParameter(MethodInfo resourceMethod, String name) {
+        return null;
+    }
 
     private Parameter mapParameter(MethodInfo resourceMethod, ParameterContext context) {
         Parameter param;
@@ -513,13 +546,7 @@ public abstract class AbstractParameterProcessor {
             BeanValidationScanner.applyConstraints(paramTarget,
                     paramSchema,
                     paramName,
-                    (target, name) -> {
-                        List<String> requiredProperties = schema.getRequired();
-
-                        if (requiredProperties == null || !requiredProperties.contains(name)) {
-                            schema.addRequired(name);
-                        }
-                    });
+                    (target, name) -> setRequired(name, schema));
 
             if (paramSchema.getNullable() == null && TypeUtil.isOptional(paramType)) {
                 paramSchema.setNullable(Boolean.TRUE);
@@ -530,6 +557,21 @@ public abstract class AbstractParameterProcessor {
             }
 
             schema.addProperty(paramName, paramSchema);
+        }
+    }
+
+    /**
+     * Called by the BeanValidationScanner when a member is found to have a BV annotation
+     * indicating the parameter is required.
+     * 
+     * @param name name of the schema property
+     * @param schema schema holding the property
+     */
+    private void setRequired(String name, Schema schema) {
+        List<String> requiredProperties = schema.getRequired();
+
+        if (requiredProperties == null || !requiredProperties.contains(name)) {
+            schema.addRequired(name);
         }
     }
 

--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -28,7 +28,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
         <!-- SmallRye core implementation -->
         <dependency>
@@ -85,6 +85,12 @@
           <groupId>org.jboss.resteasy</groupId>
           <artifactId>resteasy-multipart-provider</artifactId>
           <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive-common</artifactId>
+            <version>${version.quarkus}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -99,6 +99,21 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
     @Override
     public boolean containsScannerAnnotations(List<AnnotationInstance> instances,
             List<AnnotationScannerExtension> extensions) {
+
+        if (containsJaxRsAnnotations(instances)) {
+            return true;
+        }
+
+        for (AnnotationInstance instance : instances) {
+            for (AnnotationScannerExtension extension : extensions) {
+                if (extension.isScannerAnnotationExtension(instance))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean containsJaxRsAnnotations(List<AnnotationInstance> instances) {
         for (AnnotationInstance instance : instances) {
             if (JaxRsParameter.isParameter(instance.name())) {
                 return true;
@@ -106,11 +121,8 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             if (instance.name().toString().startsWith(JAXRS_PACKAGE)) {
                 return true;
             }
-            for (AnnotationScannerExtension extension : extensions) {
-                if (extension.isScannerAnnotationExtension(instance))
-                    return true;
-            }
         }
+
         return false;
     }
 

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameter.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameter.java
@@ -29,7 +29,17 @@ public enum JaxRsParameter {
     RESTEASY_FORM_PARAM(RestEasyConstants.FORM_PARAM, null, Parameter.Style.FORM, Parameter.Style.FORM),
     RESTEASY_HEADER_PARAM(RestEasyConstants.HEADER_PARAM, Parameter.In.HEADER, null, Parameter.Style.SIMPLE),
     RESTEASY_COOKIE_PARAM(RestEasyConstants.COOKIE_PARAM, Parameter.In.COOKIE, null, Parameter.Style.FORM),
-    RESTEASY_MULITIPART_FORM(RestEasyConstants.MULTIPART_FORM, null, null, null, "multipart/form-data");
+    RESTEASY_MULITIPART_FORM(RestEasyConstants.MULTIPART_FORM, null, null, null, "multipart/form-data"),
+
+    // Support RESTEasy Reactive annotations directly
+    RESTEASY_REACTIVE_PATH_PARAM(RestEasyConstants.REACTIVE_REST_PATH, Parameter.In.PATH, null, Parameter.Style.SIMPLE),
+    // Apply to the last-matched @Path of the structure injecting the Matrix Param
+    RESTEASY_REACTIVE_MATRIX_PARAM(RestEasyConstants.REACTIVE_REST_MATRIX, Parameter.In.PATH, Parameter.Style.MATRIX,
+            Parameter.Style.MATRIX),
+    RESTEASY_REACTIVE_QUERY_PARAM(RestEasyConstants.REACTIVE_REST_QUERY, Parameter.In.QUERY, null, Parameter.Style.FORM),
+    RESTEASY_REACTIVE_FORM_PARAM(RestEasyConstants.REACTIVE_REST_FORM, null, Parameter.Style.FORM, Parameter.Style.FORM),
+    RESTEASY_REACTIVE_HEADER_PARAM(RestEasyConstants.REACTIVE_REST_HEADER, Parameter.In.HEADER, null, Parameter.Style.SIMPLE),
+    RESTEASY_REACTIVE_COOKIE_PARAM(RestEasyConstants.REACTIVE_REST_COOKIE, Parameter.In.COOKIE, null, Parameter.Style.FORM);
 
     final FrameworkParameter parameter;
 
@@ -54,4 +64,5 @@ public enum JaxRsParameter {
     public static boolean isParameter(DotName annotationName) {
         return forName(annotationName) != null;
     }
+
 }

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/RestEasyConstants.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/RestEasyConstants.java
@@ -29,6 +29,20 @@ public class RestEasyConstants {
     public static final DotName MATRIX_PARAM = DotName
             .createSimple("org.jboss.resteasy.annotations.jaxrs.MatrixParam");
 
+    // RestEasy reactive parameter extension annotations
+    public static final DotName REACTIVE_REST_QUERY = DotName
+            .createSimple("org.jboss.resteasy.reactive.RestQuery");
+    public static final DotName REACTIVE_REST_FORM = DotName
+            .createSimple("org.jboss.resteasy.reactive.RestForm");
+    public static final DotName REACTIVE_REST_COOKIE = DotName
+            .createSimple("org.jboss.resteasy.reactive.RestCookie");
+    public static final DotName REACTIVE_REST_PATH = DotName
+            .createSimple("org.jboss.resteasy.reactive.RestPath");
+    public static final DotName REACTIVE_REST_HEADER = DotName
+            .createSimple("org.jboss.resteasy.reactive.RestHeader");
+    public static final DotName REACTIVE_REST_MATRIX = DotName
+            .createSimple("org.jboss.resteasy.reactive.RestMatrix");
+
     // RestEasy multi-part form annotations
     public static final DotName MULTIPART_FORM = DotName
             .createSimple("org.jboss.resteasy.annotations.providers.multipart.MultipartForm");

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-reactive-missing-restpath.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-reactive-missing-restpath.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/path/{param1}/params/{param2}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "param1",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "minimum": 100,
+              "type": "integer"
+            }
+          },
+          {
+            "name": "param2",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Widget"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/path/{param1}/params/{param3}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "param3",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-custom-info": "value for param3"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Widget"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Widget": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringParameterProcessor.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringParameterProcessor.java
@@ -71,7 +71,7 @@ public class SpringParameterProcessor extends AbstractParameterProcessor {
             List<AnnotationScannerExtension> extensions) {
 
         SpringParameterProcessor processor = new SpringParameterProcessor(context, reader, extensions);
-        return processor.process(resourceClass, resourceMethod, reader);
+        return processor.process(resourceClass, resourceMethod);
     }
 
     @Override

--- a/extension-vertx/pom.xml
+++ b/extension-vertx/pom.xml
@@ -12,11 +12,6 @@
 
     <name>SmallRye: OpenAPI extension - Vert.x</name>
 
-    <properties>
-        <version.vertx>3.9.2</version.vertx>
-        <version.quarkus>1.11.0.Final</version.quarkus>
-    </properties>
-
     <dependencies>
         <!-- SmallRye core implementation -->
         <dependency>

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxParameterProcessor.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxParameterProcessor.java
@@ -72,7 +72,7 @@ public class VertxParameterProcessor extends AbstractParameterProcessor {
             List<AnnotationScannerExtension> extensions) {
 
         VertxParameterProcessor processor = new VertxParameterProcessor(context, reader, extensions);
-        return processor.process(resourceClass, resourceMethod, reader);
+        return processor.process(resourceClass, resourceMethod);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <version.arquillian.jetty>1.0.0.CR3</version.arquillian.jetty>
         <version.jetty>9.3.29.v20201019</version.jetty>
         <version.resteasy>4.6.0.Final</version.resteasy>
+        <version.quarkus>1.11.0.Final</version.quarkus>
 
         <!--
             xmlReportPaths must contain an entry for each project that reports coverage.


### PR DESCRIPTION
Fixes #576

Note: un-annotated path params will work for any JAX-RS annotation set (since we can't tell which annotation was meant to be omitted).