### PR TITLE
Bump version.com.fasterxml.jackson from 2.12.2 to 2.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <version.buildhelper.plugin>3.2.0</version.buildhelper.plugin>
-        <version.com.fasterxml.jackson>2.12.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.12.3</version.com.fasterxml.jackson>
         <version.eclipse.microprofile.config>1.4</version.eclipse.microprofile.config>
         <version.io.smallrye.smallrye-config>1.10.0</version.io.smallrye.smallrye-config>
         <version.eclipse.microprofile.openapi>1.1.3-RC1</version.eclipse.microprofile.openapi>


### PR DESCRIPTION
Bumps `version.com.fasterxml.jackson` from 2.12.2 to 2.12.3.

Updates `jackson-core` from 2.12.2 to 2.12.3
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.12.2...jackson-core-2.12.3)

Updates `jackson-databind` from 2.12.2 to 2.12.3
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-dataformat-yaml` from 2.12.2 to 2.12.3
- [Release
notes](https://github.com/FasterXML/jackson-dataformats-text/releases)
- [Commits](https://github.com/FasterXML/jackson-dataformats-text/compare/jackson-dataformats-text-2.12.2...jackson-dataformats-text-2.12.3)

Conflicts:
	pom.xml

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>