### PR TITLE
Support `@Schema` annotation directly on parameters (2.0.x)

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -479,46 +479,20 @@ public abstract class AbstractParameterProcessor {
     }
 
     private Parameter mapParameter(MethodInfo resourceMethod, ParameterContext context) {
-        Parameter param;
-
-        if (context.oaiParam == null) {
-            param = new ParameterImpl();
-        } else {
-            param = context.oaiParam;
-        }
+        Parameter param = context.oaiParam != null ? context.oaiParam : new ParameterImpl();
 
         param.setName(context.name);
 
-        if (param.getIn() == null && context.location != null) {
-            param.setIn(context.location);
-        }
+        mapParameterIn(param, context);
 
         if (isIgnoredParameter(param, resourceMethod)) {
             return null;
         }
 
-        if (param.getIn() == In.PATH) {
-            param.setRequired(true);
-        }
-
-        if (param.getStyle() == null && context.frameworkParam != null) {
-            param.setStyle(context.frameworkParam.style);
-        }
-
-        if (!ModelUtil.parameterHasSchema(param) && context.targetType != null) {
-            Schema schema = SchemaFactory.typeToSchema(scannerContext, context.targetType, extensions);
-            ModelUtil.setParameterSchema(param, schema);
-        }
-
-        if (param.getDeprecated() == null && TypeUtil.hasAnnotation(context.target, DOTNAME_DEPRECATED)) {
-            param.setDeprecated(Boolean.TRUE);
-        }
-
-        List<AnnotationInstance> extensionAnnotations = ExtensionReader.getExtensionsAnnotations(context.target);
-
-        if (param.getExtensions() == null && !extensionAnnotations.isEmpty()) {
-            param.setExtensions(ExtensionReader.readExtensions(this.scannerContext, extensionAnnotations));
-        }
+        mapParameterStyle(param, context);
+        mapParameterSchema(param, context);
+        mapParameterDeprecated(param, context);
+        mapParameterExtensions(param, context);
 
         if (param.getSchema() != null) {
             augmentParamSchema(param, context);
@@ -529,6 +503,64 @@ public abstract class AbstractParameterProcessor {
         }
 
         return param;
+    }
+
+    void mapParameterIn(Parameter param, ParameterContext context) {
+        if (param.getIn() == null && context.location != null) {
+            param.setIn(context.location);
+        }
+
+        if (param.getIn() == In.PATH) {
+            param.setRequired(true);
+        }
+
+    }
+
+    void mapParameterStyle(Parameter param, ParameterContext context) {
+        if (param.getStyle() == null && context.frameworkParam != null) {
+            param.setStyle(context.frameworkParam.style);
+        }
+    }
+
+    void mapParameterSchema(Parameter param, ParameterContext context) {
+        if (ModelUtil.parameterHasSchema(param) || context.targetType == null) {
+            return;
+        }
+
+        AnnotationInstance schemaAnnotation = TypeUtil.getAnnotation(context.target, SchemaConstant.DOTNAME_SCHEMA);
+        Schema schema;
+
+        if (schemaAnnotation != null) {
+            Type paramType = JandexUtil.value(schemaAnnotation, SchemaConstant.PROP_IMPLEMENTATION, context.targetType);
+            Map<String, Object> defaults;
+
+            if (JandexUtil.isArraySchema(schemaAnnotation)) {
+                defaults = Collections.emptyMap();
+            } else {
+                defaults = TypeUtil.getTypeAttributes(paramType);
+            }
+
+            // readSchema *may* replace the existing schema, so we must assign.
+            schema = SchemaFactory.readSchema(scannerContext, new SchemaImpl(), schemaAnnotation, defaults);
+        } else {
+            schema = SchemaFactory.typeToSchema(scannerContext, context.targetType, extensions);
+        }
+
+        ModelUtil.setParameterSchema(param, schema);
+    }
+
+    void mapParameterDeprecated(Parameter param, ParameterContext context) {
+        if (param.getDeprecated() == null && TypeUtil.hasAnnotation(context.target, DOTNAME_DEPRECATED)) {
+            param.setDeprecated(Boolean.TRUE);
+        }
+    }
+
+    void mapParameterExtensions(Parameter param, ParameterContext context) {
+        List<AnnotationInstance> extensionAnnotations = ExtensionReader.getExtensionsAnnotations(context.target);
+
+        if (param.getExtensions() == null && !extensionAnnotations.isEmpty()) {
+            param.setExtensions(ExtensionReader.readExtensions(this.scannerContext, extensionAnnotations));
+        }
     }
 
     /**
@@ -959,7 +991,7 @@ public abstract class AbstractParameterProcessor {
     }
 
     protected List<DotName> getDefaultAnnotationNames() {
-        return null;
+        return Collections.emptyList();
     }
 
     protected String getDefaultAnnotationProperty() {

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -153,6 +153,21 @@ public class JandexUtil {
     }
 
     /**
+     * Convenience method to retrieve the named parameter from an annotation.
+     * The value will be unwrapped from its containing {@link AnnotationValue}.
+     *
+     * @param <T> the type of the parameter being retrieved
+     * @param annotation the annotation from which to fetch the parameter
+     * @param name the name of the parameter
+     * @param defaultValue a default value to return if the parameter is not defined
+     * @return an unwrapped annotation parameter value
+     */
+    public static <T> T value(AnnotationInstance annotation, String name, T defaultValue) {
+        T value = JandexUtil.value(annotation, name);
+        return value != null ? value : defaultValue;
+    }
+
+    /**
      * Reads a String property value from the given annotation instance. If no value is found
      * this will return null.
      * 

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/BaseResource2.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/BaseResource2.java
@@ -6,11 +6,13 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
 public class BaseResource2<T, S> {
 
     @GET
     @Path(value = "typevar")
-    public T test(@QueryParam(value = "q1") S q1) {
+    public T test(@QueryParam(value = "q1") @Schema(description = "Description for q1's schema") S q1) {
         return null;
     }
 

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/TestResource3.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/TestResource3.java
@@ -1,10 +1,16 @@
 package test.io.smallrye.openapi.runtime.scanner;
 
+import java.util.List;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Path(value = "/generic")
 @Consumes(value = MediaType.APPLICATION_JSON)
@@ -14,6 +20,13 @@ public class TestResource3 extends BaseResource2<Apple, String> {
     @POST
     @Path(value = "save")
     public Apple update(Apple filter) {
+        return null;
+    }
+
+    @POST
+    @Path(value = "retrieve")
+    public List<Apple> update(
+            @QueryParam("ids") @Schema(type = SchemaType.ARRAY, implementation = Integer.class) String values) {
         return null;
     }
 

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/BaseResource2.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/BaseResource2.java
@@ -2,6 +2,8 @@ package test.io.smallrye.openapi.runtime.scanner.jakarta;
 
 import java.util.Map;
 
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
@@ -10,7 +12,7 @@ public class BaseResource2<T, S> {
 
     @GET
     @Path(value = "typevar")
-    public T test(@QueryParam(value = "q1") S q1) {
+    public T test(@QueryParam(value = "q1") @Schema(description = "Description for q1's schema") S q1) {
         return null;
     }
 

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/TestResource3.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/TestResource3.java
@@ -1,9 +1,15 @@
 package test.io.smallrye.openapi.runtime.scanner.jakarta;
 
+import java.util.List;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import test.io.smallrye.openapi.runtime.scanner.Apple;
 
@@ -15,6 +21,13 @@ public class TestResource3 extends BaseResource2<Apple, String> {
     @POST
     @Path(value = "save")
     public Apple update(Apple filter) {
+        return null;
+    }
+
+    @POST
+    @Path(value = "retrieve")
+    public List<Apple> update(
+            @QueryParam("ids") @Schema(type = SchemaType.ARRAY, implementation = Integer.class) String values) {
         return null;
     }
 

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.generic-type-variables.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.generic-type-variables.json
@@ -20,6 +20,38 @@
         }
       }
     },
+    "/generic/retrieve": {
+      "post": {
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "format": "int32",
+                "type": "integer"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Apple"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/generic/save": {
       "post": {
         "requestBody": {
@@ -52,7 +84,8 @@
             "name": "q1",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Description for q1's schema"
             }
           }
         ],


### PR DESCRIPTION
As discussed in #769, same as #772 for 2.0.x (minus the Junit modifier change)