### PR TITLE
Remove 204 response code default for DELETE method

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -438,8 +438,6 @@ public interface AnnotationScanner {
         if (isVoidResponse(method)) {
             if (isPostMethod(method)) {
                 status = 201; // Created
-            } else if (isDeleteMethod(method)) {
-                status = 204; // No Content (Maybe this should be 202 Accepted ?)
             } else if (!isAsyncResponse(method)) {
                 status = 204; // No Content
             } else {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
@@ -197,17 +197,27 @@ public class ApiResponseTests extends IndexScannerTestBase {
         }
     }
 
-    @Path("pets")
+    @Path("pets/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     static class VoidAsyncResponseGenerationTestResource {
         @SuppressWarnings("unused")
-        @Path("{id}")
         @GET
-        @Consumes(MediaType.APPLICATION_JSON)
-        @Produces(MediaType.APPLICATION_JSON)
         @APIResponse(responseCode = "200")
         @APIResponse(responseCode = "400", description = "Description 400")
         @APIResponseSchema(value = ServerError.class, responseDescription = "Server Error: 500", responseCode = "500")
         public void getPet(@PathParam("id") String id, @Suspended AsyncResponse response) {
+        }
+
+        @SuppressWarnings("unused")
+        @DELETE
+        public void deletePet(@PathParam("id") String id) {
+        }
+
+        @SuppressWarnings("unused")
+        @DELETE
+        @Path("async")
+        public void deletePetAsync(@PathParam("id") String id, @Suspended AsyncResponse response) {
         }
     }
 

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.void-async-response-generation.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.void-async-response-generation.json
@@ -31,6 +31,42 @@
             }
           }
         }
+      },
+      "delete": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/pets/{id}/async": {
+      "delete": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
Fixes #642 

@phillip-kruger - I think the logic for DELETE was added with the Spring changes, but since there is no `AsyncResponse` for Spring, it doesn't appear necessary. Please have a look and let me know if you disagree and we can adjust this.