### PR TITLE
Bump version.quarkus from 1.12.1.Final to 1.12.2.Final (2.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <version.arquillian.jetty>1.0.0.CR3</version.arquillian.jetty>
         <version.jetty>9.3.29.v20201019</version.jetty>
         <version.resteasy>4.6.0.Final</version.resteasy>
-        <version.quarkus>1.12.1.Final</version.quarkus>
+        <version.quarkus>1.12.2.Final</version.quarkus>
 
         <!--
             xmlReportPaths must contain an entry for each project that reports coverage.


### PR DESCRIPTION
Bumps `version.quarkus` from 1.12.1.Final to 1.12.2.Final.

Updates `resteasy-reactive-common` from 1.12.1.Final to 1.12.2.Final

Updates `quarkus-vertx-web` from 1.12.1.Final to 1.12.2.Final
