### PR TITLE
Properly handle single character property methods (2.0.x)

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
@@ -174,8 +174,7 @@ public class IgnoreResolver {
                 return target.asField().name();
             }
             // Assuming this is a getter or setter
-            String name = target.asMethod().name().substring(3);
-            return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+            return TypeResolver.propertyName(target.asMethod());
         }
 
         private Visibility shouldIgnoreTarget(AnnotationInstance jipAnnotation, String targetName) {

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -423,6 +423,29 @@ class TypeResolverTests extends IndexScannerTestBase {
         assertTrue(properties.get("field2").isIgnored());
     }
 
+    @Test
+    /*
+     * Issue: https://github.com/smallrye/smallrye-open-api/issues/746
+     */
+    void testSingleCharacterPropertyName() {
+        @SuppressWarnings("unused")
+        class Test {
+            private boolean b;
+
+            public boolean isB() {
+                return b;
+            }
+
+            public void setB(boolean b) {
+                this.b = b;
+            }
+        }
+
+        Map<String, TypeResolver> properties = getProperties(Test.class, emptyConfig(), Test.class);
+        assertEquals(1, properties.size());
+        assertEquals("b", properties.keySet().iterator().next());
+    }
+
     /* Test models and resources below. */
 
     @com.fasterxml.jackson.annotation.JsonPropertyOrder({ "age", "type" })


### PR DESCRIPTION
Fixes #746 for `2.0.x`