### PR TITLE
Add Jandex `equals` implementations

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -1179,7 +1179,7 @@ public abstract class AbstractParameterProcessor {
          */
         boolean nameMatches = (context.name == null || name == null || Objects.equals(context.name, name));
 
-        if (target.equals(context.target)) {
+        if (JandexUtil.equals(target, context.target)) {
             /*
              * The name must match for annotations on a method because it is
              * ambiguous which parameters is being referenced.

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -18,6 +18,7 @@ import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
@@ -507,4 +508,34 @@ public class JandexUtil {
 
         return chain;
     }
+
+    public static boolean equals(AnnotationTarget t1, AnnotationTarget t2) {
+        if (t1.kind() != t2.kind()) {
+            return false;
+        }
+
+        switch (t1.kind()) {
+            case CLASS:
+                return equals(t1.asClass(), t2.asClass());
+            case FIELD:
+                return equals(t1.asField(), t2.asField());
+            case METHOD_PARAMETER:
+                return equals(t1.asMethodParameter(), t2.asMethodParameter());
+            default:
+                return t1.equals(t2);
+        }
+    }
+
+    public static boolean equals(ClassInfo c1, ClassInfo c2) {
+        return c1.name().equals(c2.name());
+    }
+
+    public static boolean equals(FieldInfo f1, FieldInfo f2) {
+        return equals(f1.declaringClass(), f2.declaringClass()) && f1.name().equals(f2.name());
+    }
+
+    public static boolean equals(MethodParameterInfo p1, MethodParameterInfo p2) {
+        return p1.method().equals(p2.method()) && p1.position() == p2.position();
+    }
+
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.serialized-annotation-index.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.serialized-annotation-index.json
@@ -1,0 +1,45 @@
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/greet/{name}": {
+      "get": {
+        "summary": "Returns a personalized greeting",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The greeting name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Simple JSON containing the greeting",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GreetingMessage"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GreetingMessage": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #646 

Ensure de-serialized index associates multiple method parameter annotations

CC:  @tjquinno