### PR TITLE
Sort scanned component entries, paths, and tags after all scanners

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -14,14 +13,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.PathItem;
-import org.eclipse.microprofile.openapi.models.Paths;
 import org.eclipse.microprofile.openapi.models.callbacks.Callback;
 import org.eclipse.microprofile.openapi.models.media.Content;
 import org.eclipse.microprofile.openapi.models.media.MediaType;
@@ -44,7 +40,6 @@ import org.jboss.jandex.Type;
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.api.constants.SecurityConstants;
 import io.smallrye.openapi.api.models.OperationImpl;
-import io.smallrye.openapi.api.models.PathsImpl;
 import io.smallrye.openapi.api.models.media.ContentImpl;
 import io.smallrye.openapi.api.models.media.MediaTypeImpl;
 import io.smallrye.openapi.api.models.media.SchemaImpl;
@@ -723,42 +718,6 @@ public interface AnnotationScanner {
         // this can be a useful extension point to set/override the application path
         for (AnnotationScannerExtension extension : context.getExtensions()) {
             extension.processScannerApplications(this, applications);
-        }
-    }
-
-    /**
-     * Sort the tags unless the application has defined the order in OpenAPIDefinition annotation(s)
-     * 
-     * @param openApi the openAPI model
-     * @param tagsDefined is the tags defined
-     */
-    default void sortTags(OpenAPI openApi, boolean tagsDefined) {
-
-        if (!tagsDefined && openApi.getTags() != null) {
-            openApi.setTags(openApi.getTags()
-                    .stream()
-                    .sorted(Comparator.comparing(Tag::getName))
-                    .collect(Collectors.toList()));
-        }
-    }
-
-    /**
-     * Now that all paths have been created, sort them.
-     * (we don't have a better way to organize them)
-     * 
-     * @param openApi the openApi model
-     */
-    default void sortPaths(OpenAPI openApi) {
-        Paths paths = openApi.getPaths();
-        if (paths != null) {
-            Paths sortedPaths = new PathsImpl();
-            TreeSet<String> sortedKeys = new TreeSet<>(paths.getPathItems().keySet());
-            for (String pathKey : sortedKeys) {
-                PathItem pathItem = paths.getPathItem(pathKey);
-                sortedPaths.addPathItem(pathKey, pathItem);
-            }
-            sortedPaths.setExtensions(paths.getExtensions());
-            openApi.setPaths(sortedPaths);
         }
     }
 

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/ComponentOrderTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/ComponentOrderTest.java
@@ -1,0 +1,48 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+
+class ComponentOrderTest extends IndexScannerTestBase {
+
+    /*
+     * https://github.com/smallrye/smallrye-open-api/issues/735
+     */
+    @Test
+    void testComponentsKeysSorted() throws Exception {
+        Index index = indexOf(Class.forName(getClass().getPackage().getName() + ".sorttest1.package-info"),
+                Class.forName(getClass().getPackage().getName() + ".sorttest2.package-info"));
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+        String[] expectedNames = { "123", "ABC", "DEF", "GHI", "KLM", "XYZ" };
+
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+
+        assertArrayEquals(expectedNames, result.getComponents().getCallbacks().keySet().toArray());
+        assertArrayEquals(expectedNames, result.getComponents().getExamples().keySet().toArray());
+        assertArrayEquals(expectedNames, result.getComponents().getHeaders().keySet().toArray());
+        assertArrayEquals(expectedNames, result.getComponents().getLinks().keySet().toArray());
+        assertArrayEquals(expectedNames, result.getComponents().getParameters().keySet().toArray());
+        assertArrayEquals(expectedNames, result.getComponents().getRequestBodies().keySet().toArray());
+        assertArrayEquals(expectedNames, result.getComponents().getResponses().keySet().toArray());
+        assertArrayEquals(expectedNames, result.getComponents().getSchemas().keySet().toArray());
+        assertArrayEquals(expectedNames, result.getComponents().getSecuritySchemes().keySet().toArray());
+    }
+
+    @Test
+    void testDefinitionTagOrderPreserved() throws Exception {
+        Index index = indexOf(Class.forName(getClass().getPackage().getName() + ".sorttest1.package-info"),
+                Class.forName(getClass().getPackage().getName() + ".sorttest2.package-info"));
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+        String[] expectedNames = { "DEF", "XYZ", "ABC" };
+
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+
+        assertArrayEquals(expectedNames, result.getTags().stream().map(Tag::getName).toArray());
+    }
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/sorttest1/package-info.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/sorttest1/package-info.java
@@ -1,0 +1,51 @@
+@OpenAPIDefinition(info = @Info(title = "Test", version = "1.0"), tags = {}, components = @Components(callbacks = {
+        @Callback(name = "DEF"),
+        @Callback(name = "XYZ"),
+        @Callback(name = "ABC")
+}, examples = {
+        @ExampleObject(name = "DEF"),
+        @ExampleObject(name = "XYZ"),
+        @ExampleObject(name = "ABC")
+}, headers = {
+        @Header(name = "DEF"),
+        @Header(name = "XYZ"),
+        @Header(name = "ABC")
+}, links = {
+        @Link(name = "DEF"),
+        @Link(name = "XYZ"),
+        @Link(name = "ABC")
+}, parameters = {
+        @Parameter(name = "DEF"),
+        @Parameter(name = "XYZ"),
+        @Parameter(name = "ABC")
+}, requestBodies = {
+        @RequestBody(name = "DEF"),
+        @RequestBody(name = "XYZ"),
+        @RequestBody(name = "ABC")
+}, responses = {
+        @APIResponse(name = "DEF"),
+        @APIResponse(name = "XYZ"),
+        @APIResponse(name = "ABC")
+}, schemas = {
+        @Schema(name = "DEF"),
+        @Schema(name = "XYZ"),
+        @Schema(name = "ABC")
+}, securitySchemes = {
+        @SecurityScheme(securitySchemeName = "DEF"),
+        @SecurityScheme(securitySchemeName = "XYZ"),
+        @SecurityScheme(securitySchemeName = "ABC")
+}))
+package io.smallrye.openapi.runtime.scanner.sorttest1;
+
+import org.eclipse.microprofile.openapi.annotations.Components;
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.callbacks.Callback;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.links.Link;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/sorttest2/package-info.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/sorttest2/package-info.java
@@ -1,0 +1,56 @@
+@OpenAPIDefinition(info = @Info(title = "Test", version = "1.0"), tags = {
+        @Tag(name = "DEF"),
+        @Tag(name = "XYZ"),
+        @Tag(name = "ABC")
+}, components = @Components(callbacks = {
+        @Callback(name = "KLM"),
+        @Callback(name = "GHI"),
+        @Callback(name = "123")
+}, examples = {
+        @ExampleObject(name = "KLM"),
+        @ExampleObject(name = "GHI"),
+        @ExampleObject(name = "123")
+}, headers = {
+        @Header(name = "KLM"),
+        @Header(name = "GHI"),
+        @Header(name = "123")
+}, links = {
+        @Link(name = "KLM"),
+        @Link(name = "GHI"),
+        @Link(name = "123")
+}, parameters = {
+        @Parameter(name = "KLM"),
+        @Parameter(name = "GHI"),
+        @Parameter(name = "123")
+}, requestBodies = {
+        @RequestBody(name = "KLM"),
+        @RequestBody(name = "GHI"),
+        @RequestBody(name = "123")
+}, responses = {
+        @APIResponse(name = "KLM"),
+        @APIResponse(name = "GHI"),
+        @APIResponse(name = "123")
+}, schemas = {
+        @Schema(name = "KLM"),
+        @Schema(name = "GHI"),
+        @Schema(name = "123")
+}, securitySchemes = {
+        @SecurityScheme(securitySchemeName = "KLM"),
+        @SecurityScheme(securitySchemeName = "GHI"),
+        @SecurityScheme(securitySchemeName = "123")
+}))
+package io.smallrye.openapi.runtime.scanner.sorttest2;
+
+import org.eclipse.microprofile.openapi.annotations.Components;
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.callbacks.Callback;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.links.Link;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -132,17 +132,8 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         // Get all JaxRs applications and convert them to OpenAPI models (and merge them into a single one)
         processApplicationClasses(context, openApi);
 
-        // This needs to be here just after we have done JaxRs Application
-        boolean tagsDefined = openApi.getTags() != null && !openApi.getTags().isEmpty();
-
         // Now find all jax-rs endpoints
         processResourceClasses(context, openApi);
-
-        // Sort the tags unless the application has defined the order in OpenAPIDefinition annotation(s)
-        sortTags(openApi, tagsDefined);
-
-        // Now that all paths have been created, sort them (we don't have a better way to organize them).
-        sortPaths(openApi);
 
         return openApi;
     }

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -122,14 +122,6 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
         // Get all Spring controllers and convert them to OpenAPI models (and merge them into a single one)
         processControllerClasses(context, openApi);
 
-        boolean tagsDefined = openApi.getTags() != null && !openApi.getTags().isEmpty();
-
-        // Sort the tags unless the application has defined the order in OpenAPIDefinition annotation(s)
-        sortTags(openApi, tagsDefined);
-
-        // Now that all paths have been created, sort them (we don't have a better way to organize them).
-        sortPaths(openApi);
-
         return openApi;
     }
 

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
@@ -95,14 +95,6 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
         // Get all Vert.x routes and convert them to OpenAPI models (and merge them into a single one)
         processRoutes(context, openApi);
 
-        boolean tagsDefined = openApi.getTags() != null && !openApi.getTags().isEmpty();
-
-        // Sort the tags unless the application has defined the order in OpenAPIDefinition annotation(s)
-        sortTags(openApi, tagsDefined);
-
-        // Now that all paths have been created, sort them (we don't have a better way to organize them).
-        sortPaths(openApi);
-
         return openApi;
     }
 


### PR DESCRIPTION
Fixes #735 

- Tag and PathItem sorting centralized (removed from AnnotationScanner interface and implementations)