### PR TITLE
enable noHtml5Validate, validation msg reset feat.

### DIFF
--- a/ui/open-api-ui-forms/package-lock.json
+++ b/ui/open-api-ui-forms/package-lock.json
@@ -1148,17 +1148,17 @@
       }
     },
     "@rjsf/bootstrap-4": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-2.3.0.tgz",
-      "integrity": "sha512-SuuLj/GokP5v2VK8o07d2R/qO+rv+XpRLQYV39Bhh3XIkdhfirYU46JXBt0Kb0usyyvyvRSRTO7i+6Lggnz88w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-2.4.2.tgz",
+      "integrity": "sha512-rbB373Kff6YRQ8XpO3j95sSQmJeFttbbunwT1bFog4+FjqfnMW46cYbRpOkTGYT23dGGxYD8yv8Q6uR7pMhc6g==",
       "requires": {
         "react-icons": "^3.10.0"
       }
     },
     "@rjsf/core": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.3.0.tgz",
-      "integrity": "sha512-OZKYHt9tjKhzOH4CvsPiCwepuIacqI++cNmnL2fsxh1IF+uEWGlo3NLDWhhSaBbOv9jps6a5YQcLbLtjNuSwug==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.4.2.tgz",
+      "integrity": "sha512-3EHpGiWryCx8kNv5TcKwnVtKlq08s2QvQTlwCF3pELqK9YQoa7SEsFQtZzU03wWk7o0Wvuig4BhJJKU8Dc2c5A==",
       "requires": {
         "@babel/runtime-corejs2": "^7.8.7",
         "@types/json-schema": "^7.0.4",
@@ -2117,9 +2117,9 @@
       "dev": true
     },
     "compute-gcd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
-      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
       "requires": {
         "validate.io-array": "^1.0.3",
         "validate.io-function": "^1.0.2",
@@ -2127,11 +2127,11 @@
       }
     },
     "compute-lcm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
-      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
       "requires": {
-        "compute-gcd": "^1.2.0",
+        "compute-gcd": "^1.2.1",
         "validate.io-array": "^1.0.3",
         "validate.io-function": "^1.0.2",
         "validate.io-integer-array": "^1.0.0"
@@ -3937,9 +3937,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
     },
@@ -4466,9 +4466,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
         }
       }
     },
@@ -4888,9 +4888,9 @@
       "dev": true
     },
     "shortid": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
-      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
       "requires": {
         "nanoid": "^2.1.0"
       }
@@ -5816,9 +5816,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
-      "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     },
     "which": {
       "version": "1.3.1",

--- a/ui/open-api-ui-forms/package.json
+++ b/ui/open-api-ui-forms/package.json
@@ -16,8 +16,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-bootstrap": "^1.2.2",
-    "@rjsf/core": "^2.2.2",
-    "@rjsf/bootstrap-4": "^2.2.2",
+    "@rjsf/core": "^2.4.2",
+    "@rjsf/bootstrap-4": "^2.4.2",
     "swagger-client": "^3.10.12"
   },
   "devDependencies": {

--- a/ui/open-api-ui-forms/src/App.js
+++ b/ui/open-api-ui-forms/src/App.js
@@ -34,6 +34,8 @@ class OverrideRequestModal extends React.Component {
     this.handleClose = this.handleClose.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.handleSave = this.handleSave.bind(this);
+    this.handleApply = this.handleApply.bind(this);
+    this.handleReset = this.handleReset.bind(this);
   }
 
   handleShow() {
@@ -60,12 +62,24 @@ class OverrideRequestModal extends React.Component {
     }
     this.setState({show: false});
   }
+  handleApply() {
+    this.onSave(this.getCurrentRequestValue());
+  }
+  handleReset() {
+    this.onSave({});
+  }
 
   render() {
     return (
       <div>
         <Button variant="light" onClick={this.handleShow}>
           Override request payload manually
+        </Button>
+        <Button variant="outline-light" onClick={this.handleApply}>
+          Apply
+        </Button>
+        <Button variant="outline-light" onClick={this.handleReset}>
+          Reset
         </Button>
 
         <Modal show={this.state.show} onHide={this.handleClose} animation={false}>
@@ -101,7 +115,8 @@ class MyOpenAPIForm extends React.Component {
   "type": "object"
 }},
                    requestPayload : {},
-                   responsePayload : "(nothing yet.)"
+                   responsePayload : "(nothing yet.)",
+                   key: Date.now() // required to reset any possible validation errors
                  };
 
     this.handleOpenAPIURLChange = this.handleOpenAPIURLChange.bind(this);
@@ -135,7 +150,10 @@ class MyOpenAPIForm extends React.Component {
 
   overrideRequest(x) {
     console.log(x);
-    this.setState({requestPayload: x});
+    this.setState({
+      requestPayload: x,
+      key: Date.now() // reset any possible validation errors
+    });
   }
 
   getCurrentRequestValue() {
@@ -195,7 +213,7 @@ class MyOpenAPIForm extends React.Component {
 
 <div className="row">
 <div className="col">
-  <Form schema={this.state.selected.schema} onSubmit={this.handleForm} onChange={this.handleFormChange} formData={this.state.requestPayload} />
+  <Form key={this.state.key} schema={this.state.selected.schema} onSubmit={this.handleForm} onChange={this.handleFormChange} formData={this.state.requestPayload} noHtml5Validate={true} />
 </div>
 <div className="col">
   <div className="form-group">


### PR DESCRIPTION
Executive summary: html5 validation interfers with mandatory boolean attribute from JSON schema. This resolve by disabling html5 validation, and providing a mean for end-user to reset library's form validation messages.

## Details

When an OpenAPI operation has object property as `boolean` and `required`:

![Screenshot 2021-02-08 at 11 43 22](https://user-images.githubusercontent.com/1699252/107210244-29e1a800-6a04-11eb-8e65-96fd0b3eddeb.png)

this interfers with the library form submission if html5 validation is also performed:

![Screenshot 2021-02-08 at 11 42 34](https://user-images.githubusercontent.com/1699252/107210299-3cf47800-6a04-11eb-962d-3ba4efc13d11.png)

This is documented here: https://react-jsonschema-form.readthedocs.io/en/latest/usage/validation/#html5-validation

This change disables html5 form validation per reference, thus setting `noHtml5Validate` to true.

![Screenshot 2021-02-08 at 11 45 32](https://user-images.githubusercontent.com/1699252/107210505-82b14080-6a04-11eb-8249-1c72cfdd70f6.png)

Additionally, this change allow end-user to reset the form validation messages (emitted by the library validation itself) taking a similar approach as in https://github.com/aerogear/mobile-developer-console/pull/338
Example.
Step1, some fields are missing:
![image](https://user-images.githubusercontent.com/1699252/107210764-e176ba00-6a04-11eb-9795-20e8f0c1174c.png)
Step2, User may opt to re-apply the payload (or reset it to blank):
![Screenshot 2021-02-08 at 11 58 34](https://user-images.githubusercontent.com/1699252/107211099-5fd35c00-6a05-11eb-9c69-582fd0b74e4f.png)
at this stage any missing fields can be valorized by the end-user, will reflect on the payload, and when all is okay the library's validation will not emit any "missing" message and fully submit, as detailed above.

I will shortly open a PR to cherry-pick and backport to `2.0.x` branch too.