### PR TITLE
SchemaProperty negative tests

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -155,10 +155,10 @@ public class SchemaFactory {
         schema.setTitle(readAttr(annotation, SchemaConstant.PROP_TITLE, defaults));
         schema.setMultipleOf(SchemaFactory.<Double, BigDecimal> readAttr(annotation, SchemaConstant.PROP_MULTIPLE_OF,
                 BigDecimal::valueOf, defaults));
-        schema.setMaximum(SchemaFactory.<String, BigDecimal> readAttr(annotation, SchemaConstant.PROP_MAXIMUM,
-                BigDecimal::new, defaults));
-        schema.setMinimum(SchemaFactory.<String, BigDecimal> readAttr(annotation, SchemaConstant.PROP_MINIMUM,
-                BigDecimal::new, defaults));
+        schema.setMaximum(SchemaFactory.readAttr(annotation, SchemaConstant.PROP_MAXIMUM,
+                SchemaFactory::tolerantParseBigDecimal, defaults));
+        schema.setMinimum(SchemaFactory.readAttr(annotation, SchemaConstant.PROP_MINIMUM,
+                SchemaFactory::tolerantParseBigDecimal, defaults));
         schema.setExclusiveMaximum(readAttr(annotation, SchemaConstant.PROP_EXCLUSIVE_MAXIMUM, defaults));
         schema.setExclusiveMinimum(readAttr(annotation, SchemaConstant.PROP_EXCLUSIVE_MINIMUM, defaults));
         schema.setMaxLength(readAttr(annotation, SchemaConstant.PROP_MAX_LENGTH, defaults));
@@ -662,5 +662,13 @@ public class SchemaFactory {
         }
 
         discriminator.addMapping(propertyValue, schemaRef);
+    }
+
+    private static BigDecimal tolerantParseBigDecimal(String value) {
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -197,6 +197,7 @@ public class OpenApiDataObjectScanner {
         // If top level item is not indexed
         if (rootClassInfo == null && objectStack.isEmpty()) {
             // If there's something on the objectStack stack then pre-scanning may have found something.
+            ScannerLogging.logger.schemaTypeNotFound(rootClassType.name());
             return new SchemaImpl().type(SchemaType.OBJECT);
         }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/ScannerLogging.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/ScannerLogging.java
@@ -33,4 +33,8 @@ interface ScannerLogging extends BasicLogger {
     @Message(id = 4004, value = "Configured schema for %s has been registered")
     void configSchemaRegistered(String className);
 
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 4005, value = "Could not find schema class in index: %s")
+    void schemaTypeNotFound(DotName className);
+
 }

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/LogCapture.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/LogCapture.java
@@ -1,0 +1,112 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Capture logs from a named logger and make them available to the test
+ * <p>
+ * <code><pre>
+ * &commat;RegisterExtension
+ * LogCapture c = new LogCapture(ClassUnderTest.class.getName());
+ * 
+ * &commat;Test
+ * public void test() {
+ *     // do something to provoke a log message
+ *     new ClassUnderTest().logMyMessage();
+ *     
+ *     LogRecord r = c.assertLogContaining("My Special Message");
+ *     assertEquals(Level.INFO, r.getLevel());
+ * }
+ * </pre></code>
+ */
+public class LogCapture implements BeforeEachCallback, AfterEachCallback {
+
+    private String loggerName;
+    private Logger logger;
+    private TestHandler handler;
+    private Level oldLevel;
+
+    public LogCapture(String loggerName) {
+        this.loggerName = loggerName;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        logger = Logger.getLogger(loggerName);
+        handler = new TestHandler();
+        logger.addHandler(handler);
+        oldLevel = logger.getLevel();
+        logger.setLevel(Level.ALL);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        if (handler != null) {
+            logger.removeHandler(handler);
+        }
+        if (logger != null) {
+            logger.setLevel(oldLevel);
+        }
+    }
+
+    public List<LogRecord> getAll() {
+        synchronized (handler.records) {
+            return new ArrayList<>(handler.records);
+        }
+    }
+
+    public LogRecord assertLogContaining(String substring) {
+        synchronized (handler.records) {
+            for (LogRecord r : handler.records) {
+                if (r.getMessage().contains(substring)) {
+                    return r;
+                }
+
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("Log containing \"").append(substring).append("\" was not found.");
+            sb.append("\n");
+            sb.append("Log records recorded:\n");
+            if (handler.records.isEmpty()) {
+                sb.append("<no records>\n");
+            }
+            for (LogRecord r : handler.records) {
+                sb.append("[").append(r.getLevel()).append("] ");
+                sb.append(r.getMessage()).append("\n");
+            }
+
+            throw new AssertionError(sb.toString());
+        }
+    }
+
+    private static class TestHandler extends Handler {
+
+        private List<LogRecord> records = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+
+    }
+
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaPropertyNegativeTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaPropertyNegativeTest.java
@@ -1,0 +1,351 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SchemaPropertyNegativeTest extends IndexScannerTestBase {
+
+    @RegisterExtension
+    public LogCapture logs = new LogCapture(ScannerLogging.class.getPackage().getName());
+
+    @BeforeEach
+    public void beforeEach(TestInfo testInfo) {
+        System.out.println(testInfo.getDisplayName());
+    }
+
+    @Test
+    public void testClassSchemaPropertyBlankName() throws Exception {
+        Index index = indexOf(BlankNameTest.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-blankname.json", result);
+
+    }
+
+    // Blank name is treated as valid
+    @Schema(properties = { @SchemaProperty(name = "", type = SchemaType.STRING) })
+    static class BlankNameTest {
+    }
+
+    @Test
+    public void testClassSchemaPropertyDuplicateName() throws Exception {
+        Index index = indexOf(DuplicateNameTest.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-duplicatename.json", result);
+    }
+
+    // Last instance replaces others, instances are not merged
+    @Schema(properties = { @SchemaProperty(name = "foo", type = SchemaType.STRING, defaultValue = "5"),
+            @SchemaProperty(name = "foo", type = SchemaType.INTEGER) })
+    static class DuplicateNameTest {
+    }
+
+    @Test
+    public void testClassSchemaPropertyNegativeMultipleOf() throws Exception {
+        Index index = indexOf(NegativeMultipleOf.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-negativemultipleof.json", result);
+    }
+
+    @Schema(properties = { @SchemaProperty(name = "test", type = SchemaType.INTEGER, multipleOf = -2) })
+    static class NegativeMultipleOf {
+    }
+
+    @Test
+    public void testClassSchemaPropertyMaximumNotNumber() throws Exception {
+        Index index = indexOf(MaximumNotNumber.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-maximumnotnumber.json", result);
+    }
+
+    // maximum should be ignored
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.INTEGER, maximum = "foo"))
+    static class MaximumNotNumber {
+    }
+
+    @Test
+    public void testClassSchemaPropertyMinimumNotNumber() throws Exception {
+        Index index = indexOf(MinimumNotNumber.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-minimumnotnumber.json", result);
+    }
+
+    // minimum should be ignored
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.INTEGER, minimum = "foo"))
+    static class MinimumNotNumber {
+    }
+
+    @Test
+    public void testClassSchemaPropertyMinLengthNegative() throws Exception {
+        Index index = indexOf(MinLengthNegative.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-minlengthnegative.json", result);
+    }
+
+    // Negative value used in document
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.STRING, minLength = -2))
+    static class MinLengthNegative {
+    }
+
+    @Test
+    public void testClassSchemaPropertyMaxLengthNegative() throws Exception {
+        Index index = indexOf(MaxLengthNegative.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-maxlengthnegative.json", result);
+    }
+
+    // Negative value used in document
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.STRING, maxLength = -2))
+    static class MaxLengthNegative {
+    }
+
+    @Test
+    public void testClassSchemaPropertyPatternInvalid() throws Exception {
+        Index index = indexOf(PatternInvalid.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-patterninvalid.json", result);
+    }
+
+    // Invalid pattern used in document
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.STRING, pattern = "(invalid"))
+    static class PatternInvalid {
+    }
+
+    @Test
+    public void testClassSchemaPropertyMaxPropertiesNegative() throws Exception {
+        Index index = indexOf(MaxPropertiesNegative.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-maxpropertiesnegative.json", result);
+    }
+
+    // Negative value used in document
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.OBJECT, maxProperties = -2))
+    static class MaxPropertiesNegative {
+    }
+
+    @Test
+    public void testClassSchemaPropertyMinPropertiesNegative() throws Exception {
+        Index index = indexOf(MinPropertiesNegative.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-minpropertiesnegative.json", result);
+    }
+
+    // Negative value used in document
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.OBJECT, minProperties = -2))
+    static class MinPropertiesNegative {
+    }
+
+    @Test
+    public void testClassSchemaPropertyRefWithOtherProps() throws Exception {
+        Index index = indexOf(RefWithOtherProps.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-refwithotherprops.json", result);
+    }
+
+    // Name and ref used in document, other attributes ignored
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.STRING, ref = "foobar"))
+    static class RefWithOtherProps {
+    }
+
+    @Test
+    public void testClassSchemaPropertyDefaultValueWrongType() throws Exception {
+        Index index = indexOf(DefaultValueWrongType.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-defaultvaluewrongtype.json", result);
+    }
+
+    // Invalid default value used in document
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.INTEGER, defaultValue = "foo"))
+    static class DefaultValueWrongType {
+    }
+
+    @Test
+    public void testClassSchemaPropertyMaxItemsNegative() throws Exception {
+        Index index = indexOf(MaxItemsNegative.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-maxitemsnegative.json", result);
+    }
+
+    // Negative value used in document
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.ARRAY, maxItems = -2))
+    static class MaxItemsNegative {
+    }
+
+    @Test
+    public void testClassSchemaPropertyMinItemsNegative() throws Exception {
+        Index index = indexOf(MinItemsNegative.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-minitemsnegative.json", result);
+    }
+
+    // Negative value used in document
+    @Schema(properties = @SchemaProperty(name = "test", type = SchemaType.ARRAY, minItems = -2))
+    static class MinItemsNegative {
+    }
+
+    static class MissingClass {
+        public String example;
+    }
+
+    @Test
+    public void testClassSchemaPropertyImplementationMissing() throws Exception {
+        Index index = indexOf(ImplementationMissing.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-implementationmissing.json", result);
+    }
+
+    // Implementation attribute not included in document
+    @Schema(properties = @SchemaProperty(name = "test", implementation = MissingClass.class))
+    static class ImplementationMissing {
+    }
+
+    @Test
+    public void testClassSchemaPropertyNotMissing() throws Exception {
+        Index index = indexOf(NotMissing.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-notmissing.json", result);
+
+        String expectedMessage = String.format("Could not find schema class in index: %s", MissingClass.class.getName());
+        LogRecord record = logs.assertLogContaining(expectedMessage);
+        assertEquals(Level.WARNING, record.getLevel());
+    }
+
+    // Not attribute present, pointing to an empty schema
+    @Schema(properties = @SchemaProperty(name = "test", not = MissingClass.class))
+    static class NotMissing {
+    }
+
+    @Test
+    public void testClassSchemaPropertyOneOfMissing() throws Exception {
+        Index index = indexOf(OneOfMissing.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-oneofmissing.json", result);
+
+        String expectedMessage = String.format("Could not find schema class in index: %s", MissingClass.class.getName());
+        LogRecord record = logs.assertLogContaining(expectedMessage);
+        assertEquals(Level.WARNING, record.getLevel());
+    }
+
+    // OneOf attribute present, pointing to an empty schema
+    @Schema(properties = @SchemaProperty(name = "test", oneOf = { MissingClass.class }))
+    static class OneOfMissing {
+    }
+
+    @Test
+    public void testClassSchemaPropertyAnyOfMissing() throws Exception {
+        Index index = indexOf(AnyOfMissing.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-anyofmissing.json", result);
+
+        String expectedMessage = String.format("Could not find schema class in index: %s", MissingClass.class.getName());
+        LogRecord record = logs.assertLogContaining(expectedMessage);
+        assertEquals(Level.WARNING, record.getLevel());
+    }
+
+    // AnyOf attribute present, pointing to an empty schema
+    @Schema(properties = @SchemaProperty(name = "test", anyOf = MissingClass.class))
+    static class AnyOfMissing {
+    }
+
+    @Test
+    public void testClassSchemaPropertyAllOfMissing() throws Exception {
+        Index index = indexOf(AllOfMissing.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.schemaproperty-allofmissing.json", result);
+
+        String expectedMessage = String.format("Could not find schema class in index: %s", MissingClass.class.getName());
+        LogRecord record = logs.assertLogContaining(expectedMessage);
+        assertEquals(Level.WARNING, record.getLevel());
+    }
+
+    @Schema(properties = @SchemaProperty(name = "test", allOf = MissingClass.class))
+    static class AllOfMissing {
+    }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-allofmissing.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-allofmissing.json
@@ -1,0 +1,17 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "AllOfMissing" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "allOf" : [ {
+              "type" : "object"
+            } ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-anyofmissing.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-anyofmissing.json
@@ -1,0 +1,17 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "AnyOfMissing" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "anyOf" : [ {
+              "type" : "object"
+            } ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-blankname.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-blankname.json
@@ -1,0 +1,15 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "BlankNameTest" : {
+        "type" : "object",
+        "properties" : {
+          "" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-defaultvaluewrongtype.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-defaultvaluewrongtype.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "DefaultValueWrongType" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "default" : "foo",
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-duplicatename.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-duplicatename.json
@@ -1,0 +1,15 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "DuplicateNameTest" : {
+        "type" : "object",
+        "properties" : {
+          "foo" : {
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-implementationmissing.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-implementationmissing.json
@@ -1,0 +1,15 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "ImplementationMissing" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "type" : "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-maximumnotnumber.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-maximumnotnumber.json
@@ -1,0 +1,15 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "MaximumNotNumber" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-maxitemsnegative.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-maxitemsnegative.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "MaxItemsNegative" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "maxItems" : -2,
+            "type" : "array"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-maxlengthnegative.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-maxlengthnegative.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "MaxLengthNegative" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "maxLength" : -2,
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-maxpropertiesnegative.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-maxpropertiesnegative.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "MaxPropertiesNegative" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "maxProperties" : -2,
+            "type" : "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-minimumnotnumber.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-minimumnotnumber.json
@@ -1,0 +1,15 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "MinimumNotNumber" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-minitemsnegative.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-minitemsnegative.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "MinItemsNegative" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "minItems" : -2,
+            "type" : "array"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-minlengthnegative.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-minlengthnegative.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "MinLengthNegative" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "minLength" : -2,
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-minpropertiesnegative.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-minpropertiesnegative.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "MinPropertiesNegative" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "minProperties" : -2,
+            "type" : "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-negativemultipleof.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-negativemultipleof.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "NegativeMultipleOf" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "multipleOf" : -2,
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-notmissing.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-notmissing.json
@@ -1,0 +1,17 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "NotMissing" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "not" : {
+              "type" : "object"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-oneofmissing.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-oneofmissing.json
@@ -1,0 +1,17 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "OneOfMissing" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "oneOf" : [ {
+              "type" : "object"
+            } ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-patterninvalid.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-patterninvalid.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "PatternInvalid" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "pattern" : "(invalid",
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-refwithotherprops.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-refwithotherprops.json
@@ -1,0 +1,15 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "RefWithOtherProps" : {
+        "type" : "object",
+        "properties" : {
+          "test" : {
+            "$ref" : "#/components/schemas/foobar"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add negative tests for `@SchemaProperty`

Also make two improvements revealed by testing:
* Log when a class is referenced as a schema from an annotation but isn't found in the index
* Correctly ignore non-numbers for `minimum` and `maximum`

In other cases, the tests assert the current behaviour. In most cases this means that invalid values from the annotations are put directly into the constructed document.

For #621 