### PR TITLE
Preserve schema model's type when value from annotation is null

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -176,10 +176,8 @@ public class SchemaFactory {
         AnnotationInstance externalDocsAnnotation = JandexUtil.value(annotation, ExternalDocsConstant.PROP_EXTERNAL_DOCS);
         schema.setExternalDocs(ExternalDocsReader.readExternalDocs(context, externalDocsAnnotation));
         schema.setDeprecated(readAttr(annotation, SchemaConstant.PROP_DEPRECATED, defaults));
-        final SchemaType schemaType = SchemaFactory.<String, SchemaType> readAttr(annotation, SchemaConstant.PROP_TYPE,
-                value -> JandexUtil.enumValue(value, SchemaType.class), defaults);
-        schema.setType(schemaType);
-        schema.setExample(parseSchemaAttr(annotation, SchemaConstant.PROP_EXAMPLE, defaults, schemaType));
+        schema.setType(readSchemaType(annotation, schema, defaults));
+        schema.setExample(parseSchemaAttr(annotation, SchemaConstant.PROP_EXAMPLE, defaults, schema.getType()));
         schema.setDefaultValue(readAttr(annotation, SchemaConstant.PROP_DEFAULT_VALUE, defaults));
         schema.setDiscriminator(
                 readDiscriminator(context,
@@ -330,6 +328,30 @@ public class SchemaFactory {
         }
 
         return value;
+    }
+
+    /**
+     * Read the <code>type</code> property from the provided <code>@Schema<code> annotation.
+     * When null, the value previously set on the given schema object (if any) will be returned.
+     * 
+     * @param annotation schema annotation being processed
+     * @param schema schema model being populated
+     * @param defaults default schema property values or empty
+     * @return the value of the type property if not null, otherwise the current schema type
+     */
+    static SchemaType readSchemaType(AnnotationInstance annotation, Schema schema, Map<String, Object> defaults) {
+        SchemaType type = readAttr(annotation, SchemaConstant.PROP_TYPE, SchemaFactory::parseSchemaType, defaults);
+        return type != null ? type : schema.getType();
+    }
+
+    /**
+     * Convert the string value to the enum equivalent <code>SchemaType</code>
+     * 
+     * @param value string value from the <code>@Schema<code> annotation.
+     * @return the equivalent SchemaType value, or null if not set or no match
+     */
+    static SchemaType parseSchemaType(String value) {
+        return JandexUtil.enumValue(value, SchemaType.class);
     }
 
     /**

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.registered-schema-type-preserved.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.registered-schema-type-preserved.json
@@ -1,0 +1,130 @@
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "AnimalListEnvelope": {
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "The API version",
+            "type": "string",
+            "example": "v3"
+          },
+          "context": {
+            "description": "Optional context-value for request/response correlation",
+            "type": "string"
+          },
+          "requestId": {
+            "description": "Unique request-id (used for logging)",
+            "type": "string",
+            "example": "F176f717c7a71"
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageDataItemsAnimal"
+              },
+              {
+                "description": "The business data object"
+              }
+            ]
+          },
+          "kind": {
+            "description": "The class-name of the business data object",
+            "type": "string"
+          }
+        }
+      },
+      "MessageDataItems": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Animal"
+            }
+          },
+          "currentItemCount": {
+            "format": "int32",
+            "type": "integer",
+            "example": 1
+          }
+        }
+      },
+      "MessageDataItemsAnimal": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Animal"
+            }
+          },
+          "currentItemCount": {
+            "format": "int32",
+            "type": "integer",
+            "example": 1
+          }
+        }
+      },
+      "Animal": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "MessageBase": {
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "The API version",
+            "type": "string",
+            "example": "v3"
+          },
+          "context": {
+            "description": "Optional context-value for request/response correlation",
+            "type": "string"
+          },
+          "requestId": {
+            "description": "Unique request-id (used for logging)",
+            "type": "string",
+            "example": "F176f717c7a71"
+          }
+        }
+      },
+      "MessageData": {
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "The API version",
+            "type": "string",
+            "example": "v3"
+          },
+          "context": {
+            "description": "Optional context-value for request/response correlation",
+            "type": "string"
+          },
+          "requestId": {
+            "description": "Unique request-id (used for logging)",
+            "type": "string",
+            "example": "F176f717c7a71"
+          },
+          "data": {
+            "description": "The business data object",
+            "type": "object"
+          },
+          "kind": {
+            "description": "The class-name of the business data object",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #649 

The null schema type is causing the generated schema to be excluded from the output, as described in https://github.com/quarkusio/quarkus/issues/14670.