### PR TITLE
Fix/enhance handling of nested and custom collection types

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -288,9 +288,16 @@ public class TypeUtil {
         TypeWithFormat typeFormat = getTypeFormat(classType);
 
         if (typeFormat.isSchemaType(SchemaType.ARRAY, SchemaType.OBJECT)) {
-            return !typeFormat.isOpaque() && context.getIndex().getClassByName(classType.name()) != null;
+            return !typeFormat.isOpaque()
+                    && !knownJavaType(classType.name())
+                    && context.getIndex().getClassByName(classType.name()) != null;
         }
+
         return typeFormat.getProperties().size() > 2;
+    }
+
+    public static boolean knownJavaType(DotName name) {
+        return jdkIndex.getClassByName(name) != null;
     }
 
     /**
@@ -351,7 +358,7 @@ public class TypeUtil {
     }
 
     private static Class<?> getClass(DotName name, ClassLoader cl) throws ClassNotFoundException {
-        return Class.forName(name.toString(), true, cl);
+        return Class.forName(name.toString(), false, cl);
     }
 
     private static boolean isAssignableFrom(DotName subject, DotName object, ClassLoader cl) {

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -2,8 +2,13 @@ package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -326,5 +331,80 @@ public class StandaloneSchemaScanTest extends IndexScannerTestBase {
         protected String city;
         protected String state;
         protected String postalCode;
+    }
+
+    /****************************************************************/
+
+    /*
+     * https://github.com/smallrye/smallrye-open-api/issues/226
+     */
+    @Test
+    public void testNestedCollectionSchemas() throws IOException, JSONException {
+        // Place the JDK classes in the index to simulate Quarkus
+        Index index = indexOf(CollectionBean.class,
+                EntryBean.class,
+                MultivaluedCollection.class,
+                MultivaluedMap.class,
+                // CustomMap.class excluded intentionally
+                Collection.class,
+                ArrayList.class,
+                HashMap.class,
+                List.class,
+                Map.class,
+                Set.class,
+                UUID.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals("components.schemas.nested-parameterized-collection-types.json", result);
+    }
+
+    @Schema
+    static class CollectionBean {
+        @Schema(description = "In-line schema, `additionalProperties` array `items` reference `EntryBean`")
+        CustomMap<String, List<EntryBean>> a_customMapOfLists;
+
+        @Schema(description = "Reference to `MultivaluedMapStringEntryBean")
+        MultivaluedMap<String, EntryBean> b_multivaluedEntryMap;
+
+        @Schema(description = "In-line schema, `additionalProperties` array `items` reference `EntryBean`")
+        Map<String, List<EntryBean>> c_mapStringListEntryBean;
+
+        @Schema(description = "In-line schema (All JDK types, no references)")
+        Collection<Map<String, List<String>>> d_collectionOfMapsOfListsOfStrings;
+
+        @Schema(description = "In-line schema")
+        Map<UUID, Map<String, Set<UUID>>> e_mapOfMapsOfSetsOfUUIDs;
+
+        @Schema(description = "Reference to `MultivaluedCollectionString`")
+        MultivaluedCollection<String> f_listOfStringLists;
+    }
+
+    static class EntryBean {
+        String name;
+        String value;
+    }
+
+    /*
+     * Not present in index - will cause call to Class.forName(...) and is not
+     * eligible for a entry in #/components/schemas
+     */
+    static class CustomMap<K, V> extends HashMap<K, V> {
+        private static final long serialVersionUID = 1L;
+
+        static {
+            // We shouldn't run any code while scanning
+            if (true) {
+                throw new RuntimeException("CustomMap was initialized!?");
+            }
+        }
+    }
+
+    static class MultivaluedCollection<T> extends ArrayList<List<T>> {
+        private static final long serialVersionUID = 1L;
+    }
+
+    static class MultivaluedMap<K, V> extends HashMap<K, List<V>> {
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -336,7 +336,7 @@ public class StandaloneSchemaScanTest extends IndexScannerTestBase {
     /****************************************************************/
 
     /*
-     * https://github.com/smallrye/smallrye-open-api/issues/226
+     * https://github.com/smallrye/smallrye-open-api/issues/688
      */
     @Test
     public void testNestedCollectionSchemas() throws IOException, JSONException {

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.nested-parameterized-collection-types.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.nested-parameterized-collection-types.json
@@ -1,0 +1,104 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "CollectionBean" : {
+        "type" : "object",
+        "properties" : {
+          "a_customMapOfLists" : {
+            "description" : "In-line schema, `additionalProperties` array `items` reference `EntryBean`",
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/EntryBean"
+              }
+            }
+          },
+          "b_multivaluedEntryMap" : {
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/MultivaluedMapStringEntryBean"
+            }, {
+              "description" : "Reference to `MultivaluedMapStringEntryBean"
+            } ]
+          },
+          "c_mapStringListEntryBean" : {
+            "description" : "In-line schema, `additionalProperties` array `items` reference `EntryBean`",
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/EntryBean"
+              }
+            }
+          },
+          "d_collectionOfMapsOfListsOfStrings" : {
+            "description" : "In-line schema (All JDK types, no references)",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "e_mapOfMapsOfSetsOfUUIDs" : {
+            "description" : "In-line schema",
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "uniqueItems" : true,
+                "type" : "array",
+                "items" : {
+                  "format" : "uuid",
+                  "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "f_listOfStringLists" : {
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/MultivaluedCollectionString"
+            }, {
+              "description" : "Reference to `MultivaluedCollectionString`"
+            } ]
+          }
+        }
+      },
+      "MultivaluedCollectionString" : {
+        "type" : "array",
+        "items" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "EntryBean" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      },
+      "MultivaluedMapStringEntryBean" : {
+        "type" : "object",
+        "additionalProperties" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/components/schemas/EntryBean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -123,6 +123,12 @@
             <scope>test</scope>
             <type>pom</type>
         </dependency>
+        <dependency>
+  <groupId>org.keycloak</groupId>
+  <artifactId>keycloak-core</artifactId>
+  <version>11.0.3</version>
+  <scope>test</scope>
+</dependency>
         
         <!-- Depend on core tests -->
         <dependency>
@@ -132,9 +138,8 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-  
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -53,27 +53,7 @@
         <!-- Test Only Dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -135,6 +115,16 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <!-- Overriding version from smallrye-parent. JUnit 5 Tests not executed otherwise. -->
+                    <version>3.0.0-M5</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -178,7 +168,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>coverage</id>

--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -123,13 +123,7 @@
             <scope>test</scope>
             <type>pom</type>
         </dependency>
-        <dependency>
-  <groupId>org.keycloak</groupId>
-  <artifactId>keycloak-core</artifactId>
-  <version>11.0.3</version>
-  <scope>test</scope>
-</dependency>
-        
+
         <!-- Depend on core tests -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -265,7 +265,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
                     .map(PathItem.HttpMethod::valueOf)
                     .forEach(httpMethod -> {
                         resourceCount.incrementAndGet();
-                        processResourceMethod(context, resourceClass, methodInfo, httpMethod, openApi, tagRefs,
+                        processResourceMethod(context, resourceClass, methodInfo, httpMethod, tagRefs,
                                 locatorPathParameters, exceptionAnnotationMap);
                     });
 
@@ -383,7 +383,6 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             final ClassInfo resourceClass,
             final MethodInfo method,
             final PathItem.HttpMethod methodType,
-            OpenAPI openApi,
             Set<String> resourceTags,
             List<Parameter> locatorPathParameters,
             Map<DotName, AnnotationInstance> exceptionAnnotationMap) {
@@ -406,7 +405,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         final Operation operation = maybeOperation.get();
 
         // Process tags - @Tag and @Tags annotations combines with the resource tags we've already found (passed in)
-        processOperationTags(context, method, openApi, resourceTags, operation);
+        processOperationTags(context, method, context.getOpenApi(), resourceTags, operation);
 
         // Process @Parameter annotations.
         Function<AnnotationInstance, Parameter> reader = t -> ParameterReader.readParameter(context, t);
@@ -456,10 +455,10 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         }
 
         // Get or create a PathItem to hold the operation
-        PathItem existingPath = ModelUtil.paths(openApi).getPathItem(path);
+        PathItem existingPath = ModelUtil.paths(context.getOpenApi()).getPathItem(path);
 
         if (existingPath == null) {
-            ModelUtil.paths(openApi).addPathItem(path, pathItem);
+            ModelUtil.paths(context.getOpenApi()).addPathItem(path, pathItem);
         } else {
             // Changes applied to 'existingPath', no need to re-assign or add to OAI.
             MergeUtil.mergeObjects(existingPath, pathItem);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
@@ -1,7 +1,10 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.json.JsonObject;
 import javax.json.JsonString;
@@ -19,17 +22,23 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.openapi.annotations.Components;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartOutput;
 import org.json.JSONException;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -262,6 +271,26 @@ public class ApiResponseTests extends IndexScannerTestBase {
     public void testGenericTypeVariableResponses() throws IOException, JSONException {
         test("responses.generic-type-variables.json",
                 Apple.class, BaseResource.class, TestResource.class);
+    }
+
+    @Test
+    @Ignore
+    public void testKeycloakIssue() throws IOException, JSONException {
+        test("",
+                AccountResource.class,
+                PasswordRequest.class,
+                UsersResource.class,
+                org.keycloak.representations.idm.UserRepresentation.class,
+                org.keycloak.representations.idm.CredentialRepresentation.class,
+                org.keycloak.representations.idm.FederatedIdentityRepresentation.class,
+                org.keycloak.representations.idm.UserConsentRepresentation.class,
+                org.keycloak.representations.idm.SocialLinkRepresentation.class,
+                org.keycloak.representations.idm.RoleRepresentation.class,
+                org.keycloak.common.util.MultivaluedHashMap.class,
+                Collection.class,
+                List.class,
+                Map.class,
+                Set.class);
     }
 
     /***************** Test models and resources below. ***********************/
@@ -654,6 +683,174 @@ public class ApiResponseTests extends IndexScannerTestBase {
         @Path("save")
         public Apple update(Apple filter) {
             return null;
+        }
+    }
+
+    @Tag(name = "Account Management", description = "An API to manage the logged in Account Account.")
+    @Path("/account")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    static class AccountResource {
+
+        @GET
+        @Operation(summary = "Get account", description = "Get the logged in account.")
+        @APIResponses({
+                @APIResponse(responseCode = "200", description = "The logged in account profile"),
+                @APIResponse(responseCode = "500", description = "The logged in account profile is either empty or invalid or an internal error occurred")
+        })
+        public org.keycloak.representations.idm.UserRepresentation getAccount() {
+            return null;
+        }
+
+        @POST
+        @Operation(summary = "Update account", description = "Update the logged in account.")
+        public org.keycloak.representations.idm.UserRepresentation updateAccount(
+                @RequestBody(description = "The updated user account") org.keycloak.representations.idm.UserRepresentation user) {
+            return null;
+        }
+
+        @POST
+        @Path("/credentials/password")
+        @Operation(summary = "Update password", description = "Update the password for logged in account.")
+        public void updatePassword(@RequestBody(description = "The password change request") PasswordRequest request) {
+        }
+    }
+
+    static class PasswordRequest {
+        String currentPassword;
+        String newPassword;
+        String confirmation;
+
+        public PasswordRequest() {
+        }
+
+        public String getCurrentPassword() {
+            return currentPassword;
+        }
+
+        public void setCurrentPassword(String currentPassword) {
+            this.currentPassword = currentPassword;
+        }
+
+        public String getNewPassword() {
+            return newPassword;
+        }
+
+        public void setNewPassword(String newPassword) {
+            this.newPassword = newPassword;
+        }
+
+        public String getConfirmation() {
+            return confirmation;
+        }
+
+        public void setConfirmation(String confirmation) {
+            this.confirmation = confirmation;
+        }
+    }
+
+    @Tag(name = "Users Management", description = "An API to manage users.")
+    @Path("/users")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    static class UsersResource {
+        @GET
+        @Operation(summary = "Get users", description = "Get all users.")
+        @APIResponses({
+                @APIResponse(responseCode = "200", description = "The list of Users"),
+                @APIResponse(responseCode = "500", description = "An internal error occurred")
+        })
+        public Collection<org.keycloak.representations.idm.UserRepresentation> getUsers() {
+            return null;
+        }
+
+        @GET
+        @Path("{id}")
+        @Operation(summary = "Get user", description = "Get the user.")
+        @Consumes(MediaType.TEXT_PLAIN)
+        @APIResponses({
+                @APIResponse(responseCode = "200", description = "The Account"),
+                @APIResponse(responseCode = "500", description = "An internal error occurred")
+        })
+        public org.keycloak.representations.idm.UserRepresentation getUser(
+                @Parameter(description = "The id of the user") @PathParam("id") String id) {
+            return null;
+        }
+
+        @POST
+        @Operation(summary = "Create user", description = "Create user.")
+        @APIResponses({
+                @APIResponse(responseCode = "201", description = "Creation succeeded"),
+                @APIResponse(responseCode = "500", description = "An internal error occurred")
+        })
+        public Response createUser(
+                @RequestBody(description = "The user") org.keycloak.representations.idm.UserRepresentation user) {
+            return null;
+        }
+
+        @PUT
+        @Path("{id}")
+        @Operation(summary = "Update user", description = "Update user by id.")
+        @APIResponses({
+                @APIResponse(responseCode = "200", description = "Update succeeded"),
+                @APIResponse(responseCode = "500", description = "An internal error occurred")
+        })
+        public org.keycloak.representations.idm.UserRepresentation updateUser(
+                @Parameter(description = "The id of the user") @PathParam("id") String id,
+                @RequestBody(description = "The user") org.keycloak.representations.idm.UserRepresentation user) {
+            return null;
+        }
+
+        @DELETE
+        @Path("{id}")
+        @Operation(summary = "Delete users", description = "Delete user by id.")
+        @APIResponses({
+                @APIResponse(responseCode = "200", description = "Deletion succeeded"),
+                @APIResponse(responseCode = "500", description = "An internal error occurred")
+        })
+        public Response deleteUser(@Parameter(description = "The id of the user") @PathParam("id") String id) {
+            return null;
+        }
+
+        @PUT
+        @Path("{id}/reset-password")
+        @Operation(summary = "Reset password", description = "Reset the old password with new one..")
+        public void resetPassword(@Parameter(description = "The id of the user") @PathParam("id") String id,
+                @RequestBody(description = "The credentials. Only newPassword is used here.") PasswordRequest credentials) {
+        }
+
+        @GET
+        @Path("{id}/role-mappings/realm")
+        @Operation(summary = "Get realm roles", description = "Get a list of realm roles of the user.")
+        @APIResponses({
+                @APIResponse(responseCode = "200", description = "The list of Roles."),
+                @APIResponse(responseCode = "500", description = "An internal error occurred")
+        })
+        public Collection<org.keycloak.representations.idm.RoleRepresentation> getRealmRoleMappings(
+                @Parameter(description = "The id of the user") @PathParam("id") String id) {
+            return null;
+        }
+
+        @POST
+        @Path("{id}/role-mappings/realm")
+        @Operation(summary = "Add realm roles to user", description = "Add a list of realm roles to the user.")
+        @APIResponses({
+                @APIResponse(responseCode = "204", description = "Operation successful."),
+                @APIResponse(responseCode = "500", description = "An internal error occurred")
+        })
+        public void addRealmRoleMappings(@Parameter(description = "The id of the user") @PathParam("id") String id,
+                Collection<org.keycloak.representations.idm.RoleRepresentation> roles) {
+        }
+
+        @DELETE
+        @Path("{id}/role-mappings/realm")
+        @Operation(summary = "Delete realm roles", description = "Delete a list of realm roles from the user.")
+        @APIResponses({
+                @APIResponse(responseCode = "204", description = "Operation successful."),
+                @APIResponse(responseCode = "500", description = "An internal error occurred")
+        })
+        public void deleteRealmRoleMappings(@Parameter(description = "The id of the user") @PathParam("id") String id,
+                Collection<org.keycloak.representations.idm.RoleRepresentation> roles) {
         }
     }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
@@ -2,9 +2,10 @@ package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.NavigableMap;
 
 import javax.json.JsonObject;
 import javax.json.JsonString;
@@ -22,23 +23,18 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import javax.ws.rs.core.MultivaluedMap;
 
 import org.eclipse.microprofile.openapi.annotations.Components;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
-import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.info.Info;
-import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
-import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartOutput;
 import org.json.JSONException;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -274,23 +270,37 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    @Ignore
-    public void testKeycloakIssue() throws IOException, JSONException {
-        test("",
-                AccountResource.class,
-                PasswordRequest.class,
-                UsersResource.class,
-                org.keycloak.representations.idm.UserRepresentation.class,
-                org.keycloak.representations.idm.CredentialRepresentation.class,
-                org.keycloak.representations.idm.FederatedIdentityRepresentation.class,
-                org.keycloak.representations.idm.UserConsentRepresentation.class,
-                org.keycloak.representations.idm.SocialLinkRepresentation.class,
-                org.keycloak.representations.idm.RoleRepresentation.class,
-                org.keycloak.common.util.MultivaluedHashMap.class,
+    public void testMultivaluedCustomMapTypeResponse() throws IOException, JSONException {
+        @Path("map")
+        @SuppressWarnings("unused")
+        class Resource {
+            class CustomRequest {
+                public String requestName;
+            }
+
+            class CustomResponse {
+                public String responseName;
+            }
+
+            @POST
+            @Consumes(MediaType.APPLICATION_JSON)
+            @Produces(MediaType.APPLICATION_JSON)
+            public MultivaluedMap<String, Map<String, CustomResponse>> getMapOfListsOfMaps(
+                    MultivaluedMap<String, Map<String, CustomRequest>> request) {
+                return null;
+            }
+        }
+
+        test("responses.nested-parameterized-collection-types.json",
+                Resource.class,
+                Resource.CustomRequest.class,
+                Resource.CustomResponse.class,
+                MultivaluedMap.class,
                 Collection.class,
                 List.class,
                 Map.class,
-                Set.class);
+                NavigableMap.class,
+                HashMap.class);
     }
 
     /***************** Test models and resources below. ***********************/
@@ -683,174 +693,6 @@ public class ApiResponseTests extends IndexScannerTestBase {
         @Path("save")
         public Apple update(Apple filter) {
             return null;
-        }
-    }
-
-    @Tag(name = "Account Management", description = "An API to manage the logged in Account Account.")
-    @Path("/account")
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)
-    static class AccountResource {
-
-        @GET
-        @Operation(summary = "Get account", description = "Get the logged in account.")
-        @APIResponses({
-                @APIResponse(responseCode = "200", description = "The logged in account profile"),
-                @APIResponse(responseCode = "500", description = "The logged in account profile is either empty or invalid or an internal error occurred")
-        })
-        public org.keycloak.representations.idm.UserRepresentation getAccount() {
-            return null;
-        }
-
-        @POST
-        @Operation(summary = "Update account", description = "Update the logged in account.")
-        public org.keycloak.representations.idm.UserRepresentation updateAccount(
-                @RequestBody(description = "The updated user account") org.keycloak.representations.idm.UserRepresentation user) {
-            return null;
-        }
-
-        @POST
-        @Path("/credentials/password")
-        @Operation(summary = "Update password", description = "Update the password for logged in account.")
-        public void updatePassword(@RequestBody(description = "The password change request") PasswordRequest request) {
-        }
-    }
-
-    static class PasswordRequest {
-        String currentPassword;
-        String newPassword;
-        String confirmation;
-
-        public PasswordRequest() {
-        }
-
-        public String getCurrentPassword() {
-            return currentPassword;
-        }
-
-        public void setCurrentPassword(String currentPassword) {
-            this.currentPassword = currentPassword;
-        }
-
-        public String getNewPassword() {
-            return newPassword;
-        }
-
-        public void setNewPassword(String newPassword) {
-            this.newPassword = newPassword;
-        }
-
-        public String getConfirmation() {
-            return confirmation;
-        }
-
-        public void setConfirmation(String confirmation) {
-            this.confirmation = confirmation;
-        }
-    }
-
-    @Tag(name = "Users Management", description = "An API to manage users.")
-    @Path("/users")
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)
-    static class UsersResource {
-        @GET
-        @Operation(summary = "Get users", description = "Get all users.")
-        @APIResponses({
-                @APIResponse(responseCode = "200", description = "The list of Users"),
-                @APIResponse(responseCode = "500", description = "An internal error occurred")
-        })
-        public Collection<org.keycloak.representations.idm.UserRepresentation> getUsers() {
-            return null;
-        }
-
-        @GET
-        @Path("{id}")
-        @Operation(summary = "Get user", description = "Get the user.")
-        @Consumes(MediaType.TEXT_PLAIN)
-        @APIResponses({
-                @APIResponse(responseCode = "200", description = "The Account"),
-                @APIResponse(responseCode = "500", description = "An internal error occurred")
-        })
-        public org.keycloak.representations.idm.UserRepresentation getUser(
-                @Parameter(description = "The id of the user") @PathParam("id") String id) {
-            return null;
-        }
-
-        @POST
-        @Operation(summary = "Create user", description = "Create user.")
-        @APIResponses({
-                @APIResponse(responseCode = "201", description = "Creation succeeded"),
-                @APIResponse(responseCode = "500", description = "An internal error occurred")
-        })
-        public Response createUser(
-                @RequestBody(description = "The user") org.keycloak.representations.idm.UserRepresentation user) {
-            return null;
-        }
-
-        @PUT
-        @Path("{id}")
-        @Operation(summary = "Update user", description = "Update user by id.")
-        @APIResponses({
-                @APIResponse(responseCode = "200", description = "Update succeeded"),
-                @APIResponse(responseCode = "500", description = "An internal error occurred")
-        })
-        public org.keycloak.representations.idm.UserRepresentation updateUser(
-                @Parameter(description = "The id of the user") @PathParam("id") String id,
-                @RequestBody(description = "The user") org.keycloak.representations.idm.UserRepresentation user) {
-            return null;
-        }
-
-        @DELETE
-        @Path("{id}")
-        @Operation(summary = "Delete users", description = "Delete user by id.")
-        @APIResponses({
-                @APIResponse(responseCode = "200", description = "Deletion succeeded"),
-                @APIResponse(responseCode = "500", description = "An internal error occurred")
-        })
-        public Response deleteUser(@Parameter(description = "The id of the user") @PathParam("id") String id) {
-            return null;
-        }
-
-        @PUT
-        @Path("{id}/reset-password")
-        @Operation(summary = "Reset password", description = "Reset the old password with new one..")
-        public void resetPassword(@Parameter(description = "The id of the user") @PathParam("id") String id,
-                @RequestBody(description = "The credentials. Only newPassword is used here.") PasswordRequest credentials) {
-        }
-
-        @GET
-        @Path("{id}/role-mappings/realm")
-        @Operation(summary = "Get realm roles", description = "Get a list of realm roles of the user.")
-        @APIResponses({
-                @APIResponse(responseCode = "200", description = "The list of Roles."),
-                @APIResponse(responseCode = "500", description = "An internal error occurred")
-        })
-        public Collection<org.keycloak.representations.idm.RoleRepresentation> getRealmRoleMappings(
-                @Parameter(description = "The id of the user") @PathParam("id") String id) {
-            return null;
-        }
-
-        @POST
-        @Path("{id}/role-mappings/realm")
-        @Operation(summary = "Add realm roles to user", description = "Add a list of realm roles to the user.")
-        @APIResponses({
-                @APIResponse(responseCode = "204", description = "Operation successful."),
-                @APIResponse(responseCode = "500", description = "An internal error occurred")
-        })
-        public void addRealmRoleMappings(@Parameter(description = "The id of the user") @PathParam("id") String id,
-                Collection<org.keycloak.representations.idm.RoleRepresentation> roles) {
-        }
-
-        @DELETE
-        @Path("{id}/role-mappings/realm")
-        @Operation(summary = "Delete realm roles", description = "Delete a list of realm roles from the user.")
-        @APIResponses({
-                @APIResponse(responseCode = "204", description = "Operation successful."),
-                @APIResponse(responseCode = "500", description = "An internal error occurred")
-        })
-        public void deleteRealmRoleMappings(@Parameter(description = "The id of the user") @PathParam("id") String id,
-                Collection<org.keycloak.representations.idm.RoleRepresentation> roles) {
         }
     }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
@@ -35,12 +35,12 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartOutput;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>} and Scott Curtis {@literal <Scott.Curtis@ibm.com>}
  */
-public class ApiResponseTests extends IndexScannerTestBase {
+class ApiResponseTests extends IndexScannerTestBase {
 
     private static void test(String expectedResource, Class<?>... classes) throws IOException, JSONException {
         Index index = indexOf(classes);
@@ -51,133 +51,133 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResponseGenerationSuppressedByApiResourcesAnnotation() throws IOException, JSONException {
+    void testResponseGenerationSuppressedByApiResourcesAnnotation() throws IOException, JSONException {
         test("responses.generation-suppressed-by-api-responses-annotation.json",
                 ResponseGenerationSuppressedByApiResourcesAnnotationTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationSuppressedBySuppliedDefaultApiResource() throws IOException, JSONException {
+    void testResponseGenerationSuppressedBySuppliedDefaultApiResource() throws IOException, JSONException {
         test("responses.generation-suppressed-by-supplied-default-api-response.json",
                 ResponseGenerationSuppressedBySuppliedDefaultApiResourceTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationSuppressedByStatusOmission() throws IOException, JSONException {
+    void testResponseGenerationSuppressedByStatusOmission() throws IOException, JSONException {
         test("responses.generation-suppressed-by-status-omission.json",
                 ResponseGenerationSuppressedByStatusOmissionTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationEnabledByIncompleteApiResponse() throws IOException, JSONException {
+    void testResponseGenerationEnabledByIncompleteApiResponse() throws IOException, JSONException {
         test("responses.generation-enabled-by-incomplete-api-response.json",
                 ResponseGenerationEnabledByIncompleteApiResponseTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaNoResponseDescription() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaNoResponseDescription() throws IOException, JSONException {
         test("responses.api-response-schema-no-description.json",
                 ResponseGenerationAPIResponseSchemaNoResponseDescriptionTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodePostNonVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodePostNonVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-post.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodePostAndNonVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeGetNonVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeGetNonVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-get.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeGetAndNonVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodePutNonVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodePutNonVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-put.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodePutAndNonVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodePatchAndNonVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodePatchAndNonVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-patch.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodePatchAndNonVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeDeleteAndNonVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeDeleteAndNonVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-delete.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeDeleteAndNonVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodePostAndVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodePostAndVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-void-post.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodePostAndVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeGetAndVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeGetAndVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-not-async-void-get.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeGetAndVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodePutAndVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodePutAndVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-not-async-void-put.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodePutAndVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodePatchAndVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodePatchAndVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-not-async-void-patch.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodePatchAndVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeDeleteAndVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeDeleteAndVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-not-async-void-delete.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeDeleteAndVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPostAndVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPostAndVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-void-post.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPostAndVoidTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncGetAndVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncGetAndVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-get.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncGetAndVoidTestResource.class, Pet.class,
                 JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPutAndVoid() throws IOException, JSONException {
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPutAndVoid() throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-put.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPutAndVoidTestResource.class, Pet.class,
                 JsonString.class);
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPatchAndVoid()
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPatchAndVoid()
             throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-patch.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPatchAndVoidTestResource.class, Pet.class,
@@ -185,7 +185,7 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncDeleteAndVoid()
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncDeleteAndVoid()
             throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-delete.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncDeleteAndVoidTestResource.class, Pet.class,
@@ -193,7 +193,7 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPostAndNonVoid()
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPostAndNonVoid()
             throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-post.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPostAndNonVoidTestResource.class,
@@ -201,7 +201,7 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncGetAndNonVoid()
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncGetAndNonVoid()
             throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-get.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncGetAndNonVoidTestResource.class,
@@ -209,7 +209,7 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPutAndNonVoid()
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPutAndNonVoid()
             throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-put.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPutAndNonVoidTestResource.class,
@@ -217,7 +217,7 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPatchAndNonVoid()
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPatchAndNonVoid()
             throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-patch.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncPatchAndNonVoidTestResource.class,
@@ -225,7 +225,7 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncDeleteAndNonVoid()
+    void testResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncDeleteAndNonVoid()
             throws IOException, JSONException {
         test("responses.api-response-schema-invalid-response-code-delete.json",
                 ResponseGenerationAPIResponseSchemaInvalidResponseCodeAsyncDeleteAndNonVoidTestResource.class,
@@ -233,44 +233,44 @@ public class ApiResponseTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResponseMultipartGeneration() throws IOException, JSONException {
+    void testResponseMultipartGeneration() throws IOException, JSONException {
         test("responses.multipart-generation.json",
                 ResponseMultipartGenerationTestResource.class);
     }
 
     @Test
-    public void testVoidPostResponseGeneration() throws IOException, JSONException {
+    void testVoidPostResponseGeneration() throws IOException, JSONException {
         test("responses.void-post-response-generation.json",
                 VoidPostResponseGenerationTestResource.class,
                 Pet.class, JsonString.class);
     }
 
     @Test
-    public void testVoidNonPostResponseGeneration() throws IOException, JSONException {
+    void testVoidNonPostResponseGeneration() throws IOException, JSONException {
         test("responses.void-nonpost-response-generation.json",
                 VoidNonPostResponseGenerationTestResource.class);
     }
 
     @Test
-    public void testVoidAsyncResponseGeneration() throws IOException, JSONException {
+    void testVoidAsyncResponseGeneration() throws IOException, JSONException {
         test("responses.void-async-response-generation.json",
                 VoidAsyncResponseGenerationTestResource.class, ServerError.class);
     }
 
     @Test
-    public void testReferenceResponse() throws IOException, JSONException {
+    void testReferenceResponse() throws IOException, JSONException {
         test("responses.component-status-reuse.json",
                 ReferenceResponseTestApp.class, ReferenceResponseTestResource.class, JsonObject.class);
     }
 
     @Test
-    public void testGenericTypeVariableResponses() throws IOException, JSONException {
+    void testGenericTypeVariableResponses() throws IOException, JSONException {
         test("responses.generic-type-variables.json",
                 Apple.class, BaseResource.class, TestResource.class);
     }
 
     @Test
-    public void testMultivaluedCustomMapTypeResponse() throws IOException, JSONException {
+    void testMultivaluedCustomMapTypeResponse() throws IOException, JSONException {
         @Path("map")
         @SuppressWarnings("unused")
         class Resource {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigExtensionsTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigExtensionsTest.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfigImpl;
@@ -21,7 +21,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource;
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
+class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
 
     private static final String TITLE = "mp.openapi.extensions.smallrye.info.title";
     private static final String VERSION = "mp.openapi.extensions.smallrye.info.version";
@@ -34,7 +34,7 @@ public class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
     private static final String LICENSE_URL = "mp.openapi.extensions.smallrye.info.license.url";
 
     @Test
-    public void testSettingJustTitle() throws IOException, JSONException {
+    void testSettingJustTitle() throws IOException, JSONException {
         System.setProperty(TITLE, "My Awesome Service");
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
@@ -51,7 +51,7 @@ public class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testSettingJustContactEmail() throws IOException, JSONException {
+    void testSettingJustContactEmail() throws IOException, JSONException {
         System.setProperty(CONTACT_EMAIL, "phillip.kruger@redhat.com");
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
@@ -68,7 +68,7 @@ public class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testSettingJustLicenseName() throws IOException, JSONException {
+    void testSettingJustLicenseName() throws IOException, JSONException {
         System.setProperty(LICENSE_NAME, "Apache License 2.0");
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
@@ -85,7 +85,7 @@ public class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testSettingAllInfo() throws IOException, JSONException {
+    void testSettingAllInfo() throws IOException, JSONException {
 
         System.setProperty(TITLE, "My own awesome REST service");
         System.setProperty(VERSION, "1.2.3");

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigSchemaTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigSchemaTest.java
@@ -9,7 +9,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfigImpl;
@@ -22,7 +22,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource;
  * 
  * @author Scott Curtis (@literal <Scott.Curtis@ibm.com>)
  */
-public class ConfigSchemaTest extends JaxRsDataObjectScannerTestBase {
+class ConfigSchemaTest extends JaxRsDataObjectScannerTestBase {
 
     private static final String VALID_SCHEMA_PROPERTY_KEY = "mp.openapi.schema.java.lang.String";
     private static final String INVALID_SCHEMA_PROPERTY_KEY = "mp.openapi.schema.java.lang.NonExistentClass";
@@ -46,7 +46,7 @@ public class ConfigSchemaTest extends JaxRsDataObjectScannerTestBase {
             + "  \"description\": \"Invali\"{d\"}";
 
     @Test
-    public void testValidSchemaDefinitionViaConfig() throws IOException, JSONException {
+    void testValidSchemaDefinitionViaConfig() throws IOException, JSONException {
         System.setProperty(VALID_SCHEMA_PROPERTY_KEY, VALID_PROPERTY_VALUE);
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
@@ -64,7 +64,7 @@ public class ConfigSchemaTest extends JaxRsDataObjectScannerTestBase {
 
     // If the class in the key is non existent, schema is only rendered in components block
     @Test
-    public void testInvalidSchemaKeyDefinitionViaConfig() throws IOException, JSONException {
+    void testInvalidSchemaKeyDefinitionViaConfig() throws IOException, JSONException {
         System.setProperty(INVALID_SCHEMA_PROPERTY_KEY, VALID_PROPERTY_VALUE);
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
@@ -82,7 +82,7 @@ public class ConfigSchemaTest extends JaxRsDataObjectScannerTestBase {
 
     // Technically correct behaviour as malformed-property is not rendered in schema, but no feedback
     @Test
-    public void testValidSchemaKeyWithInvalidSchemaPropertyValueViaConfig() throws IOException, JSONException {
+    void testValidSchemaKeyWithInvalidSchemaPropertyValueViaConfig() throws IOException, JSONException {
         System.setProperty(VALID_SCHEMA_PROPERTY_KEY, INVALID_PROPERTY_VALUE_SCHEMA);
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
@@ -100,7 +100,7 @@ public class ConfigSchemaTest extends JaxRsDataObjectScannerTestBase {
 
     // Technically correct behaviour as malformed schema is not rendered, but no feedback
     @Test
-    public void testValidSchemaKeyWithInvalidSchemaJSONValueViaConfig() throws IOException, JSONException {
+    void testValidSchemaKeyWithInvalidSchemaJSONValueViaConfig() throws IOException, JSONException {
         System.setProperty(VALID_SCHEMA_PROPERTY_KEY, INVALID_PROPERTY_VALUE_JSON);
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/CustomExtensionParsingTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/CustomExtensionParsingTests.java
@@ -1,8 +1,8 @@
 package io.smallrye.openapi.runtime.scanner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,11 +24,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.InitializationError;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 
@@ -39,23 +36,11 @@ import io.smallrye.openapi.api.OpenApiConfig;
  * 
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-@RunWith(CustomExtensionParsingTests.JacksonExcludedRunner.class)
-public class CustomExtensionParsingTests {
-
-    public static class JacksonExcludedRunner extends BlockJUnit4ClassRunner {
-
-        public JacksonExcludedRunner(Class<?> testClass) throws InitializationError {
-            super(testClass);
-        }
-
-        @Override
-        protected boolean isIgnored(FrameworkMethod child) {
-            return !Boolean.valueOf(System.getProperty("classpath.jackson.excluded"));
-        }
-    }
+@EnabledIfSystemProperty(named = "classpath.jackson.excluded", matches = "true")
+class CustomExtensionParsingTests {
 
     @Test
-    public void testDefaultExtensionParseThrowsJacksonNotFound() {
+    void testDefaultExtensionParseThrowsJacksonNotFound() {
         Index index = IndexScannerTestBase.indexOf(ExtensionParsingTestResource.class);
         OpenApiConfig config = IndexScannerTestBase.emptyConfig();
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, index);
@@ -64,7 +49,7 @@ public class CustomExtensionParsingTests {
     }
 
     @Test
-    public void testCustomAnnotationScannerExtension() {
+    void testCustomAnnotationScannerExtension() {
         Index index = IndexScannerTestBase.indexOf(ExtensionParsingTestResource.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(IndexScannerTestBase.emptyConfig(), index,
                 Arrays.asList(new AnnotationScannerExtension() {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/CustomExtensionParsingTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/CustomExtensionParsingTests.java
@@ -30,6 +30,8 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
+import io.smallrye.openapi.api.OpenApiConfig;
+
 /**
  * Special tests using a custom {@link AnnotationScannerExtension#parseExtension(String, String)}
  * implementation. The tests in this class will only run when system property `classpath.jackson.excluded`
@@ -55,8 +57,9 @@ public class CustomExtensionParsingTests {
     @Test
     public void testDefaultExtensionParseThrowsJacksonNotFound() {
         Index index = IndexScannerTestBase.indexOf(ExtensionParsingTestResource.class);
-        NoClassDefFoundError err = assertThrows(NoClassDefFoundError.class,
-                () -> new OpenApiAnnotationScanner(IndexScannerTestBase.emptyConfig(), index).scan());
+        OpenApiConfig config = IndexScannerTestBase.emptyConfig();
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, index);
+        NoClassDefFoundError err = assertThrows(NoClassDefFoundError.class, () -> scanner.scan());
         assertTrue(err.getMessage().contains("jackson"));
     }
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/DefaultContentTypeTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/DefaultContentTypeTest.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfigImpl;
@@ -21,7 +21,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.DefaultContentTypeReso
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class DefaultContentTypeTest extends JaxRsDataObjectScannerTestBase {
+class DefaultContentTypeTest extends JaxRsDataObjectScannerTestBase {
     /**
      * This test the normal (no config) case
      * 
@@ -29,7 +29,7 @@ public class DefaultContentTypeTest extends JaxRsDataObjectScannerTestBase {
      * @throws org.json.JSONException
      */
     @Test
-    public void testVanilla() throws IOException, JSONException {
+    void testVanilla() throws IOException, JSONException {
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
 
@@ -48,7 +48,7 @@ public class DefaultContentTypeTest extends JaxRsDataObjectScannerTestBase {
      * @throws org.json.JSONException
      */
     @Test
-    public void testConfigured() throws IOException, JSONException {
+    void testConfigured() throws IOException, JSONException {
         System.setProperty(OpenApiConstants.DEFAULT_CONSUMES, "application/json");
         System.setProperty(OpenApiConstants.DEFAULT_PRODUCES, "application/json");
         Config config = ConfigProvider.getConfig();

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/DiscriminatorMappingTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/DiscriminatorMappingTests.java
@@ -15,15 +15,15 @@ import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class DiscriminatorMappingTests extends IndexScannerTestBase {
+class DiscriminatorMappingTests extends IndexScannerTestBase {
 
     @Test
-    public void testDiscriminatorFullDeclaredInResponse() throws IOException, JSONException {
+    void testDiscriminatorFullDeclaredInResponse() throws IOException, JSONException {
         assertJsonEquals("polymorphism.declared-discriminator.json",
                 DiscriminatorFullDeclaredInResponseTestResource.class,
                 AbstractPet.class,
@@ -34,7 +34,7 @@ public class DiscriminatorMappingTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDiscriminatorNoMappingTestResource() throws IOException, JSONException {
+    void testDiscriminatorNoMappingTestResource() throws IOException, JSONException {
         assertJsonEquals("polymorphism.declared-discriminator-no-mapping.json",
                 DiscriminatorNoMappingTestResource.class,
                 AbstractPet.class,
@@ -45,7 +45,7 @@ public class DiscriminatorMappingTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDiscriminatorMappingNoSchema() throws IOException, JSONException {
+    void testDiscriminatorMappingNoSchema() throws IOException, JSONException {
         assertJsonEquals("polymorphism.declared-discriminator-no-mapping-schema.json",
                 DiscriminatorMappingNoSchemaTestResource.class,
                 AbstractPet.class,
@@ -56,7 +56,7 @@ public class DiscriminatorMappingTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDiscriminatorMappingNoKey() throws IOException, JSONException {
+    void testDiscriminatorMappingNoKey() throws IOException, JSONException {
         assertJsonEquals("polymorphism.declared-discriminator-no-mapping-key.json",
                 DiscriminatorMappingNoKeyTestResource.class,
                 AbstractPet.class,
@@ -67,7 +67,7 @@ public class DiscriminatorMappingTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDiscriminatorMappingEmptyMapping() throws IOException, JSONException {
+    void testDiscriminatorMappingEmptyMapping() throws IOException, JSONException {
         assertJsonEquals("polymorphism.declared-discriminator-empty-mapping.json",
                 DiscriminatorMappingEmptyMappingTestResource.class,
                 AbstractPet.class,
@@ -78,7 +78,7 @@ public class DiscriminatorMappingTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDiscriminatorMappingNoPropertyName() throws IOException, JSONException {
+    void testDiscriminatorMappingNoPropertyName() throws IOException, JSONException {
         assertJsonEquals("polymorphism.declared-discriminator-no-property-name.json",
                 DiscriminatorMappingNoPropertyNameTestResource.class,
                 AbstractPet.class,

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
@@ -16,9 +16,9 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ExceptionMapperScanTests extends IndexScannerTestBase {
+class ExceptionMapperScanTests extends IndexScannerTestBase {
 
     private static void test(String expectedResource, Class<?>... classes) throws IOException, JSONException {
         Index index = indexOf(classes);
@@ -29,13 +29,13 @@ public class ExceptionMapperScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testExceptionMapper() throws IOException, JSONException {
+    void testExceptionMapper() throws IOException, JSONException {
         test("responses.exception-mapper-generation.json", TestResource.class, ExceptionHandler1.class,
                 ExceptionHandler2.class, ResteasyReactiveExceptionMapper.class);
     }
 
     @Test
-    public void testMethodAnnotationOverrideExceptionMapper() throws IOException, JSONException {
+    void testMethodAnnotationOverrideExceptionMapper() throws IOException, JSONException {
         test("responses.exception-mapper-overridden-by-method-annotation-generation.json", TestResource2.class,
                 ExceptionHandler1.class, ExceptionHandler2.class, ResteasyReactiveExceptionMapper.class);
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
@@ -10,6 +10,8 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.Bar;
 import test.io.smallrye.openapi.runtime.scanner.entities.BuzzLinkedList;
@@ -20,7 +22,7 @@ import test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContaine
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
  */
-public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
+class ExpectationTests extends JaxRsDataObjectScannerTestBase {
 
     /**
      * Unresolvable type parameter.
@@ -72,75 +74,21 @@ public class ExpectationTests extends JaxRsDataObjectScannerTestBase {
         assertJsonEquals(baz.local(), "enumRequired.expected.json", result);
     }
 
-    @Test
-    public void testNestedGenerics() throws IOException, JSONException {
+    @ParameterizedTest
+    @CsvSource({
+            "nesting, generic.nested.expected.json",
+            "complexNesting, generic.complexNesting.expected.json",
+            "complexInheritance, generic.complexInheritance.expected.json",
+            "genericWithBounds, generic.withBounds.expected.json",
+            "genericContainer, generic.fields.expected.json",
+            "overriddenNames, generic.fields.overriddenNames.expected.json"
+    })
+    void testGenericTypeFields(String fieldName, String expectedResource) throws IOException, JSONException {
         String name = GenericTypeTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "nesting").type();
+        Type pType = getFieldFromKlazz(name, fieldName).type();
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
         Schema result = scanner.process();
-
         printToConsole(name, result);
-        assertJsonEquals(name, "generic.nested.expected.json", result);
-    }
-
-    @Test
-    public void testComplexNestedGenerics() throws IOException, JSONException {
-        String name = GenericTypeTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "complexNesting").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "generic.complexNesting.expected.json", result);
-    }
-
-    @Test
-    public void testComplexInheritanceGenerics() throws IOException, JSONException {
-        String name = GenericTypeTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "complexInheritance").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "generic.complexInheritance.expected.json", result);
-    }
-
-    @Test
-    public void testGenericsWithBounds() throws IOException, JSONException {
-        String name = GenericTypeTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "genericWithBounds").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "generic.withBounds.expected.json", result);
-    }
-
-    @Test
-    public void genericFieldTest() throws IOException, JSONException {
-        String name = GenericTypeTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "genericContainer").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "generic.fields.expected.json", result);
-    }
-
-    @Test
-    public void fieldNameOverrideTest() throws IOException, JSONException {
-        String name = GenericTypeTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "overriddenNames").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "generic.fields.overriddenNames.expected.json", result);
+        assertJsonEquals(name, expectedResource, result);
     }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationTests.java
@@ -9,7 +9,7 @@ import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -28,7 +28,7 @@ class ExpectationTests extends JaxRsDataObjectScannerTestBase {
      * Unresolvable type parameter.
      */
     @Test
-    public void testUnresolvable() throws IOException, JSONException {
+    void testUnresolvable() throws IOException, JSONException {
         DotName bar = createSimple(Bar.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, ClassType.create(bar, Type.Kind.CLASS));
 
@@ -42,7 +42,7 @@ class ExpectationTests extends JaxRsDataObjectScannerTestBase {
      * Unresolvable type parameter.
      */
     @Test
-    public void testCycle() throws IOException, JSONException {
+    void testCycle() throws IOException, JSONException {
         DotName buzz = createSimple(BuzzLinkedList.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, ClassType.create(buzz, Type.Kind.CLASS));
 
@@ -53,7 +53,7 @@ class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testBareEnum() throws IOException, JSONException {
+    void testBareEnum() throws IOException, JSONException {
         DotName baz = createSimple(EnumContainer.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, ClassType.create(baz, Type.Kind.CLASS));
 
@@ -64,7 +64,7 @@ class ExpectationTests extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testRequiredEnum() throws IOException, JSONException {
+    void testRequiredEnum() throws IOException, JSONException {
         DotName baz = createSimple(EnumRequiredContainer.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, ClassType.create(baz, Type.Kind.CLASS));
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
@@ -7,8 +7,8 @@ import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.models.OpenAPIImpl;
 import test.io.smallrye.openapi.runtime.scanner.entities.Bar;
@@ -20,13 +20,13 @@ import test.io.smallrye.openapi.runtime.scanner.entities.GenericTypeTestContaine
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
+class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
 
     OpenAPIImpl oai;
     SchemaRegistry registry;
 
-    @Before
-    public void setupRegistry() {
+    @BeforeEach
+    void setupRegistry() {
         oai = (OpenAPIImpl) context.getOpenApi();
         registry = SchemaRegistry.newInstance(context);
     }
@@ -63,7 +63,7 @@ public class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
      * Unresolvable type parameter.
      */
     @Test
-    public void testUnresolvableWithRefs() throws IOException, JSONException {
+    void testUnresolvableWithRefs() throws IOException, JSONException {
         testAssertion(Bar.class, "refsEnabled.unresolvable.expected.json");
     }
 
@@ -71,59 +71,59 @@ public class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
      * Cyclic reference.
      */
     @Test
-    public void testCycleWithRef() throws IOException, JSONException {
+    void testCycleWithRef() throws IOException, JSONException {
         testAssertion(BuzzLinkedList.class, "refsEnabled.cycle.expected.json");
     }
 
     @Test
-    public void testBareEnumWithRef() throws IOException, JSONException {
+    void testBareEnumWithRef() throws IOException, JSONException {
         testAssertion(EnumContainer.class, "refsEnabled.enum.expected.json");
     }
 
     @Test
-    public void testRequiredEnumWithRef() throws IOException, JSONException {
+    void testRequiredEnumWithRef() throws IOException, JSONException {
         testAssertion(EnumRequiredContainer.class, "refsEnabled.enumRequired.expected.json");
     }
 
     @Test
-    public void testNestedGenericsWithRefs() throws IOException, JSONException {
+    void testNestedGenericsWithRefs() throws IOException, JSONException {
         testAssertion(GenericTypeTestContainer.class, "nesting", "refsEnabled.generic.nested.expected.json");
     }
 
     @Test
-    public void testComplexNestedGenericsWithRefs() throws IOException, JSONException {
+    void testComplexNestedGenericsWithRefs() throws IOException, JSONException {
         testAssertion(GenericTypeTestContainer.class, "complexNesting", "refsEnabled.generic.complexNesting.expected.json");
     }
 
     @Test
-    public void testComplexInheritanceGenericsWithRefs() throws IOException, JSONException {
+    void testComplexInheritanceGenericsWithRefs() throws IOException, JSONException {
         testAssertion(GenericTypeTestContainer.class, "complexInheritance",
                 "refsEnabled.generic.complexInheritance.expected.json");
     }
 
     @Test
-    public void testGenericsWithBoundsWithRef() throws IOException, JSONException {
+    void testGenericsWithBoundsWithRef() throws IOException, JSONException {
         testAssertion(GenericTypeTestContainer.class, "genericWithBounds", "refsEnabled.generic.withBounds.expected.json");
     }
 
     @Test
-    public void genericFieldWithRefTest() throws IOException, JSONException {
+    void genericFieldWithRefTest() throws IOException, JSONException {
         testAssertion(GenericTypeTestContainer.class, "genericContainer", "refsEnabled.generic.fields.expected.json");
     }
 
     @Test
-    public void fieldNameOverrideWithRefTest() throws IOException, JSONException {
+    void fieldNameOverrideWithRefTest() throws IOException, JSONException {
         testAssertion(GenericTypeTestContainer.class, "overriddenNames",
                 "refsEnabled.generic.fields.overriddenNames.expected.json");
     }
 
     @Test
-    public void durationContainer() throws IOException, JSONException {
+    void durationContainer() throws IOException, JSONException {
         testAssertion(GenericTypeTestContainer.class, "durationContainer", "refsEnabled.duration.fields.expected.json");
     }
 
     @Test
-    public void periodContainer() throws IOException, JSONException {
+    void periodContainer() throws IOException, JSONException {
         testAssertion(GenericTypeTestContainer.class, "periodContainer", "refsEnabled.period.fields.expected.json");
     }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExtensionParsingTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExtensionParsingTests.java
@@ -20,16 +20,16 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  * 
  */
-public class ExtensionParsingTests extends IndexScannerTestBase {
+class ExtensionParsingTests extends IndexScannerTestBase {
 
     @Test
-    public void testAllExpectedParseTypes() throws IOException, JSONException {
+    void testAllExpectedParseTypes() throws IOException, JSONException {
         assertJsonEquals("extensions.parsing.expected.json",
                 ExtensionParsingTestResource.class);
     }
@@ -61,7 +61,7 @@ public class ExtensionParsingTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testSiblingExtensionAnnotations() throws IOException, JSONException {
+    void testSiblingExtensionAnnotations() throws IOException, JSONException {
         assertJsonEquals("extensions.scan-siblings.expected.json",
                 ExtensionPlacementTestResource.class,
                 ExtensionPlacementTestResource.Model.class);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/GenericModelTypesResourceTest.java
@@ -35,11 +35,11 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 
-public class GenericModelTypesResourceTest extends IndexScannerTestBase {
+class GenericModelTypesResourceTest extends IndexScannerTestBase {
 
     /*
      * Test case derived from original example in Smallrye OpenAPI issue #25.
@@ -48,7 +48,7 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
      *
      */
     @Test
-    public void testGenericsApplication() throws IOException, JSONException {
+    void testGenericsApplication() throws IOException, JSONException {
         Index i = indexOf(BaseModel.class,
                 BaseResource.class,
                 KingCrimson.class,
@@ -70,7 +70,7 @@ public class GenericModelTypesResourceTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testGenericsApplicationWithoutArrayRefs() throws IOException, JSONException {
+    void testGenericsApplicationWithoutArrayRefs() throws IOException, JSONException {
         Index i = indexOf(BaseModel.class,
                 BaseResource.class,
                 KingCrimson.class,

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/IgnoreTests.java
@@ -8,7 +8,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.IgnoreSchemaOnFieldExample;
 import test.io.smallrye.openapi.runtime.scanner.entities.IgnoreTestContainer;
@@ -20,11 +20,11 @@ import test.io.smallrye.openapi.runtime.scanner.entities.TransientFieldExample;
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
  */
-public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
+class IgnoreTests extends JaxRsDataObjectScannerTestBase {
 
     // Always ignore nominated properties when given class is used.
     @Test
-    public void testIgnore_jsonIgnorePropertiesOnClass() throws IOException, JSONException {
+    void testIgnore_jsonIgnorePropertiesOnClass() throws IOException, JSONException {
         String name = IgnoreTestContainer.class.getName();
         Type type = getFieldFromKlazz(name, "jipOnClassTest").type();
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, type);
@@ -37,7 +37,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
 
     // Ignore nominated properties of the field in this instance only.
     @Test
-    public void testIgnore_jsonIgnorePropertiesOnField() throws IOException, JSONException {
+    void testIgnore_jsonIgnorePropertiesOnField() throws IOException, JSONException {
         String name = IgnoreTestContainer.class.getName();
         FieldInfo fieldInfo = getFieldFromKlazz(name, "jipOnFieldTest");
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, fieldInfo, fieldInfo.type());
@@ -50,7 +50,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
 
     // Entirely ignore a single field once.
     @Test
-    public void testIgnore_jsonIgnoreField() throws IOException, JSONException {
+    void testIgnore_jsonIgnoreField() throws IOException, JSONException {
         DotName name = DotName.createSimple(JsonIgnoreOnFieldExample.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
@@ -63,7 +63,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
 
     // Entirely ignore a single field once.
     @Test
-    public void testIgnore_jsonIgnoreType() throws IOException, JSONException {
+    void testIgnore_jsonIgnoreType() throws IOException, JSONException {
         DotName name = DotName.createSimple(JsonIgnoreTypeExample.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
@@ -76,7 +76,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
 
     // Entirely ignore a single field once using JSON-B.
     @Test
-    public void testIgnore_jsonbTransientField() throws IOException, JSONException {
+    void testIgnore_jsonbTransientField() throws IOException, JSONException {
         DotName name = DotName.createSimple(JsonbTransientOnFieldExample.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
@@ -89,7 +89,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
 
     // Entirely ignore a single field once using hidden attribute of Schema.
     @Test
-    public void testIgnore_schemaHiddenField() throws IOException, JSONException {
+    void testIgnore_schemaHiddenField() throws IOException, JSONException {
         DotName name = DotName.createSimple(IgnoreSchemaOnFieldExample.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));
@@ -101,7 +101,7 @@ public class IgnoreTests extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testIgnore_transientField() throws IOException, JSONException {
+    void testIgnore_transientField() throws IOException, JSONException {
         DotName name = DotName.createSimple(TransientFieldExample.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(name, Type.Kind.CLASS));

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/InterfaceInheritanceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/InterfaceInheritanceTest.java
@@ -21,11 +21,11 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class InterfaceInheritanceTest extends IndexScannerTestBase {
+class InterfaceInheritanceTest extends IndexScannerTestBase {
 
     /*
      * Test case derived from original example in Smallrye OpenAPI issue #423.
@@ -34,7 +34,7 @@ public class InterfaceInheritanceTest extends IndexScannerTestBase {
      *
      */
     @Test
-    public void testInterfaceInheritance() throws IOException, JSONException {
+    void testInterfaceInheritance() throws IOException, JSONException {
         Index i = indexOf(ImmutableEntity.class, MutableEntity.class, Note.class, FruitResource.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
         OpenAPI result = scanner.scan();

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerBasicTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerBasicTest.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
 import test.io.smallrye.openapi.runtime.scanner.resources.GreetingDeleteResource;
@@ -18,7 +18,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPutResource;
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class JaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerTestBase {
+class JaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerTestBase {
 
     /**
      * This test a basic, no OpenApi annotations, hello world GET service
@@ -27,7 +27,7 @@ public class JaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerTestB
      * @throws JSONException
      */
     @Test
-    public void testBasicJaxRsGetDefinitionScanning() throws IOException, JSONException {
+    void testBasicJaxRsGetDefinitionScanning() throws IOException, JSONException {
         Index i = indexOf(GreetingGetResource.class, Greeting.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
 
@@ -44,7 +44,7 @@ public class JaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerTestB
      * @throws JSONException
      */
     @Test
-    public void testBasicJaxRsPostDefinitionScanning() throws IOException, JSONException {
+    void testBasicJaxRsPostDefinitionScanning() throws IOException, JSONException {
         Index i = indexOf(GreetingPostResource.class, Greeting.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
 
@@ -61,7 +61,7 @@ public class JaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerTestB
      * @throws JSONException
      */
     @Test
-    public void testBasicJaxRsPutDefinitionScanning() throws IOException, JSONException {
+    void testBasicJaxRsPutDefinitionScanning() throws IOException, JSONException {
         Index i = indexOf(GreetingPutResource.class, Greeting.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
 
@@ -78,7 +78,7 @@ public class JaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerTestB
      * @throws JSONException
      */
     @Test
-    public void testBasicJaxRsDeleteDefinitionScanning() throws IOException, JSONException {
+    void testBasicJaxRsDeleteDefinitionScanning() throws IOException, JSONException {
         Index i = indexOf(GreetingDeleteResource.class, Greeting.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
@@ -43,7 +43,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.EmptySecurityRequireme
 /**
  * @author eric.wittmann@gmail.com
  */
-public class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
+class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
 
     @Test
     public void testHiddenOperationNotPresent() throws IOException, JSONException {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
@@ -28,7 +28,7 @@ import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -46,7 +46,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.EmptySecurityRequireme
 class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
 
     @Test
-    public void testHiddenOperationNotPresent() throws IOException, JSONException {
+    void testHiddenOperationNotPresent() throws IOException, JSONException {
         Indexer indexer = new Indexer();
 
         // Test samples
@@ -62,7 +62,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testHiddenOperationPathNotPresent() throws IOException, JSONException {
+    void testHiddenOperationPathNotPresent() throws IOException, JSONException {
         Indexer indexer = new Indexer();
 
         // Test samples
@@ -77,7 +77,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testRequestBodyComponentGeneration() throws IOException, JSONException {
+    void testRequestBodyComponentGeneration() throws IOException, JSONException {
         Indexer indexer = new Indexer();
 
         // Test samples
@@ -98,7 +98,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testPackageInfoDefinitionScanning() throws IOException, JSONException {
+    void testPackageInfoDefinitionScanning() throws IOException, JSONException {
         Indexer indexer = new Indexer();
         index(indexer, "test/io/smallrye/openapi/runtime/scanner/package-info.class");
         index(indexer, "test/io/smallrye/openapi/runtime/scanner/resources/PackageInfoTestApplication.class");
@@ -115,7 +115,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     /**
      * Example of a simple custom schema registry that has only UUID type schema.
      */
-    public static class MyCustomSchemaRegistry implements CustomSchemaRegistry {
+    static class MyCustomSchemaRegistry implements CustomSchemaRegistry {
 
         @Override
         public void registerCustomSchemas(SchemaRegistry schemaRegistry) {
@@ -133,7 +133,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testTagScanning() throws IOException, JSONException {
+    void testTagScanning() throws IOException, JSONException {
         Index i = indexOf(TagTestResource1.class, TagTestResource2.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(new HashMap<String, Object>()), i);
         OpenAPI result = scanner.scan();
@@ -142,7 +142,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testTagScanning_OrderGivenAnnotations() throws IOException, JSONException {
+    void testTagScanning_OrderGivenAnnotations() throws IOException, JSONException {
         Index i = indexOf(TagTestApp.class, TagTestResource1.class, TagTestResource2.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(new HashMap<String, Object>()), i);
         OpenAPI result = scanner.scan();
@@ -151,7 +151,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testTagScanning_OrderGivenStaticFile() throws IOException, JSONException {
+    void testTagScanning_OrderGivenStaticFile() throws IOException, JSONException {
         Index i = indexOf(TagTestResource1.class, TagTestResource2.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(new HashMap<String, Object>()), i);
         OpenAPI scanResult = scanner.scan();
@@ -176,20 +176,20 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
 
         @GET
         @Produces(MediaType.TEXT_PLAIN)
-        public String getValue1() {
+        String getValue1() {
             return null;
         }
 
         @POST
         @Consumes(MediaType.TEXT_PLAIN)
         @Tag(name = "tag1", description = "TAG1 from TagTestResource1#postValue")
-        public void postValue(String value) {
+        void postValue(String value) {
         }
 
         @PATCH
         @Consumes(MediaType.TEXT_PLAIN)
         @Tag
-        public void patchValue(String value) {
+        void patchValue(String value) {
         }
     }
 
@@ -203,13 +203,13 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
         @GET
         @Produces(MediaType.TEXT_PLAIN)
         @Tag(name = "tag3", description = "TAG3 from TagTestResource2#getValue1", externalDocs = @ExternalDocumentation(description = "Ext doc from TagTestResource2#getValue1"))
-        public String getValue1() {
+        String getValue1() {
             return null;
         }
 
         @POST
         @Consumes(MediaType.TEXT_PLAIN)
-        public void postValue(String value) {
+        void postValue(String value) {
         }
 
         @PATCH
@@ -217,7 +217,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
         @Tags({
                 @Tag, @Tag
         })
-        public void patchValue(String value) {
+        void patchValue(String value) {
         }
     }
 
@@ -229,7 +229,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testEmptySecurityRequirements() throws IOException, JSONException {
+    void testEmptySecurityRequirements() throws IOException, JSONException {
         Index index = indexOf(EmptySecurityRequirementsResource.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
 
@@ -242,7 +242,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     /**************************************************************************/
 
     @Test
-    public void testInterfaceWithoutImplentationExcluded() throws IOException, JSONException {
+    void testInterfaceWithoutImplentationExcluded() throws IOException, JSONException {
         Index index = indexOf(MissingImplementation.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
 
@@ -280,7 +280,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     /**************************************************************************/
 
     @Test
-    public void testInterfaceWithConcreteImplentation() throws IOException, JSONException {
+    void testInterfaceWithConcreteImplentation() throws IOException, JSONException {
         Index index = indexOf(HasConcreteImplementation.class, ImplementsHasConcreteImplementation.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
 
@@ -307,7 +307,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
     /**************************************************************************/
 
     @Test
-    public void testInterfaceWithAbstractImplentation() throws IOException, JSONException {
+    void testInterfaceWithAbstractImplentation() throws IOException, JSONException {
         Index index = indexOf(HasAbstractImplementation.class, ImplementsHasAbstractImplementation.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsDataObjectScannerTestBase.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsDataObjectScannerTestBase.java
@@ -5,8 +5,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -22,7 +21,6 @@ public class JaxRsDataObjectScannerTestBase extends IndexScannerTestBase {
     protected static Index index;
 
     @BeforeAll
-    @BeforeClass
     public static void createIndex() {
         Indexer indexer = new Indexer();
 
@@ -48,9 +46,13 @@ public class JaxRsDataObjectScannerTestBase extends IndexScannerTestBase {
     }
 
     @BeforeEach
-    @Before
     public void createContext() {
         context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(), emptyConfig());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.removeSchemaRegistry();
     }
 
     public FieldInfo getFieldFromKlazz(String containerName, String fieldName) {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsDataObjectScannerTestBase.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsDataObjectScannerTestBase.java
@@ -7,6 +7,8 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import io.smallrye.openapi.api.util.ClassLoaderUtil;
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
@@ -19,6 +21,7 @@ public class JaxRsDataObjectScannerTestBase extends IndexScannerTestBase {
     protected AnnotationScannerContext context;
     protected static Index index;
 
+    @BeforeAll
     @BeforeClass
     public static void createIndex() {
         Indexer indexer = new Indexer();
@@ -44,6 +47,7 @@ public class JaxRsDataObjectScannerTestBase extends IndexScannerTestBase {
         index = indexer.complete();
     }
 
+    @BeforeEach
     @Before
     public void createContext() {
         context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(), emptyConfig());

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxbJaxRsAnnotationScannerBasicTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxbJaxRsAnnotationScannerBasicTest.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
 import test.io.smallrye.openapi.runtime.scanner.entities.JaxbGreeting;
@@ -17,7 +17,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.*;
  *
  * @author Andrey Batalev (andrey.batalev@gmail.com)
  */
-public class JaxbJaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerTestBase {
+class JaxbJaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerTestBase {
 
     /**
      * This test a basic, no OpenApi annotations, hello world GET service
@@ -26,7 +26,7 @@ public class JaxbJaxRsAnnotationScannerBasicTest extends JaxRsDataObjectScannerT
      * @throws JSONException
      */
     @Test
-    public void testBasicJaxRsGetDefinitionScanning() throws IOException, JSONException {
+    void testBasicJaxRsGetDefinitionScanning() throws IOException, JSONException {
         Index i = indexOf(JaxbGreetingGetResource.class, Greeting.class, JaxbGreeting.class, JaxbWithNameGreeting.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
@@ -1,5 +1,7 @@
 package io.smallrye.openapi.runtime.scanner;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import java.io.IOException;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -16,7 +18,7 @@ import test.io.smallrye.openapi.runtime.scanner.entities.KitchenSink;
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
  */
-public class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
+class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
 
     private static final Logger LOG = Logger.getLogger(KitchenSinkTest.class);
 
@@ -29,13 +31,14 @@ public class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
      * It is to validate the scanner doesn't break rather than strictly assessing correctness.
      */
     @Test
-    public void testKitchenSink() throws IOException {
+    void testKitchenSink() throws IOException {
         DotName kitchenSink = DotName.createSimple(KitchenSink.class.getName());
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context,
                 ClassType.create(kitchenSink, Type.Kind.CLASS));
 
         LOG.debugv("Scanning top-level entity: {0}", KitchenSink.class.getName());
-        printToConsole(kitchenSink.local(), scanner.process());
+        Schema resultSchema = assertDoesNotThrow(() -> scanner.process());
+        printToConsole(kitchenSink.local(), resultSchema);
     }
 
     /**
@@ -44,13 +47,14 @@ public class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
      * @see org.jboss.jandex.ParameterizedType
      */
     @Test
-    public void testTopLevelParameterisedType() throws IOException {
+    void testTopLevelParameterisedType() throws IOException {
         // Look up the kitchen sink and get the field named "simpleParameterizedType"
         Type pType = getFieldFromKlazz(KitchenSink.class.getName(), "simpleParameterizedType").type();
 
         LOG.debugv("Scanning top-level entity: {0}", pType);
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-        printToConsole("KustomPair", scanner.process());
+        Schema resultSchema = assertDoesNotThrow(() -> scanner.process());
+        printToConsole("KustomPair", resultSchema);
     }
 
     @Test

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
@@ -11,7 +11,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.KitchenSink;
 
@@ -58,7 +58,7 @@ class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testKitchenSinkWithRefs() throws IOException, JSONException {
+    void testKitchenSinkWithRefs() throws IOException, JSONException {
         DotName name = componentize(KitchenSink.class.getName());
         Type type = ClassType.create(name, Type.Kind.CLASS);
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, type);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
@@ -11,7 +11,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.NestedSchemaParent;
 import test.io.smallrye.openapi.runtime.scanner.resources.NestedSchemaOnParameterResource;
@@ -19,10 +19,10 @@ import test.io.smallrye.openapi.runtime.scanner.resources.NestedSchemaOnParamete
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class NestedSchemaReferenceTests extends JaxRsDataObjectScannerTestBase {
+class NestedSchemaReferenceTests extends JaxRsDataObjectScannerTestBase {
 
     @Test
-    public void testNestedSchemasAddedToRegistry() throws IOException, JSONException {
+    void testNestedSchemasAddedToRegistry() throws IOException, JSONException {
         DotName parentName = componentize(NestedSchemaParent.class.getName());
         Type parentType = ClassType.create(parentName, Type.Kind.CLASS);
         OpenAPI oai = context.getOpenApi();
@@ -38,7 +38,7 @@ public class NestedSchemaReferenceTests extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testNestedSchemaOnParameter() throws IOException, JSONException {
+    void testNestedSchemaOnParameter() throws IOException, JSONException {
         IndexView i = indexOf(NestedSchemaOnParameterResource.class,
                 NestedSchemaOnParameterResource.NestedParameterTestParent.class,
                 NestedSchemaOnParameterResource.NestedParameterTestChild.class,
@@ -59,7 +59,7 @@ public class NestedSchemaReferenceTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testSimpleNestedSchemaOnParameter() throws IOException, JSONException {
+    void testSimpleNestedSchemaOnParameter() throws IOException, JSONException {
         Indexer indexer = new Indexer();
 
         // Test samples

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationIdTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationIdTest.java
@@ -1,100 +1,48 @@
 package io.smallrye.openapi.runtime.scanner;
 
-import java.io.IOException;
-
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
-import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfigImpl;
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.runtime.OpenApiProcessor;
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingOperationResource;
 
 /**
  * Basic tests to check the operation Id autogeneration
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class OperationIdTest extends JaxRsDataObjectScannerTestBase {
+class OperationIdTest extends JaxRsDataObjectScannerTestBase {
 
-    /**
-     * This test a Method naming strategy
-     * 
-     * @throws java.io.IOException
-     * @throws org.json.JSONException
-     */
-    @Test
-    public void testMethodNaming() throws IOException, JSONException {
-        System.setProperty(OpenApiConstants.OPERATION_ID_STRAGEGY, "METHOD");
+    @ParameterizedTest
+    @CsvSource({
+            "METHOD, test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource, resource.testOperationIdMethod.json",
+            "CLASS_METHOD, test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource, resource.testOperationIdClassMethod.json",
+            "PACKAGE_CLASS_METHOD, test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource, resource.testOperationIdPackageClassMethod.json",
+            "METHOD, test.io.smallrye.openapi.runtime.scanner.resources.GreetingOperationResource, resource.testOperationIdMethodWithOperation.json"
+    })
+    void testOperationIdStrategies(String strategy, String resourceClass, String expectedResultResourceName)
+            throws Exception {
+
+        System.setProperty(OpenApiConstants.OPERATION_ID_STRAGEGY, strategy);
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+
         try {
-            Index i = indexOf(GreetingGetResource.class, Greeting.class);
+            Index i = indexOf(Class.forName(resourceClass), Greeting.class);
             OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
 
             printToConsole(result);
-            assertJsonEquals("resource.testOperationIdMethod.json", result);
-
+            assertJsonEquals(expectedResultResourceName, result);
         } finally {
             System.clearProperty(OpenApiConstants.OPERATION_ID_STRAGEGY);
         }
     }
 
-    @Test
-    public void testClassMethodNaming() throws IOException, JSONException {
-        System.setProperty(OpenApiConstants.OPERATION_ID_STRAGEGY, "CLASS_METHOD");
-        Config config = ConfigProvider.getConfig();
-        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
-        try {
-            Index i = indexOf(GreetingGetResource.class, Greeting.class);
-            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
-
-            printToConsole(result);
-            assertJsonEquals("resource.testOperationIdClassMethod.json", result);
-
-        } finally {
-            System.clearProperty(OpenApiConstants.OPERATION_ID_STRAGEGY);
-        }
-    }
-
-    @Test
-    public void testPackageClassMethodNaming() throws IOException, JSONException {
-        System.setProperty(OpenApiConstants.OPERATION_ID_STRAGEGY, "PACKAGE_CLASS_METHOD");
-        Config config = ConfigProvider.getConfig();
-        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
-        try {
-            Index i = indexOf(GreetingGetResource.class, Greeting.class);
-            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
-
-            printToConsole(result);
-            assertJsonEquals("resource.testOperationIdPackageClassMethod.json", result);
-
-        } finally {
-            System.clearProperty(OpenApiConstants.OPERATION_ID_STRAGEGY);
-        }
-    }
-
-    @Test
-    public void testMethodNamingWhenOperationIsSet() throws IOException, JSONException {
-        System.setProperty(OpenApiConstants.OPERATION_ID_STRAGEGY, "METHOD");
-        Config config = ConfigProvider.getConfig();
-        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
-        try {
-            Index i = indexOf(GreetingOperationResource.class, Greeting.class);
-            OpenAPI result = OpenApiProcessor.bootstrap(openApiConfig, i);
-
-            printToConsole(result);
-            assertJsonEquals("resource.testOperationIdMethodWithOperation.json", result);
-
-        } finally {
-            System.clearProperty(OpenApiConstants.OPERATION_ID_STRAGEGY);
-        }
-    }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -66,12 +66,12 @@ import org.jboss.resteasy.reactive.RestMatrix;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class ParameterScanTests extends IndexScannerTestBase {
+class ParameterScanTests extends IndexScannerTestBase {
 
     private static void test(String expectedResource, Class<?>... classes) throws IOException, JSONException {
         Index index = indexOf(classes);
@@ -82,28 +82,28 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIgnoredMpOpenApiHeaders() throws IOException, JSONException {
+    void testIgnoredMpOpenApiHeaders() throws IOException, JSONException {
         test("params.ignored-mp-openapi-headers.json",
                 IgnoredMpOpenApiHeaderArgsTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testParameterOnMethod() throws IOException, JSONException {
+    void testParameterOnMethod() throws IOException, JSONException {
         test("params.parameter-on-method.json",
                 ParameterOnMethodTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testParameterOnField() throws IOException, JSONException {
+    void testParameterOnField() throws IOException, JSONException {
         test("params.parameter-on-field.json",
                 ResourcePathParamTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testParameterInBeanFromField() throws IOException, JSONException {
+    void testParameterInBeanFromField() throws IOException, JSONException {
         test("params.parameter-in-bean-from-field.json",
                 ParameterInBeanFromFieldTestResource.class,
                 ParameterInBeanFromFieldTestResource.Bean.class,
@@ -111,7 +111,7 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testParameterInBeanFromSetter() throws IOException, JSONException {
+    void testParameterInBeanFromSetter() throws IOException, JSONException {
         test("params.parameter-in-bean-from-setter.json",
                 ParameterInBeanFromSetterTestResource.class,
                 ParameterInBeanFromSetterTestResource.Bean.class,
@@ -119,21 +119,21 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testPathParamWithFormParams() throws IOException, JSONException {
+    void testPathParamWithFormParams() throws IOException, JSONException {
         test("params.path-param-with-form-params.json",
                 PathParamWithFormParamsTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testMultipleContentTypesWithFormParams() throws IOException, JSONException {
+    void testMultipleContentTypesWithFormParams() throws IOException, JSONException {
         test("params.multiple-content-types-with-form-params.json",
                 MultipleContentTypesWithFormParamsTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testParametersInConstructor() throws IOException, JSONException {
+    void testParametersInConstructor() throws IOException, JSONException {
         test("params.parameters-in-constructor.json",
                 ParametersInConstructorTestResource.class,
                 ParametersInConstructorTestResource.Bean.class,
@@ -141,28 +141,28 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testMatrixParamsOnResourceMethodArgs() throws IOException, JSONException {
+    void testMatrixParamsOnResourceMethodArgs() throws IOException, JSONException {
         test("params.matrix-params-on-resource-method-args.json",
                 MatrixParamsOnResourceMethodArgsTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testMatrixParamsOnResourceMethodCustomName() throws IOException, JSONException {
+    void testMatrixParamsOnResourceMethodCustomName() throws IOException, JSONException {
         test("params.matrix-params-on-resource-method-custom-name.json",
                 MatrixParamsOnResourceMethodCustomNameTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testMatrixParamsOnMethodAndFieldArgs() throws IOException, JSONException {
+    void testMatrixParamsOnMethodAndFieldArgs() throws IOException, JSONException {
         test("params.matrix-params-on-method-and-field-args.json",
                 MatrixParamsOnMethodAndFieldArgsTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testAllTheParams() throws IOException, JSONException {
+    void testAllTheParams() throws IOException, JSONException {
         test("params.all-the-params.json",
                 AllTheParamsTestResource.class,
                 AllTheParamsTestResource.Bean.class,
@@ -174,7 +174,7 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testMultipartForm() throws IOException, JSONException {
+    void testMultipartForm() throws IOException, JSONException {
         test("params.multipart-form.json",
                 MultipartFormTestResource.class,
                 MultipartFormTestResource.Bean.class,
@@ -183,7 +183,7 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testEnumQueryParam() throws IOException, JSONException {
+    void testEnumQueryParam() throws IOException, JSONException {
         test("params.enum-form-param.json",
                 EnumQueryParamTestResource.class,
                 EnumQueryParamTestResource.TestEnum.class,
@@ -191,27 +191,27 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testUUIDQueryParam() throws IOException, JSONException {
+    void testUUIDQueryParam() throws IOException, JSONException {
         test("params.uuid-params-responses.json",
                 UUIDQueryParamTestResource.class,
                 UUIDQueryParamTestResource.WrappedUUID.class);
     }
 
     @Test
-    public void testRestEasyFieldsAndSetters() throws IOException, JSONException {
+    void testRestEasyFieldsAndSetters() throws IOException, JSONException {
         test("params.resteasy-fields-and-setters.json",
                 RestEasyFieldsAndSettersTestResource.class);
     }
 
     @Test
-    public void testCharSequenceArrayParam() throws IOException, JSONException {
+    void testCharSequenceArrayParam() throws IOException, JSONException {
         test("params.char-sequence-arrays.json",
                 CharSequenceArrayParamTestResource.class,
                 CharSequenceArrayParamTestResource.EchoResult.class);
     }
 
     @Test
-    public void testOptionalParam() throws IOException, JSONException {
+    void testOptionalParam() throws IOException, JSONException {
         test("params.optional-types.json",
                 OptionalParamTestResource.class,
                 OptionalParamTestResource.Bean.class,
@@ -223,36 +223,36 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testPathParamTemplateRegex() throws IOException, JSONException {
+    void testPathParamTemplateRegex() throws IOException, JSONException {
         test("params.path-param-templates.json",
                 PathParamTemplateRegexTestResource.class);
     }
 
     @Test
-    public void testPathSegmentMatrix() throws IOException, JSONException {
+    void testPathSegmentMatrix() throws IOException, JSONException {
         test("params.path-segment-param.json",
                 PathSegmentMatrixTestResource.class);
     }
 
     @Test
-    public void testParamNameOverride() throws IOException, JSONException {
+    void testParamNameOverride() throws IOException, JSONException {
         test("params.param-name-override.json",
                 ParamNameOverrideTestResource.class);
     }
 
     @Test
-    public void testCommonTargetMethodParameter() throws IOException, JSONException {
+    void testCommonTargetMethodParameter() throws IOException, JSONException {
         test("params.common-annotation-target-method.json", CommonTargetMethodParameterResource.class);
     }
 
     @Test
-    public void testRestEasyReactivePathParamOmitted() throws IOException, JSONException {
+    void testRestEasyReactivePathParamOmitted() throws IOException, JSONException {
         test("params.resteasy-reactive-missing-restpath.json", RestEasyReactivePathParamOmittedTestResource.class,
                 Widget.class);
     }
 
     @Test
-    public void testSerializedIndexParameterAnnotations() throws IOException, JSONException {
+    void testSerializedIndexParameterAnnotations() throws IOException, JSONException {
         Index i1 = indexOf(GreetResource.class, GreetResource.GreetingMessage.class);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IndexWriter writer = new IndexWriter(out);
@@ -266,17 +266,17 @@ public class ParameterScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testParameterRefOnly() throws IOException, JSONException {
+    void testParameterRefOnly() throws IOException, JSONException {
         test("params.parameter-ref-property.json", ParameterRefTestApplication.class, ParameterRefTestResource.class);
     }
 
     @Test
-    public void testDefaultEnumValue() throws IOException, JSONException {
+    void testDefaultEnumValue() throws IOException, JSONException {
         test("params.local-schema-attributes.json", DefaultEnumTestResource.class, DefaultEnumTestResource.MyEnum.class);
     }
 
     @Test
-    public void testGenericTypeVariableResource() throws IOException, JSONException {
+    void testGenericTypeVariableResource() throws IOException, JSONException {
         test("params.generic-type-variables.json", BaseGenericResource.class, BaseGenericResource.GenericBean.class,
                 IntegerStringUUIDResource.class);
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/RequestBodyScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/RequestBodyScanTests.java
@@ -17,9 +17,9 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartInput;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartRelatedInput;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RequestBodyScanTests extends IndexScannerTestBase {
+class RequestBodyScanTests extends IndexScannerTestBase {
 
     private static void test(String expectedResource, Class<?>... classes) throws IOException, JSONException {
         Index index = indexOf(classes);
@@ -30,33 +30,33 @@ public class RequestBodyScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResteasyMultipartInput() throws IOException, JSONException {
+    void testResteasyMultipartInput() throws IOException, JSONException {
         test("params.resteasy-multipart-mixed.json",
                 ResteasyMultipartInputTestResource.class);
     }
 
     @Test
-    public void testResteasyMultipartInputList() throws IOException, JSONException {
+    void testResteasyMultipartInputList() throws IOException, JSONException {
         test("params.resteasy-multipart-mixed-array.json",
                 ResteasyMultipartMixedListTestResource.class,
                 RequestBodyWidget.class);
     }
 
     @Test
-    public void testResteasyMultipartFormDataInput() throws IOException, JSONException {
+    void testResteasyMultipartFormDataInput() throws IOException, JSONException {
         test("params.resteasy-multipart-form-data-input.json",
                 ResteasyMultipartFormDataInputTestResource.class);
     }
 
     @Test
-    public void testResteasyMultipartFormDataMap() throws IOException, JSONException {
+    void testResteasyMultipartFormDataMap() throws IOException, JSONException {
         test("params.resteasy-multipart-form-data-map.json",
                 ResteasyMultipartFormDataMapTestResource.class,
                 RequestBodyWidget.class);
     }
 
     @Test
-    public void testResteasyMultipartRelatedInput() throws IOException, JSONException {
+    void testResteasyMultipartRelatedInput() throws IOException, JSONException {
         test("params.resteasy-multipart-related-input.json",
                 ResteasyMultipartRelatedInputTestResource.class);
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceInheritanceTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceInheritanceTests.java
@@ -21,14 +21,14 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexView;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class ResourceInheritanceTests extends JaxRsDataObjectScannerTestBase {
+class ResourceInheritanceTests extends JaxRsDataObjectScannerTestBase {
 
     /*
      * Test case derived from original example linked from Smallrye OpenAPI
@@ -39,7 +39,7 @@ public class ResourceInheritanceTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testInheritedResourceMethod() throws IOException, JSONException {
+    void testInheritedResourceMethod() throws IOException, JSONException {
         Index i = indexOf(GenericResource.class,
                 ExampleResource1.class,
                 ExampleResource2.class,

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ResourceParameterTests.java
@@ -52,7 +52,7 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexView;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +64,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.ParameterResource;
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
+class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
 
     /*
      * Test case derived from original example in Smallrye OpenAPI issue #25.
@@ -73,7 +73,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testParameterResource() throws IOException, JSONException {
+    void testParameterResource() throws IOException, JSONException {
         Index i = indexOf(ParameterResource.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(new HashMap<String, Object>()), i);
         OpenAPI result = scanner.scan();
@@ -88,7 +88,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testPrimitiveArraySchema() throws IOException, JSONException {
+    void testPrimitiveArraySchema() throws IOException, JSONException {
         Index i = indexOf(PrimitiveArraySchemaTestResource.class,
                 PrimitiveArraySchemaTestResource.PrimitiveArrayTestObject.class);
         OpenApiConfig config = emptyConfig();
@@ -123,7 +123,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
     /*************************************************************************/
 
     @Test
-    public void testPrimitiveArrayParameter() throws IOException, JSONException {
+    void testPrimitiveArrayParameter() throws IOException, JSONException {
         Index i = indexOf(PrimitiveArrayParameterTestResource.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(i, config);
@@ -149,7 +149,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
     /*************************************************************************/
 
     @Test
-    public void testPrimitiveArrayPolymorphism() throws IOException, JSONException {
+    void testPrimitiveArrayPolymorphism() throws IOException, JSONException {
         Index i = indexOf(PrimitiveArrayPolymorphismTestResource.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(i, config);
@@ -183,7 +183,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testSchemaImplementationType() throws IOException, JSONException {
+    void testSchemaImplementationType() throws IOException, JSONException {
         Index i = indexOf(SchemaImplementationTypeResource.class,
                 SchemaImplementationTypeResource.GreetingMessage.class,
                 SchemaImplementationTypeResource.SimpleString.class);
@@ -251,7 +251,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testTimeResource() throws IOException, JSONException {
+    void testTimeResource() throws IOException, JSONException {
         Index i = indexOf(TimeTestResource.class, TimeTestResource.UTC.class, LocalTime.class, OffsetTime.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(dynamicConfig(new HashMap<String, Object>()), i);
         OpenAPI result = scanner.scan();
@@ -302,7 +302,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testTypeVariableResponse() throws IOException, JSONException {
+    void testTypeVariableResponse() throws IOException, JSONException {
         Index i = indexOf(TypeVariableResponseTestResource.class,
                 TypeVariableResponseTestResource.Dto.class);
         OpenApiConfig config = emptyConfig();
@@ -341,7 +341,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testResponseTypeUnindexed() throws IOException, JSONException {
+    void testResponseTypeUnindexed() throws IOException, JSONException {
         // Index is intentionally missing ResponseTypeUnindexedTestResource$ThirdPartyType
         Index i = indexOf(ResponseTypeUnindexedTestResource.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
@@ -372,7 +372,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testGenericSetResponseWithSetIndexed() throws IOException, JSONException {
+    void testGenericSetResponseWithSetIndexed() throws IOException, JSONException {
         Index i = indexOf(FruitResource.class, Fruit.class, Seed.class, Set.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
         OpenAPI result = scanner.scan();
@@ -381,7 +381,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testGenericSetResponseWithSetIndexedWithoutArrayRefs() throws IOException, JSONException {
+    void testGenericSetResponseWithSetIndexedWithoutArrayRefs() throws IOException, JSONException {
         Index i = indexOf(FruitResource.class, Fruit.class, Seed.class, Set.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(
                 dynamicConfig(OpenApiConstants.SMALLRYE_ARRAY_REFERENCES_ENABLE,
@@ -393,7 +393,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testGenericSetResponseWithSetUnindexed() throws IOException, JSONException {
+    void testGenericSetResponseWithSetUnindexed() throws IOException, JSONException {
         Index i = indexOf(FruitResource.class, Fruit.class, Seed.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
         OpenAPI result = scanner.scan();
@@ -441,7 +441,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      *
      */
     @Test
-    public void testBeanParamMultipartFormInheritance() throws IOException, JSONException {
+    void testBeanParamMultipartFormInheritance() throws IOException, JSONException {
         Index i = indexOf(BeanParamMultipartFormInheritanceResource.class,
                 MultipartFormVerify.class,
                 MultipartFormUploadIconForm.class,
@@ -516,7 +516,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      */
 
     @Test
-    public void testMethodTargetParametersWithoutJAXRS() throws IOException, JSONException {
+    void testMethodTargetParametersWithoutJAXRS() throws IOException, JSONException {
         Index i = indexOf(MethodTargetParametersResource.class,
                 MethodTargetParametersResource.PagedResponse.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
@@ -590,7 +590,7 @@ public class ResourceParameterTests extends JaxRsDataObjectScannerTestBase {
      */
 
     @Test
-    public void testJsonbTransientOnSetterGeneratesReadOnly() throws IOException, JSONException {
+    void testJsonbTransientOnSetterGeneratesReadOnly() throws IOException, JSONException {
         Index i = indexOf(Policy437Resource.class, Policy437.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), i);
         OpenAPI result = scanner.scan();

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/RolesAllowedScopeScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/RolesAllowedScopeScanTests.java
@@ -1,9 +1,9 @@
 package io.smallrye.openapi.runtime.scanner;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,14 +31,14 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexView;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 
-public class RolesAllowedScopeScanTests extends IndexScannerTestBase {
+class RolesAllowedScopeScanTests extends IndexScannerTestBase {
 
     @Test
-    public void testClassRolesAllowedGeneratedScheme() throws IOException {
+    void testClassRolesAllowedGeneratedScheme() throws IOException {
         Index index = indexOf(RolesAllowedApp.class, RolesAllowedResource1.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(index, config);
@@ -61,7 +61,7 @@ public class RolesAllowedScopeScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testPermitAllWithoutGeneratedScheme() throws IOException {
+    void testPermitAllWithoutGeneratedScheme() throws IOException {
         Index index = indexOf(RolesAllowedApp.class, RolesAllowedResource1.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(index, config);
@@ -72,7 +72,7 @@ public class RolesAllowedScopeScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testGeneratedSchemeEmptyRoles() throws IOException {
+    void testGeneratedSchemeEmptyRoles() throws IOException {
         Index index = indexOf(RolesAllowedApp.class, RolesAllowedResource1.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(index, config);
@@ -85,7 +85,7 @@ public class RolesAllowedScopeScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testMethodRolesAllowedGeneratedScheme() throws IOException {
+    void testMethodRolesAllowedGeneratedScheme() throws IOException {
         Index index = indexOf(RolesAllowedApp.class, RolesAllowedResource2.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(index, config);
@@ -109,7 +109,7 @@ public class RolesAllowedScopeScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testNoEligibleScheme() throws IOException {
+    void testNoEligibleScheme() throws IOException {
         Index index = indexOf(RolesNotAllowedApp.class, RolesAllowedResource1.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(index, config);
@@ -121,7 +121,7 @@ public class RolesAllowedScopeScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDeclaredRolesMethodRolesAllowedGeneratedScheme() throws IOException {
+    void testDeclaredRolesMethodRolesAllowedGeneratedScheme() throws IOException {
         Index index = indexOf(RolesAllowedApp.class, RolesDeclaredResource.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(index, config);
@@ -150,7 +150,7 @@ public class RolesAllowedScopeScanTests extends IndexScannerTestBase {
      *
      */
     @Test
-    public void testSchemesWithoutRoles() throws IOException {
+    void testSchemesWithoutRoles() throws IOException {
         Index index = indexOf(UndeclaredFlowsNoRolesAllowedApp.class, NoRolesResource.class);
         OpenApiConfig config = emptyConfig();
         IndexView filtered = new FilteredIndexView(index, config);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
@@ -1,6 +1,6 @@
 package io.smallrye.openapi.runtime.scanner;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -12,7 +12,7 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.models.media.SchemaImpl;
 import io.smallrye.openapi.api.util.ClassLoaderUtil;
@@ -24,12 +24,12 @@ import io.smallrye.openapi.runtime.util.ModelUtil;
  * @author Michael Edgar {@literal <michael@xlate.io>}
  *
  */
-public class SchemaRegistryTests extends IndexScannerTestBase {
+class SchemaRegistryTests extends IndexScannerTestBase {
 
     SchemaRegistry registry;
 
     @Test
-    public void testParameterizedNameCollisionsUseSequence() throws IOException, JSONException {
+    void testParameterizedNameCollisionsUseSequence() throws IOException, JSONException {
         Index index = indexOf(Container.class, Nestable.class);
         AnnotationScannerContext context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(),
                 emptyConfig());
@@ -52,7 +52,7 @@ public class SchemaRegistryTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testWildcardLowerBoundName() throws IOException, JSONException {
+    void testWildcardLowerBoundName() throws IOException, JSONException {
         Indexer indexer = new Indexer();
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
@@ -71,7 +71,7 @@ public class SchemaRegistryTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testWildcardUpperBoundName() throws IOException, JSONException {
+    void testWildcardUpperBoundName() throws IOException, JSONException {
         Indexer indexer = new Indexer();
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
@@ -90,7 +90,7 @@ public class SchemaRegistryTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testWildcardWithGivenName() throws IOException, JSONException {
+    void testWildcardWithGivenName() throws IOException, JSONException {
         Indexer indexer = new Indexer();
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");
@@ -110,7 +110,7 @@ public class SchemaRegistryTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testNestedGenericWildcard() throws IOException, JSONException {
+    void testNestedGenericWildcard() throws IOException, JSONException {
         Indexer indexer = new Indexer();
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Container.class");
         index(indexer, "io/smallrye/openapi/runtime/scanner/SchemaRegistryTests$Nestable.class");

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SpecialCaseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SpecialCaseTests.java
@@ -5,73 +5,33 @@ import java.io.IOException;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.Type;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.SpecialCaseTestContainer;
 
 /**
  * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
  */
-public class SpecialCaseTests extends JaxRsDataObjectScannerTestBase {
+class SpecialCaseTests extends JaxRsDataObjectScannerTestBase {
 
-    @Test
-    public void testCollection_SimpleTerminalType() throws IOException, JSONException {
+    @ParameterizedTest
+    @CsvSource({
+            "SimpleTerminalType, listOfString, special.simple.expected.json",
+            "DataObjectList, ccList, special.dataObjectList.expected.json",
+            "WildcardWithSuperBound, listSuperFlight, special.wildcardWithSuperBound.expected.json",
+            "WildcardWithExtendBound, listExtendsFoo, special.wildcardWithExtendBound.expected.json",
+            "Wildcard, listOfAnything, special.wildcard.expected.json"
+    })
+    void testCollection(String label, String field, String expectedResource) throws IOException, JSONException {
         String name = SpecialCaseTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "listOfString").type();
+        Type pType = getFieldFromKlazz(name, field).type();
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
 
         Schema result = scanner.process();
 
         printToConsole(name, result);
-        assertJsonEquals(name, "special.simple.expected.json", result);
-    }
-
-    @Test
-    public void testCollection_DataObjectList() throws IOException, JSONException {
-        String name = SpecialCaseTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "ccList").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "special.dataObjectList.expected.json", result);
-    }
-
-    @Test
-    public void testCollection_WildcardWithSuperBound() throws IOException, JSONException {
-        String name = SpecialCaseTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "listSuperFlight").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "special.wildcardWithSuperBound.expected.json", result);
-    }
-
-    @Test
-    public void testCollection_WildcardWithExtendBound() throws IOException, JSONException {
-        String name = SpecialCaseTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "listExtendsFoo").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "special.wildcardWithExtendBound.expected.json", result);
-    }
-
-    @Test
-    public void testCollection_Wildcard() throws IOException, JSONException {
-        String name = SpecialCaseTestContainer.class.getName();
-        Type pType = getFieldFromKlazz(name, "listOfAnything").type();
-        OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, pType);
-
-        Schema result = scanner.process();
-
-        printToConsole(name, result);
-        assertJsonEquals(name, "special.wildcard.expected.json", result);
+        assertJsonEquals(name, expectedResource, result);
     }
 
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SubresourceScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SubresourceScanTests.java
@@ -22,9 +22,9 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SubresourceScanTests extends IndexScannerTestBase {
+class SubresourceScanTests extends IndexScannerTestBase {
 
     private static void test(String expectedResource, Class<?>... classes) throws IOException, JSONException {
         Index index = indexOf(classes);
@@ -35,7 +35,7 @@ public class SubresourceScanTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testResteasyMultipartInput() throws IOException, JSONException {
+    void testResteasyMultipartInput() throws IOException, JSONException {
         test("resource.subresources-with-params.json",
                 MainTestResource.class, Sub1TestResource.class, Sub2TestResource.class, RecursiveLocatorResource.class);
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/VersionTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/VersionTest.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfigImpl;
@@ -23,7 +23,7 @@ import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetResource;
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class VersionTest extends JaxRsDataObjectScannerTestBase {
+class VersionTest extends JaxRsDataObjectScannerTestBase {
 
     private static final String VERSION_PROPERTY = "mp.openapi.extensions.smallrye.openapi";
 
@@ -34,7 +34,7 @@ public class VersionTest extends JaxRsDataObjectScannerTestBase {
      * @throws org.json.JSONException
      */
     @Test
-    public void testSettingViaProvidedSchema() throws IOException, JSONException {
+    void testSettingViaProvidedSchema() throws IOException, JSONException {
         Index i = indexOf(GreetingGetResource.class, Greeting.class);
         OpenAPI result = OpenApiProcessor.bootstrap(emptyConfig(), i, loadStaticFile());
 
@@ -43,7 +43,7 @@ public class VersionTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testSettingViaConfig() throws IOException, JSONException {
+    void testSettingViaConfig() throws IOException, JSONException {
         System.setProperty(VERSION_PROPERTY, "3.0.0");
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
@@ -60,7 +60,7 @@ public class VersionTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    public void testSettingViaConfigWhenStaticPresent() throws IOException, JSONException {
+    void testSettingViaConfigWhenStaticPresent() throws IOException, JSONException {
         System.setProperty(VERSION_PROPERTY, "3.0.0");
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationResourceTest.java
@@ -24,7 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
 import io.smallrye.openapi.runtime.scanner.OpenApiAnnotationScanner;
@@ -33,10 +33,10 @@ import io.smallrye.openapi.runtime.scanner.dataobject.BeanValidationScannerTest.
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class BeanValidationResourceTest extends IndexScannerTestBase {
+class BeanValidationResourceTest extends IndexScannerTestBase {
 
     @Test
-    public void testBeanValidationDocument() throws IOException, JSONException {
+    void testBeanValidationDocument() throws IOException, JSONException {
         Index index = indexOf(BVTestResource.class, BVTestResourceEntity.class, BeanValidationScannerTest.BVTestContainer.class,
                 TestEnum.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
@@ -46,7 +46,7 @@ public class BeanValidationResourceTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testInheritedBVConstraints() throws IOException, JSONException {
+    void testInheritedBVConstraints() throws IOException, JSONException {
         Index index = indexOf(User.class, BaseUser.class, UserImpl.class);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
         OpenAPI result = scanner.scan();

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.java
@@ -1,9 +1,9 @@
 package io.smallrye.openapi.runtime.scanner.dataobject;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -35,8 +35,8 @@ import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.models.media.SchemaImpl;
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
@@ -44,7 +44,7 @@ import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class BeanValidationScannerTest extends IndexScannerTestBase {
+class BeanValidationScannerTest extends IndexScannerTestBase {
 
     BeanValidationScanner testTarget;
     Index index;
@@ -52,8 +52,8 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     Schema schema;
     ClassInfo targetClass;
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         testTarget = BeanValidationScanner.INSTANCE;
         index = indexOf(BVTestContainer.class);
         methodsInvoked.clear();
@@ -78,19 +78,19 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testNullSchemaIgnored() {
+    void testNullSchemaIgnored() {
         BeanValidationScanner.applyConstraints(targetClass,
                 proxySchema(schema, methodsInvoked),
                 null,
                 null);
 
-        assertArrayEquals("Unexpected methods were invoked",
-                new String[] { "getType" },
-                methodsInvoked.toArray());
+        assertArrayEquals(new String[] { "getType" },
+                methodsInvoked.toArray(),
+                "Unexpected methods were invoked");
     }
 
     @Test
-    public void testRefSchemaIgnored() {
+    void testRefSchemaIgnored() {
         schema.setType(SchemaType.OBJECT);
         schema.setRef("#/components/schemas/Anything");
         BeanValidationScanner.applyConstraints(targetClass,
@@ -98,15 +98,15 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
                 null,
                 null);
 
-        assertArrayEquals("Unexpected methods were invoked",
-                new String[] { "getType", "getRef" },
-                methodsInvoked.toArray());
+        assertArrayEquals(new String[] { "getType", "getRef" },
+                methodsInvoked.toArray(),
+                "Unexpected methods were invoked");
     }
 
     /**********************************************************************/
 
     @Test
-    public void testArrayListNotNullAndNotEmptyAndMaxItems() {
+    void testArrayListNotNullAndNotEmptyAndMaxItems() {
         FieldInfo targetField = targetClass.field("arrayListNotNullAndNotEmptyAndMaxItems");
         Schema parentSchema = new SchemaImpl();
         String propertyKey = "TESTKEY";
@@ -124,7 +124,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testArrayListNullableAndMinItemsAndMaxItems() {
+    void testArrayListNullableAndMinItemsAndMaxItems() {
         FieldInfo targetField = targetClass.field("arrayListNullableAndMinItemsAndMaxItems");
         Schema parentSchema = new SchemaImpl();
         String propertyKey = "TESTKEY";
@@ -144,7 +144,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     /**********************************************************************/
 
     @Test
-    public void testMapObjectNotNullAndNotEmptyAndMaxProperties() {
+    void testMapObjectNotNullAndNotEmptyAndMaxProperties() {
         schema.setAdditionalPropertiesBoolean(Boolean.TRUE);
 
         FieldInfo targetField = targetClass.field("mapObjectNotNullAndNotEmptyAndMaxProperties");
@@ -164,7 +164,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testMapObjectNullableAndMinPropertiesAndMaxProperties() {
+    void testMapObjectNullableAndMinPropertiesAndMaxProperties() {
         schema.setAdditionalPropertiesBoolean(Boolean.TRUE);
 
         FieldInfo targetField = targetClass.field("mapObjectNullableAndMinPropertiesAndMaxProperties");
@@ -184,7 +184,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testMapObjectNullableNoAdditionalProperties() {
+    void testMapObjectNullableNoAdditionalProperties() {
         FieldInfo targetField = targetClass.field("mapObjectNullableAndMinPropertiesAndMaxProperties");
         Schema parentSchema = new SchemaImpl();
         String propertyKey = "TESTKEY";
@@ -204,7 +204,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     /**********************************************************************/
 
     @Test
-    public void testDecimalMaxPrimaryDigits() {
+    void testDecimalMaxPrimaryDigits() {
         FieldInfo targetField = targetClass.field("decimalMaxBigDecimalPrimaryDigits");
         testTarget.decimalMax(targetField, schema);
         testTarget.digits(targetField, schema);
@@ -215,21 +215,21 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDecimalMaxNoConstraint() {
+    void testDecimalMaxNoConstraint() {
         testTarget.decimalMax(targetClass.field("decimalMaxBigDecimalNoConstraint"), schema);
         assertEquals(null, schema.getMaximum());
         assertEquals(null, schema.getExclusiveMaximum());
     }
 
     @Test
-    public void testDecimalMaxInvalidValue() {
+    void testDecimalMaxInvalidValue() {
         testTarget.decimalMax(targetClass.field("decimalMaxBigDecimalInvalidValue"), schema);
         assertEquals(null, schema.getMaximum());
         assertEquals(null, schema.getExclusiveMaximum());
     }
 
     @Test
-    public void testDecimalMaxExclusiveDigits() {
+    void testDecimalMaxExclusiveDigits() {
         FieldInfo targetField = targetClass.field("decimalMaxBigDecimalExclusiveDigits");
         testTarget.decimalMax(targetField, schema);
         testTarget.digits(targetField, schema);
@@ -239,7 +239,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDecimalMaxInclusive() {
+    void testDecimalMaxInclusive() {
         testTarget.decimalMax(targetClass.field("decimalMaxBigDecimalInclusive"), schema);
         assertEquals(new BigDecimal("201.00"), schema.getMaximum());
         assertEquals(null, schema.getExclusiveMaximum());
@@ -248,28 +248,28 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     /**********************************************************************/
 
     @Test
-    public void testDecimalMinPrimary() {
+    void testDecimalMinPrimary() {
         testTarget.decimalMin(targetClass.field("decimalMinBigDecimalPrimary"), schema);
         assertEquals(new BigDecimal("10.0"), schema.getMinimum());
         assertEquals(null, schema.getExclusiveMinimum());
     }
 
     @Test
-    public void testDecimalMinNoConstraint() {
+    void testDecimalMinNoConstraint() {
         testTarget.decimalMin(targetClass.field("decimalMinBigDecimalNoConstraint"), schema);
         assertEquals(null, schema.getMinimum());
         assertEquals(null, schema.getExclusiveMinimum());
     }
 
     @Test
-    public void testDecimalMinInvalidValue() {
+    void testDecimalMinInvalidValue() {
         testTarget.decimalMin(targetClass.field("decimalMinBigDecimalInvalidValue"), schema);
         assertEquals(null, schema.getMinimum());
         assertEquals(null, schema.getExclusiveMinimum());
     }
 
     @Test
-    public void testDecimalMinExclusiveDigits() {
+    void testDecimalMinExclusiveDigits() {
         FieldInfo targetField = targetClass.field("decimalMinBigDecimalExclusiveDigits");
         testTarget.decimalMin(targetField, schema);
         testTarget.digits(targetField, schema);
@@ -280,7 +280,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testDecimalMinInclusive() {
+    void testDecimalMinInclusive() {
         testTarget.decimalMin(targetClass.field("decimalMinBigDecimalInclusive"), schema);
         assertEquals(new BigDecimal("9.00"), schema.getMinimum());
         assertEquals(null, schema.getExclusiveMinimum());
@@ -289,7 +289,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     /**********************************************************************/
 
     @Test
-    public void testIntegerPositiveNotZeroMaxValue() {
+    void testIntegerPositiveNotZeroMaxValue() {
         FieldInfo targetField = targetClass.field("integerPositiveNotZeroMaxValue");
         testTarget.max(targetField, schema);
         testTarget.positive(targetField, schema);
@@ -301,7 +301,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIntegerPositiveNotZeroMaxValueExclusive() {
+    void testIntegerPositiveNotZeroMaxValueExclusive() {
         FieldInfo targetField = targetClass.field("integerPositiveNotZeroMaxValue");
         schema.setExclusiveMaximum(Boolean.TRUE);
         schema.setExclusiveMinimum(Boolean.TRUE);
@@ -316,7 +316,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIntegerPositiveOrZeroMaxValue() {
+    void testIntegerPositiveOrZeroMaxValue() {
         FieldInfo targetField = targetClass.field("integerPositiveOrZeroMaxValue");
         testTarget.max(targetField, schema);
         testTarget.positiveOrZero(targetField, schema);
@@ -328,7 +328,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIntegerPositiveOrZeroMaxValueExclusive() {
+    void testIntegerPositiveOrZeroMaxValueExclusive() {
         FieldInfo targetField = targetClass.field("integerPositiveOrZeroMaxValue");
         schema.setExclusiveMaximum(Boolean.TRUE);
         schema.setExclusiveMinimum(Boolean.TRUE);
@@ -345,7 +345,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     /**********************************************************************/
 
     @Test
-    public void testIntegerNegativeNotZeroMinValue() {
+    void testIntegerNegativeNotZeroMinValue() {
         FieldInfo targetField = targetClass.field("integerNegativeNotZeroMinValue");
         testTarget.min(targetField, schema);
         testTarget.negative(targetField, schema);
@@ -357,7 +357,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIntegerNegativeNotZeroMinValueExclusive() {
+    void testIntegerNegativeNotZeroMinValueExclusive() {
         FieldInfo targetField = targetClass.field("integerNegativeNotZeroMinValue");
         schema.setExclusiveMaximum(Boolean.TRUE);
         schema.setExclusiveMinimum(Boolean.TRUE);
@@ -372,7 +372,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIntegerNegativeOrZeroMinValue() {
+    void testIntegerNegativeOrZeroMinValue() {
         FieldInfo targetField = targetClass.field("integerNegativeOrZeroMinValue");
         testTarget.min(targetField, schema);
         testTarget.negativeOrZero(targetField, schema);
@@ -384,7 +384,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIntegerNegativeOrZeroMinValueExclusive() {
+    void testIntegerNegativeOrZeroMinValueExclusive() {
         FieldInfo targetField = targetClass.field("integerNegativeOrZeroMinValue");
         schema.setExclusiveMaximum(Boolean.TRUE);
         schema.setExclusiveMinimum(Boolean.TRUE);
@@ -401,7 +401,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     /**********************************************************************/
 
     @Test
-    public void testStringNotBlankNotNull() {
+    void testStringNotBlankNotNull() {
         FieldInfo targetField = targetClass.field("stringNotBlankNotNull");
         Schema parentSchema = new SchemaImpl();
         String propertyKey = "TESTKEY";
@@ -417,7 +417,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testStringNotBlankDigits() {
+    void testStringNotBlankDigits() {
         FieldInfo targetField = targetClass.field("stringNotBlankDigits");
 
         testTarget.digits(targetField, schema);
@@ -428,7 +428,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testStringNotEmptyMaxSize() {
+    void testStringNotEmptyMaxSize() {
         FieldInfo targetField = targetClass.field("stringNotEmptyMaxSize");
 
         testTarget.sizeString(targetField, schema);
@@ -440,7 +440,7 @@ public class BeanValidationScannerTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testStringNotEmptySizeRange() {
+    void testStringNotEmptySizeRange() {
         FieldInfo targetField = targetClass.field("stringNotEmptySizeRange");
 
         testTarget.sizeString(targetField, schema);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -1,10 +1,10 @@
 package io.smallrye.openapi.runtime.scanner.dataobject;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -25,7 +25,7 @@ import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.runtime.io.schema.SchemaConstant;
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
@@ -34,10 +34,10 @@ import io.smallrye.openapi.runtime.util.TypeUtil;
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>}
  */
-public class TypeResolverTests extends IndexScannerTestBase {
+class TypeResolverTests extends IndexScannerTestBase {
 
     @Test
-    public void testAnnotatedMethodOverridesParentSchema() {
+    void testAnnotatedMethodOverridesParentSchema() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(AbstractAnimal.class,
                 Feline.class,
                 Cat.class));
@@ -57,7 +57,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testAnnotatedFieldsOverridesInterfaceSchema() {
+    void testAnnotatedFieldsOverridesInterfaceSchema() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(AbstractAnimal.class,
                 Feline.class,
                 Cat.class));
@@ -74,7 +74,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testAnnotatedInterfaceMethodOverridesImplMethod() {
+    void testAnnotatedInterfaceMethodOverridesImplMethod() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(AbstractAnimal.class,
                 Canine.class,
                 Dog.class));
@@ -95,7 +95,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testAnnotatedInterfaceMethodOverridesStaticField() {
+    void testAnnotatedInterfaceMethodOverridesStaticField() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(AbstractAnimal.class,
                 Reptile.class,
                 Lizard.class));
@@ -118,7 +118,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testBareInterface() {
+    void testBareInterface() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(MySchema.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(MySchema.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -149,7 +149,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testJacksonPropertyOrderDefault() {
+    void testJacksonPropertyOrderDefault() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(JacksonPropertyOrderDefault.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(JacksonPropertyOrderDefault.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -162,7 +162,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testJacksonPropertyOrderCustomName() {
+    void testJacksonPropertyOrderCustomName() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(JacksonPropertyOrderCustomName.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(JacksonPropertyOrderCustomName.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -176,7 +176,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testJaxbCustomPropertyOrder() {
+    void testJaxbCustomPropertyOrder() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(JaxbCustomPropertyOrder.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(JaxbCustomPropertyOrder.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -191,7 +191,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testNonJavaBeansPropertyAccessor() {
+    void testNonJavaBeansPropertyAccessor() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(NonJavaBeanAccessorProperty.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(NonJavaBeanAccessorProperty.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -208,7 +208,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testNonJavaBeansPropertyMutator() {
+    void testNonJavaBeansPropertyMutator() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(NonJavaBeanMutatorProperty.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(NonJavaBeanMutatorProperty.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -225,7 +225,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testOneSidedPropertiesHidden() {
+    void testOneSidedPropertiesHidden() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(OneSidedProperties.class, OneSidedParent.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(OneSidedProperties.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -256,7 +256,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testXmlAccessTransientField() {
+    void testXmlAccessTransientField() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(XmlTransientField.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(XmlTransientField.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -273,7 +273,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testXmlAccessTransientClass() {
+    void testXmlAccessTransientClass() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(XmlTransientClass.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(XmlTransientClass.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -296,7 +296,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testXmlAccessPublicMember() {
+    void testXmlAccessPublicMember() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(XmlAccessTypePublicMember.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(XmlAccessTypePublicMember.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -319,7 +319,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testXmlAccessTypeFieldOnly() {
+    void testXmlAccessTypeFieldOnly() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(XmlAccessTypeFieldOnly.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(XmlAccessTypeFieldOnly.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);
@@ -338,7 +338,7 @@ public class TypeResolverTests extends IndexScannerTestBase {
     }
 
     @Test
-    public void testXmlAccessTypePropertyOnly() {
+    void testXmlAccessTypePropertyOnly() {
         AugmentedIndexView index = AugmentedIndexView.augment(indexOf(XmlAccessTypePropertyOnly.class));
         ClassInfo leafKlazz = index.getClassByName(componentize(XmlAccessTypePropertyOnly.class.getName()));
         Type leaf = Type.create(leafKlazz.name(), Type.Kind.CLASS);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/util/JandexUtilTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/util/JandexUtilTests.java
@@ -1,6 +1,6 @@
 package io.smallrye.openapi.runtime.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 
@@ -14,15 +14,15 @@ import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
 import io.smallrye.openapi.runtime.util.JandexUtil.RefType;
 
-public class JandexUtilTests {
+class JandexUtilTests {
 
     @Test
-    public void testEnumValue() {
+    void testEnumValue() {
         Index index = IndexScannerTestBase.indexOf(Implementor2.class);
         ClassInfo clazz = index.getClassByName(DotName.createSimple(Implementor2.class.getName()));
         AnnotationInstance annotation = clazz.method("getData")
@@ -36,7 +36,7 @@ public class JandexUtilTests {
     }
 
     @Test
-    public void testRefValueWithHttpUrl() {
+    void testRefValueWithHttpUrl() {
         String ref = "https://www.example.com/openapi";
         AnnotationInstance annotation = AnnotationInstance.create(DotName.createSimple(""),
                 null,
@@ -46,7 +46,7 @@ public class JandexUtilTests {
     }
 
     @Test
-    public void testRefValueWithRelativeUrl() {
+    void testRefValueWithRelativeUrl() {
         String ref = "./additional-schemas.json";
         AnnotationInstance annotation = AnnotationInstance.create(DotName.createSimple(""),
                 null,
@@ -56,7 +56,7 @@ public class JandexUtilTests {
     }
 
     @Test
-    public void testRefValueWithValidLinkName() {
+    void testRefValueWithValidLinkName() {
         String ref = "L1nk.T0_Something-Useful";
         AnnotationInstance annotation = AnnotationInstance.create(DotName.createSimple(""),
                 null,
@@ -67,7 +67,7 @@ public class JandexUtilTests {
 
     // TODO: Re implement this maybe ?
     //    @Test
-    //    public void testGetJaxRsResourceClasses() {
+    //    void testGetJaxRsResourceClasses() {
     //        Index index = IndexScannerTestBase.indexOf(I1.class, I2.class, Implementor1.class, Implementor2.class);
     //        Collection<ClassInfo> resources = JandexUtil.getJaxRsResourceClasses(index);
     //        assertEquals(3, resources.size());

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/util/TypeUtilTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/util/TypeUtilTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.openapi.runtime.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -11,21 +11,21 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.util.ClassLoaderUtil;
 import io.smallrye.openapi.runtime.scanner.IndexScannerTestBase;
 import io.smallrye.openapi.runtime.scanner.OpenApiDataObjectScanner;
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 
-public class TypeUtilTest extends IndexScannerTestBase {
+class TypeUtilTest extends IndexScannerTestBase {
 
     private static final Type TYPE_COLLECTION = OpenApiDataObjectScanner.COLLECTION_TYPE;
     private static final Type TYPE_ENUM = OpenApiDataObjectScanner.ENUM_TYPE;
     private static final Type TYPE_MAP = OpenApiDataObjectScanner.MAP_TYPE;
 
     @Test
-    public void testIsA_BothIndexed() {
+    void testIsA_BothIndexed() {
         final Class<?> subjectClass = ArrayCollection.class;
         Index index = indexOf(subjectClass, Collection.class);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
@@ -34,7 +34,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_SubjectIndexed() {
+    void testIsA_SubjectIndexed() {
         final Class<?> subjectClass = ArrayCollection.class;
         Index index = indexOf(subjectClass);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
@@ -43,7 +43,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_ObjectIndexed() {
+    void testIsA_ObjectIndexed() {
         final Class<?> subjectClass = ArrayCollection.class;
         Index index = indexOf(Collection.class);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
@@ -52,7 +52,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_IndexedSubjectImplementsObject() {
+    void testIsA_IndexedSubjectImplementsObject() {
         final Class<?> subjectClass = CustomCollection.class;
         Index index = indexOf(subjectClass);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
@@ -61,7 +61,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_IndexedSubjectImplementsOther() {
+    void testIsA_IndexedSubjectImplementsOther() {
         final Class<?> subjectClass = CustomMap.class;
         Index index = indexOf(subjectClass);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
@@ -70,7 +70,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_IndexedSubjectExtendsUnindexedCollection() {
+    void testIsA_IndexedSubjectExtendsUnindexedCollection() {
         final Class<?> subjectClass = ChildCollection.class;
         Index index = indexOf(subjectClass);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
@@ -79,7 +79,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_IndexedSubjectUnrelatedToObject() {
+    void testIsA_IndexedSubjectUnrelatedToObject() {
         final Class<?> subjectClass = UnrelatedType.class;
         Index index = indexOf(subjectClass);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
@@ -88,7 +88,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_UnindexedPrimitiveSubjectUnrelatedToObject() {
+    void testIsA_UnindexedPrimitiveSubjectUnrelatedToObject() {
         final Class<?> subjectClass = int.class;
         Index index = indexOf();
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.PRIMITIVE);
@@ -97,7 +97,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_UnindexedPrimitiveWrapperSubjectUnrelatedToObject() {
+    void testIsA_UnindexedPrimitiveWrapperSubjectUnrelatedToObject() {
         final Class<?> subjectClass = Integer.class;
         final DotName subjectName = DotName.createSimple(subjectClass.getName());
         Index index = indexOf();
@@ -107,7 +107,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_SubjectIsJavaLangObject() {
+    void testIsA_SubjectIsJavaLangObject() {
         final Class<?> subjectClass = Object.class;
         Index index = indexOf(subjectClass);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);
@@ -116,7 +116,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_SubjectSameAsObject() {
+    void testIsA_SubjectSameAsObject() {
         final Class<?> subjectClass = MapContainer.class;
         final DotName subjectName = DotName.createSimple(subjectClass.getName());
         Index index = indexOf(subjectClass);
@@ -127,7 +127,7 @@ public class TypeUtilTest extends IndexScannerTestBase {
     }
 
     @Test
-    public void testIsA_SubjectSuperSameAsObject() {
+    void testIsA_SubjectSuperSameAsObject() {
         final Class<?> subjectClass = TestEnum.class;
         Index index = indexOf(subjectClass);
         Type testSubject = Type.create(DotName.createSimple(subjectClass.getName()), Type.Kind.CLASS);

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types.json
@@ -46,7 +46,10 @@
             "name": "orderby",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/ListString"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -172,7 +175,10 @@
             "name": "orderby",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/ListString"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -282,7 +288,10 @@
             "name": "orderby",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/ListString"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -429,12 +438,6 @@
           }
         }
       },
-      "ListString": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
       "Message": {
         "type": "object",
         "properties": {
@@ -446,12 +449,6 @@
           }
         }
       },
-      "ListKingCrimson": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/KingCrimson"
-        }
-      },
       "ResultListKingCrimson": {
         "type": "object",
         "properties": {
@@ -459,18 +456,15 @@
             "$ref": "#/components/schemas/Message"
           },
           "result": {
-            "$ref": "#/components/schemas/ListKingCrimson"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KingCrimson"
+            }
           },
           "status": {
             "format": "int32",
             "type": "integer"
           }
-        }
-      },
-      "ListPOJO": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/POJO"
         }
       },
       "ResultListPOJO": {
@@ -480,7 +474,10 @@
             "$ref": "#/components/schemas/Message"
           },
           "result": {
-            "$ref": "#/components/schemas/ListPOJO"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/POJO"
+            }
           },
           "status": {
             "format": "int32",
@@ -503,12 +500,6 @@
           }
         }
       },
-      "ListMagma": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Magma"
-        }
-      },
       "ResultListMagma": {
         "type": "object",
         "properties": {
@@ -516,7 +507,10 @@
             "$ref": "#/components/schemas/Message"
           },
           "result": {
-            "$ref": "#/components/schemas/ListMagma"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Magma"
+            }
           },
           "status": {
             "format": "int32",
@@ -559,12 +553,6 @@
           }
         }
       },
-      "ListResidents": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Residents"
-        }
-      },
       "ResultListResidents": {
         "type": "object",
         "properties": {
@@ -572,7 +560,10 @@
             "$ref": "#/components/schemas/Message"
           },
           "result": {
-            "$ref": "#/components/schemas/ListResidents"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Residents"
+            }
           },
           "status": {
             "format": "int32",

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.generic-collection.set-indexed.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.generic-collection.set-indexed.json
@@ -9,7 +9,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SetFruit"
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Fruit"
+                  }
                 }
               }
             }
@@ -32,7 +36,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SetFruit"
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Fruit"
+                  }
                 }
               }
             }
@@ -55,7 +63,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SetFruit"
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Fruit"
+                  }
                 }
               }
             }
@@ -84,13 +96,6 @@
               "$ref": "#/components/schemas/Seed"
             }
           }
-        }
-      },
-      "SetFruit": {
-        "type": "array",
-        "uniqueItems": true,
-        "items": {
-          "$ref": "#/components/schemas/Fruit"
         }
       }
     }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.nested-parameterized-collection-types.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.nested-parameterized-collection-types.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/map": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultivaluedMapStringMapStringCustomRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultivaluedMapStringMapStringCustomResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MultivaluedMapStringMapStringCustomRequest": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CustomRequest"
+            }
+          }
+        }
+      },
+      "CustomRequest": {
+        "type": "object",
+        "properties": {
+          "requestName": {
+            "type": "string"
+          }
+        }
+      },
+      "MultivaluedMapStringMapStringCustomResponse": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CustomResponse"
+            }
+          }
+        }
+      },
+      "CustomResponse": {
+        "type": "object",
+        "properties": {
+          "responseName": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #688 
Relates to quarkusio/quarkus#14814

Changes behaviour to prevent the registration of known JDK collection types in `#/components/schemas`. This means that schemas previously generated such as `ListString` or `MapStringCustomBean` for types `List<String>` or `Map<String, CustomBean>` will instead be in-lined as array types. When the generic type argument for the collections are eligible for registration, they will still be referenced from the in-lined schemas from `items` for arrays or `additionalProperties` for objects.

Also addressed in an bug that allows for unintentional side affects during scanning when `Class.forName` is called during the inheritance check for classes absent from the Jandex index.

This still needs a bit of work to re-factor some of the added code to `TypeProcessor` that really belongs in `TypeResolver`.