### PR TITLE
Bump version.quarkus from 1.13.0.Final to 1.13.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>
         <version.maven-resources-plugin>3.2.0</version.maven-resources-plugin>
-        <version.com.github.eirslett.frontend-maven-plugin>1.11.2</version.com.github.eirslett.frontend-maven-plugin>
+        <version.com.github.eirslett.frontend-maven-plugin>1.11.3</version.com.github.eirslett.frontend-maven-plugin>
 
         <version.arquillian.jetty>1.0.0.CR3</version.arquillian.jetty>
         <version.jetty>9.3.29.v20201019</version.jetty>
         <version.resteasy>4.6.0.Final</version.resteasy>
-        <version.quarkus>1.12.2.Final</version.quarkus>
+        <version.quarkus>1.13.1.Final</version.quarkus>
 
         <!--
             xmlReportPaths must contain an entry for each project that reports coverage.
@@ -89,7 +89,6 @@
               <enabled>true</enabled>
            </snapshots>
         </repository>
-        
     </repositories>
 
     <dependencyManagement>


### PR DESCRIPTION
Bumps `version.quarkus` from 1.13.0.Final to 1.13.1.Final.

Updates `resteasy-reactive-common` from 1.13.0.Final to 1.13.1.Final

Updates `quarkus-vertx-web` from 1.13.0.Final to 1.13.1.Final

Conflicts:
	pom.xml

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>