### PR TITLE
mp.openapi.schema.* Config Property Negative Test Coverage

### DIFF
--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigExtensionsTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigExtensionsTest.java
@@ -16,11 +16,12 @@ import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
 import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource;
 
 /**
- * Basic tests to check the setting of certain Info elements via config
+ * Basic tests to check the setting of certain Info elements via config, using
+ * extensions config properties
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class ConfigTest extends JaxRsDataObjectScannerTestBase {
+public class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
 
     private static final String TITLE = "mp.openapi.extensions.smallrye.info.title";
     private static final String VERSION = "mp.openapi.extensions.smallrye.info.version";

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigSchemaTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigSchemaTest.java
@@ -1,0 +1,118 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import java.io.IOException;
+
+import javax.json.Json;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.json.JSONException;
+import org.junit.Test;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConfigImpl;
+import io.smallrye.openapi.runtime.OpenApiProcessor;
+import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource;
+
+/**
+ * Basic tests to check the setting of schemas via the mp.openapi.schema.* config property
+ * 
+ * @author Scott Curtis (@literal <Scott.Curtis@ibm.com>)
+ */
+public class ConfigSchemaTest extends JaxRsDataObjectScannerTestBase {
+
+    private static final String VALID_SCHEMA_PROPERTY_KEY = "mp.openapi.schema.java.lang.String";
+    private static final String INVALID_SCHEMA_PROPERTY_KEY = "mp.openapi.schema.java.lang.NonExistentClass";
+
+    private static final String VALID_PROPERTY_VALUE = Json.createObjectBuilder()
+            .add("name", "message")
+            .add("type", "string")
+            .add("description", "Mock custom String class defined with config")
+            .build()
+            .toString();
+
+    private static final String INVALID_PROPERTY_VALUE_SCHEMA = Json.createObjectBuilder()
+            .add("name", "message")
+            .add("type", "string")
+            .add("malformed-property", "This should not appear in output document")
+            .build()
+            .toString();
+
+    private static final String INVALID_PROPERTY_VALUE_JSON = "{\"name\": \"message\","
+            + "  \"type\": \"string\","
+            + "  \"description\": \"Invali\"{d\"}";
+
+    @Test
+    public void testValidSchemaDefinitionViaConfig() throws IOException, JSONException {
+        System.setProperty(VALID_SCHEMA_PROPERTY_KEY, VALID_PROPERTY_VALUE);
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        try {
+            Index i = indexOf(GreetingGetResource.class, Greeting.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
+
+            printToConsole(result);
+            assertJsonEquals("resource.testValidSchemaDefinitionViaConfig.json", result);
+
+        } finally {
+            System.clearProperty(VALID_SCHEMA_PROPERTY_KEY);
+        }
+    }
+
+    // If the class in the key is non existent, schema is only rendered in components block
+    @Test
+    public void testInvalidSchemaKeyDefinitionViaConfig() throws IOException, JSONException {
+        System.setProperty(INVALID_SCHEMA_PROPERTY_KEY, VALID_PROPERTY_VALUE);
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        try {
+            Index i = indexOf(GreetingGetResource.class, Greeting.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
+
+            printToConsole(result);
+            assertJsonEquals("resource.testInvalidSchemaKeyDefinitionViaConfig.json", result);
+
+        } finally {
+            System.clearProperty(INVALID_SCHEMA_PROPERTY_KEY);
+        }
+    }
+
+    // Technically correct behaviour as malformed-property is not rendered in schema, but no feedback
+    @Test
+    public void testValidSchemaKeyWithInvalidSchemaPropertyValueViaConfig() throws IOException, JSONException {
+        System.setProperty(VALID_SCHEMA_PROPERTY_KEY, INVALID_PROPERTY_VALUE_SCHEMA);
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        try {
+            Index i = indexOf(GreetingGetResource.class, Greeting.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
+
+            printToConsole(result);
+            assertJsonEquals("resource.testValidSchemaKeyWithInvalidSchemaPropertyValueViaConfig.json", result);
+
+        } finally {
+            System.clearProperty(VALID_SCHEMA_PROPERTY_KEY);
+        }
+    }
+
+    // Technically correct behaviour as malformed schema is not rendered, but no feedback
+    @Test
+    public void testValidSchemaKeyWithInvalidSchemaJSONValueViaConfig() throws IOException, JSONException {
+        System.setProperty(VALID_SCHEMA_PROPERTY_KEY, INVALID_PROPERTY_VALUE_JSON);
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        try {
+            Index i = indexOf(GreetingGetResource.class, Greeting.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
+
+            printToConsole(result);
+            assertJsonEquals("resource.testValidSchemaKeyWithInvalidSchemaJSONValueViaConfig.json", result);
+
+        } finally {
+            System.clearProperty(VALID_SCHEMA_PROPERTY_KEY);
+        }
+    }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testInvalidSchemaKeyDefinitionViaConfig.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testInvalidSchemaKeyDefinitionViaConfig.json
@@ -1,0 +1,171 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  },
+  "paths" : {
+    "/greeting/helloOptional/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponse/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloRequestParam" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/hellosPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Greeting"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "message" : {
+        "type" : "string",
+        "description" : "Mock custom String class defined with config"
+      },
+     "Greeting" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testValidSchemaDefinitionViaConfig.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testValidSchemaDefinitionViaConfig.json
@@ -1,0 +1,171 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  },
+  "paths" : {
+    "/greeting/helloOptional/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponse/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloRequestParam" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/hellosPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Greeting"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "message" : {
+        "type" : "string",
+        "description" : "Mock custom String class defined with config"
+      },
+     "Greeting" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testValidSchemaKeyWithInvalidSchemaJSONValueViaConfig.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testValidSchemaKeyWithInvalidSchemaJSONValueViaConfig.json
@@ -1,0 +1,167 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  },
+  "paths" : {
+    "/greeting/helloOptional/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponse/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloRequestParam" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/hellosPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Greeting"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+     "Greeting" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testValidSchemaKeyWithInvalidSchemaPropertyValueViaConfig.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testValidSchemaKeyWithInvalidSchemaPropertyValueViaConfig.json
@@ -1,0 +1,170 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  },
+  "paths" : {
+    "/greeting/helloOptional/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponse/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloPathVariableWithResponseTyped/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/helloRequestParam" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/greeting/hellosPathVariable/{name}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Greeting"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "message" : {
+        "type" : "string"
+      },
+     "Greeting" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "$ref" : "#/components/schemas/message"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implements the negative tests specified for `mp.openapi.schema.* ` in relation to issue #621. These investigate the behaviour specified within @Azquelt's comment:

- Test the output for utilising a key defined for a class which does not exist.
- Test config property values which are not valid JSON.
- Test config property values which are valid JSON, but are malformed properties on the schema.

I have currently left comments in on some of these tests which I will remove before merging (assuming all else is good!). These are in place to check that the output produced by these tests is what should be expected in negative scenarios, regarding feedback to the developer in these scenarios. This is especially the case in the test for malformed property names - I have left a [comment](https://github.com/smallrye/smallrye-open-api/issues/621#issuecomment-768493657) in #621 regarding this.

Other changes which were made:
- Renamed `ConfigTest` to `ConfigExtensionsTest`. I believed it would be better to keep tests referring to `mp.openapi.extensions.*` separate from those for `mp.openapi.schema.* `. 

The reasoning for this change was for future-proofing purposes. This avoids this class growing too large (covering all config properties) at a later point in time, adding some separation and further maintainability to the code base if more Config tests are to be implemented. Perhaps `ConfigTest` could be introduced as a test suite to encapsulate all `Config*Test` classes at a later point in time.
