### PR TITLE
Support JSON-B and Jackson property naming strategies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,8 +22,11 @@ mvn clean install
 * link:core[] - The core OpenAPI code, independent of entry point dependencies.
 * link:extension-jaxrs[] - The JAX-RS entry point. This module depends on JAX-RS and core.
 * link:extension-spring[] - The Spring entry point. This module depends on Spring and core.
+* link:extension-vertx[] - The Vert.x entry point. This module depends on Vert.x and core.
 * link:implementation[] - Implementation of the Eclipse MicroProfile OpenAPI specification. This just pulls in Core and the JAX-RS extension .
-* link:tck[] - Test suite to run the implementation against the Eclipse MicroProfile OpenAPI TCK.
+* link:testsuite[] - Test suites.
+* link:testsuite/tck[] - Test suite to run the implementation against the Eclipse MicroProfile OpenAPI TCK.
+* link:testsuite/extra[] - Extra integration tests not related to the TCK.
 * link:tools/maven-plugin[] - Maven plugin that creates the OpenAPI Schema on build.
 
 === Links
@@ -31,3 +34,8 @@ mvn clean install
 * http://github.com/smallrye/smallrye-open-api/[Project Homepage]
 * {microprofile-open-api}[Eclipse MicroProfile OpenAPI]
 
+=== Configuration Extensions
+* `mp.openapi.extensions.smallrye.property-naming-strategy` - define a naming strategy to be used globally for all schema properties. Set to one of the following:
+** A standard JSON-B naming strategy (listed in `jakarta.json.bind.config.PropertyNamingStrategy`/`javax.json.bind.config.PropertyNamingStrategy`)
+** A fully-qualified class name of an implementation of a JSON-B property naming strategy (`jakarta.json.bind.config.PropertyNamingStrategy` or `javax.json.bind.config.PropertyNamingStrategy`)
+** A fully-qualified class name of an implementation of a Jackson property naming strategy base class (`com.fasterxml.jackson.databind.PropertyNamingStrategies.NamingBase`). Only the `translate` method is utilized.

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.smallrye.openapi.api.constants.JsonbConstants;
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 
 /**
@@ -84,6 +85,10 @@ public interface OpenApiConfig {
 
     default boolean privatePropertiesEnable() {
         return true;
+    }
+
+    default String propertyNamingStrategy() {
+        return JsonbConstants.IDENTITY;
     }
 
     default Map<String, String> getSchemas() {

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -37,6 +37,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     private String customSchemaRegistryClass;
     private Boolean applicationPathDisable;
     private Boolean privatePropertiesEnable;
+    private String propertyNamingStrategy;
     private Map<String, String> schemas;
     private String version;
     private String infoTitle;
@@ -251,6 +252,17 @@ public class OpenApiConfigImpl implements OpenApiConfig {
         }
 
         return privatePropertiesEnable;
+    }
+
+    @Override
+    public String propertyNamingStrategy() {
+        if (propertyNamingStrategy == null) {
+            propertyNamingStrategy = getConfig()
+                    .getOptionalValue(OpenApiConstants.SMALLRYE_PROPERTY_NAMING_STRATEGY, String.class)
+                    .orElse(OpenApiConfig.super.propertyNamingStrategy());
+        }
+
+        return propertyNamingStrategy;
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/openapi/api/constants/JacksonConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/JacksonConstants.java
@@ -22,6 +22,8 @@ public class JacksonConstants {
             .createSimple("com.fasterxml.jackson.annotation.JsonPropertyOrder");
     public static final DotName JSON_UNWRAPPED = DotName
             .createSimple("com.fasterxml.jackson.annotation.JsonUnwrapped");
+    public static final DotName JSON_NAMING = DotName
+            .createSimple("com.fasterxml.jackson.databind.annotation.JsonNaming");
 
     public static final String PROP_VALUE = "value";
 

--- a/core/src/main/java/io/smallrye/openapi/api/constants/JsonbConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/JsonbConstants.java
@@ -13,6 +13,36 @@ import org.jboss.jandex.DotName;
  */
 public class JsonbConstants {
 
+    /*
+     * See jakarta.json.bind.config.PropertyNamingStrategy#IDENTITY
+     */
+    public static final String IDENTITY = "IDENTITY";
+
+    /*
+     * See jakarta.json.bind.config.PropertyNamingStrategy#LOWER_CASE_WITH_DASHES
+     */
+    public static final String LOWER_CASE_WITH_DASHES = "LOWER_CASE_WITH_DASHES";
+
+    /*
+     * See jakarta.json.bind.config.PropertyNamingStrategy#LOWER_CASE_WITH_UNDERSCORES
+     */
+    public static final String LOWER_CASE_WITH_UNDERSCORES = "LOWER_CASE_WITH_UNDERSCORES";
+
+    /*
+     * See jakarta.json.bind.config.PropertyNamingStrategy#UPPER_CAMEL_CASE
+     */
+    public static final String UPPER_CAMEL_CASE = "UPPER_CAMEL_CASE";
+
+    /*
+     * See jakarta.json.bind.config.PropertyNamingStrategy#UPPER_CAMEL_CASE_WITH_SPACES
+     */
+    public static final String UPPER_CAMEL_CASE_WITH_SPACES = "UPPER_CAMEL_CASE_WITH_SPACES";
+
+    /*
+     * See jakarta.json.bind.config.PropertyNamingStrategy#CASE_INSENSITIVE
+     */
+    public static final String CASE_INSENSITIVE = "CASE_INSENSITIVE";
+
     public static final List<DotName> JSONB_PROPERTY = Arrays.asList(
             DotName.createSimple("javax.json.bind.annotation.JsonbProperty"),
             DotName.createSimple("jakarta.json.bind.annotation.JsonbProperty"));

--- a/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
@@ -23,6 +23,7 @@ public final class OpenApiConstants {
     public static final String SUFFIX_CUSTOM_SCHEMA_REGISTRY_CLASS = "custom-schema-registry.class";
     public static final String SUFFIX_APP_PATH_DISABLE = "application-path.disable";
     public static final String SUFFIX_PRIVATE_PROPERTIES_ENABLE = "private-properties.enable";
+    public static final String SUFFIX_PROPERTY_NAMING_STRATEGY = "property-naming-strategy";
 
     public static final String SCAN_DEPENDENCIES_DISABLE = OASConfig.EXTENSIONS_PREFIX + SUFFIX_SCAN_DEPENDENCIES_DISABLE;
     public static final String SCAN_DEPENDENCIES_JARS = OASConfig.EXTENSIONS_PREFIX + SUFFIX_SCAN_DEPENDENCIES_JARS;
@@ -38,6 +39,7 @@ public final class OpenApiConstants {
     public static final String SMALLRYE_CUSTOM_SCHEMA_REGISTRY_CLASS = SMALLRYE_PREFIX + SUFFIX_CUSTOM_SCHEMA_REGISTRY_CLASS;
     public static final String SMALLRYE_APP_PATH_DISABLE = SMALLRYE_PREFIX + SUFFIX_APP_PATH_DISABLE;
     public static final String SMALLRYE_PRIVATE_PROPERTIES_ENABLE = SMALLRYE_PREFIX + SUFFIX_PRIVATE_PROPERTIES_ENABLE;
+    public static final String SMALLRYE_PROPERTY_NAMING_STRATEGY = SMALLRYE_PREFIX + SUFFIX_PROPERTY_NAMING_STRATEGY;
 
     public static final String VERSION = SMALLRYE_PREFIX + "openapi";
     public static final String INFO_TITLE = SMALLRYE_PREFIX + "info.title";

--- a/core/src/main/java/io/smallrye/openapi/runtime/OpenApiRuntimeException.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/OpenApiRuntimeException.java
@@ -11,6 +11,14 @@ public class OpenApiRuntimeException extends RuntimeException {
 
     private static final long serialVersionUID = 8472532911884999427L;
 
+    public OpenApiRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OpenApiRuntimeException(String message) {
+        super(message);
+    }
+
     public OpenApiRuntimeException(Throwable cause) {
         super(cause);
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/DataObjectMessages.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/DataObjectMessages.java
@@ -1,8 +1,11 @@
 package io.smallrye.openapi.runtime.scanner.dataobject;
 
 import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
+
+import io.smallrye.openapi.runtime.OpenApiRuntimeException;
 
 @MessageBundle(projectCode = "SROAP", length = 5)
 interface DataObjectMessages {
@@ -10,4 +13,11 @@ interface DataObjectMessages {
 
     @Message(id = 7000, value = "Input parameter can not be null")
     RuntimeException notNull();
+
+    @Message(id = 7001, value = "Invalid property-naming-strategy: %s")
+    OpenApiRuntimeException invalidPropertyNamingStrategy(String configValue);
+
+    @Message(id = 7002, value = "Exception accessing property-naming-strategy: %s")
+    OpenApiRuntimeException invalidPropertyNamingStrategyWithCause(String configValue, @Cause Throwable cause);
+
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/PropertyNamingStrategyFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/PropertyNamingStrategyFactory.java
@@ -1,0 +1,126 @@
+package io.smallrye.openapi.runtime.scanner.dataobject;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import io.smallrye.openapi.api.constants.JsonbConstants;
+
+public class PropertyNamingStrategyFactory {
+
+    private static final String JSONB_TRANSLATE_NAME = "translateName";
+    private static final String JACKSON_TRANSLATE = "translate";
+    private static final List<String> knownMethods = Arrays.asList(JSONB_TRANSLATE_NAME, JACKSON_TRANSLATE);
+    private static final Map<String, UnaryOperator<String>> STRATEGY_CACHE = new ConcurrentHashMap<>();
+
+    private PropertyNamingStrategyFactory() {
+    }
+
+    public static UnaryOperator<String> getStrategy(String configValue, ClassLoader loader) {
+        return STRATEGY_CACHE.computeIfAbsent(configValue, key -> create(configValue, loader));
+    }
+
+    private static UnaryOperator<String> create(String configValue, ClassLoader loader) {
+        switch (configValue) {
+            case JsonbConstants.IDENTITY:
+                return propertyName -> propertyName;
+            case JsonbConstants.LOWER_CASE_WITH_DASHES:
+                return new ConfigurableNamingStrategy(Character::toLowerCase, '-');
+            case JsonbConstants.LOWER_CASE_WITH_UNDERSCORES:
+                return new ConfigurableNamingStrategy(Character::toLowerCase, '_');
+            case JsonbConstants.UPPER_CAMEL_CASE:
+                return camelCaseStrategy();
+            case JsonbConstants.UPPER_CAMEL_CASE_WITH_SPACES:
+                final UnaryOperator<String> camelCase = camelCaseStrategy();
+                final UnaryOperator<String> space = new ConfigurableNamingStrategy(UnaryOperator.identity(), ' ');
+                return propertyName -> camelCase.apply(space.apply(propertyName));
+            case JsonbConstants.CASE_INSENSITIVE:
+                return propertyName -> propertyName;
+            default:
+                final Class<?> strategyType;
+                final Object strategy;
+
+                try {
+                    strategyType = loader.loadClass(configValue);
+                    strategy = strategyType.getConstructor().newInstance();
+                } catch (Exception e) {
+                    throw DataObjectMessages.msg.invalidPropertyNamingStrategyWithCause(configValue, e);
+                }
+
+                return Arrays.stream(strategyType.getMethods())
+                        .filter(PropertyNamingStrategyFactory::isStringUnaryOperator)
+                        .filter(method -> knownMethods.contains(method.getName()))
+                        .map(method -> (UnaryOperator<String>) propertyName -> {
+                            try {
+                                return (String) method.invoke(strategy, propertyName);
+                            } catch (Exception e) {
+                                throw DataObjectMessages.msg.invalidPropertyNamingStrategyWithCause(configValue, e);
+                            }
+                        })
+                        .findFirst()
+                        .orElseThrow(() -> DataObjectMessages.msg.invalidPropertyNamingStrategy(configValue));
+        }
+    }
+
+    private static boolean isStringUnaryOperator(Method method) {
+        if (!String.class.equals(method.getReturnType())) {
+            return false;
+        }
+        if (method.getParameterCount() != 1) {
+            return false;
+        }
+
+        return String.class.equals(method.getParameterTypes()[0]);
+    }
+
+    private static UnaryOperator<String> camelCaseStrategy() {
+        return propertyName -> Character.toUpperCase(propertyName.charAt(0))
+                + (propertyName.length() > 1 ? propertyName.substring(1) : "");
+    }
+
+    private static class ConfigurableNamingStrategy implements UnaryOperator<String> {
+        private final Function<Character, Character> converter;
+        private final char separator;
+
+        public ConfigurableNamingStrategy(final UnaryOperator<Character> wordConverter, final char sep) {
+            this.converter = wordConverter;
+            this.separator = sep;
+        }
+
+        @Override
+        public String apply(final String propertyName) {
+            final StringBuilder global = new StringBuilder();
+            final StringBuilder current = new StringBuilder();
+
+            for (int i = 0; i < propertyName.length(); i++) {
+                final char c = propertyName.charAt(i);
+
+                if (Character.isUpperCase(c)) {
+                    final char transformed = converter.apply(c);
+
+                    if (current.length() > 0) {
+                        global.append(current).append(separator);
+                        current.setLength(0);
+                    }
+
+                    current.append(transformed);
+                } else {
+                    current.append(c);
+                }
+            }
+
+            if (current.length() > 0) {
+                global.append(current);
+            } else {
+                global.setLength(global.length() - 1); // remove last sep
+            }
+
+            return global.toString();
+        }
+    }
+
+}

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.IndexView;
@@ -15,6 +16,7 @@ import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
 import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
 import io.smallrye.openapi.runtime.scanner.dataobject.AugmentedIndexView;
 import io.smallrye.openapi.runtime.scanner.dataobject.IgnoreResolver;
+import io.smallrye.openapi.runtime.scanner.dataobject.PropertyNamingStrategyFactory;
 import io.smallrye.openapi.runtime.scanner.dataobject.TypeResolver;
 
 /**
@@ -28,6 +30,7 @@ public class AnnotationScannerContext {
     private final IgnoreResolver ignoreResolver;
     private final List<AnnotationScannerExtension> extensions;
     private final OpenApiConfig config;
+    private final UnaryOperator<String> propertyNameTranslator;
     private final ClassLoader classLoader;
     private final OpenAPI openApi;
     private final Deque<Type> scanStack = new ArrayDeque<>();
@@ -44,6 +47,7 @@ public class AnnotationScannerContext {
         this.extensions = extensions;
         this.config = config;
         this.openApi = openApi;
+        this.propertyNameTranslator = PropertyNamingStrategyFactory.getStrategy(config.propertyNamingStrategy(), classLoader);
     }
 
     public AnnotationScannerContext(IndexView index, ClassLoader classLoader,
@@ -69,6 +73,10 @@ public class AnnotationScannerContext {
 
     public OpenApiConfig getConfig() {
         return config;
+    }
+
+    public UnaryOperator<String> getPropertyNameTranslator() {
+        return propertyNameTranslator;
     }
 
     public ClassLoader getClassLoader() {

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/PropertyNamingStrategyTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/PropertyNamingStrategyTest.java
@@ -1,0 +1,174 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.constants.JsonbConstants;
+import io.smallrye.openapi.api.constants.OpenApiConstants;
+import io.smallrye.openapi.runtime.OpenApiRuntimeException;
+
+class PropertyNamingStrategyTest extends IndexScannerTestBase {
+
+    @Test
+    void testSnakeCase() throws Exception {
+        Index index = indexOf(NameStrategyBean1.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(
+                dynamicConfig(OpenApiConstants.SMALLRYE_PROPERTY_NAMING_STRATEGY,
+                        "com.fasterxml.jackson.databind.PropertyNamingStrategies$SnakeCaseStrategy"),
+                index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.name-strategy-snake.json", result);
+    }
+
+    @Test
+    void testJacksonNamingIgnoresConfig() throws Exception {
+        Index index = indexOf(NameStrategyBean2.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(
+                dynamicConfig(OpenApiConstants.SMALLRYE_PROPERTY_NAMING_STRATEGY,
+                        "com.fasterxml.jackson.databind.PropertyNamingStrategies$SnakeCaseStrategy"),
+                index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.name-strategy-ignored.json", result);
+    }
+
+    @Test
+    void testJacksonNamingOverridesConfig() throws Exception {
+        Index index = indexOf(NameStrategyKebab.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(
+                dynamicConfig(OpenApiConstants.SMALLRYE_PROPERTY_NAMING_STRATEGY,
+                        "com.fasterxml.jackson.databind.PropertyNamingStrategies$SnakeCaseStrategy"),
+                index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.name-strategy-kebab.json", result);
+    }
+
+    @Test
+    void testInvalidNamingStrategyClass() throws Exception {
+        Index index = indexOf(NameStrategyKebab.class);
+        OpenApiConfig config = dynamicConfig(OpenApiConstants.SMALLRYE_PROPERTY_NAMING_STRATEGY,
+                "com.fasterxml.jackson.databind.PropertyNamingStrategies$InvalidStrategy");
+        assertThrows(OpenApiRuntimeException.class, () -> new OpenApiAnnotationScanner(config, index));
+    }
+
+    @Test
+    void testNoValidTranslationMethods() throws Exception {
+        Index index = indexOf(NameStrategyKebab.class);
+        OpenApiConfig config = dynamicConfig(OpenApiConstants.SMALLRYE_PROPERTY_NAMING_STRATEGY,
+                NoValidTranslationMethods.class.getName());
+        assertThrows(OpenApiRuntimeException.class, () -> new OpenApiAnnotationScanner(config, index));
+    }
+
+    @Test
+    void testInvalidPropertyNameTranslationAttempt() throws Exception {
+        Index index = indexOf(NameStrategyBean3.class);
+        OpenApiConfig config = dynamicConfig(OpenApiConstants.SMALLRYE_PROPERTY_NAMING_STRATEGY,
+                TranslationThrowsException.class.getName());
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, index);
+        assertThrows(OpenApiRuntimeException.class, () -> scanner.scan());
+    }
+
+    @ParameterizedTest(name = "testJsonbConstantStrategy-{0}")
+    @CsvSource({
+            JsonbConstants.IDENTITY + ", simpleStringOne|anotherField|Y|z",
+            JsonbConstants.LOWER_CASE_WITH_DASHES + ", simple-string-one|another-field|y|z",
+            JsonbConstants.LOWER_CASE_WITH_UNDERSCORES + ", simple_string_one|another_field|y|z",
+            JsonbConstants.UPPER_CAMEL_CASE + ", SimpleStringOne|AnotherField|Y|Z",
+            JsonbConstants.UPPER_CAMEL_CASE_WITH_SPACES + ", Simple String One|Another Field|Y|Z",
+            JsonbConstants.CASE_INSENSITIVE + ", simpleStringOne|anotherField|Y|z"
+    })
+    void testJsonbConstantStrategy(String strategy, String expectedNames) throws Exception {
+        Index index = indexOf(NameStrategyBean3.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(
+                dynamicConfig(OpenApiConstants.SMALLRYE_PROPERTY_NAMING_STRATEGY, strategy),
+                index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        Set<String> expectedNameSet = new TreeSet<>(Arrays.asList(expectedNames.split("\\|")));
+        Map<String, org.eclipse.microprofile.openapi.models.media.Schema> schemas = result.getComponents().getSchemas();
+        org.eclipse.microprofile.openapi.models.media.Schema schema = schemas.get(NameStrategyBean3.class.getSimpleName());
+        assertEquals(expectedNameSet.size(), schema.getProperties().size());
+        assertEquals(expectedNameSet, schema.getProperties().keySet());
+    }
+
+    @Schema
+    static class NameStrategyBean1 {
+        String simpleStringValue;
+        @Schema(name = "another-string", description = "Customize name locally")
+        String anotherStringValue;
+        @Schema(maximum = "10", description = "Schema present, but name defaults to global config")
+        int simpleIntegerValue;
+    }
+
+    @Schema
+    @JsonNaming // Ignore configured strategy, no value
+    static class NameStrategyBean2 {
+        String simpleString1;
+        Integer anotherField;
+    }
+
+    @Schema
+    @JsonNaming(value = com.fasterxml.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
+    static class NameStrategyKebab {
+        String simpleStringOne;
+        Integer anotherField;
+    }
+
+    @Schema
+    static class NameStrategyBean3 {
+        String simpleStringOne;
+        Integer anotherField;
+        BigDecimal Y;
+        double z;
+    }
+
+    public static class NoValidTranslationMethods {
+        public NoValidTranslationMethods() {
+        }
+
+        public String translate() {
+            return null;
+        }
+
+        public String translate(String v1, String v2) {
+            return null;
+        }
+
+        public String translateValue(int v1) {
+            return String.valueOf(v1);
+        }
+
+    }
+
+    public static class TranslationThrowsException {
+        public String translate(String value) {
+            throw new IllegalArgumentException("dummy");
+        }
+    }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.name-strategy-ignored.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.name-strategy-ignored.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "NameStrategyBean2": {
+        "type": "object",
+        "properties": {
+          "simpleString1": {
+            "type": "string"
+          },
+          "anotherField": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.name-strategy-kebab.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.name-strategy-kebab.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "NameStrategyKebab": {
+        "type": "object",
+        "properties": {
+          "simple-string-one": {
+            "type": "string"
+          },
+          "another-field": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.name-strategy-snake.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.name-strategy-snake.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "NameStrategyBean1": {
+        "type": "object",
+        "properties": {
+          "another-string": {
+            "type": "string",
+            "description": "Customize name locally"
+          },
+          "simple_integer_value": {
+            "format": "int32",
+            "maximum": 10,
+            "type": "integer",
+            "description": "Schema present, but name defaults to global config"
+          },
+          "simple_string_value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -209,7 +209,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         // Now find all jax-rs endpoints
         Collection<ClassInfo> resourceClasses = getJaxRsResourceClasses(context);
         for (ClassInfo resourceClass : resourceClasses) {
-            TypeResolver resolver = TypeResolver.forClass(context.getAugmentedIndex(), resourceClass, null);
+            TypeResolver resolver = TypeResolver.forClass(context, resourceClass, null);
             context.getResolverStack().push(resolver);
             processResourceClass(context, openApi, resourceClass, null);
             context.getResolverStack().pop();
@@ -358,7 +358,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             this.currentAppPath = createPathFromSegments(this.currentAppPath, subResourcePath);
             this.subResourceStack.push(locator);
 
-            TypeResolver resolver = TypeResolver.forClass(context.getAugmentedIndex(), subResourceClass, methodReturnType);
+            TypeResolver resolver = TypeResolver.forClass(context, subResourceClass, methodReturnType);
             context.getResolverStack().push(resolver);
 
             /*

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
@@ -210,7 +210,7 @@ public class JaxRsParameterProcessor extends AbstractParameterProcessor {
 
             if (targetType != null) {
                 ClassInfo beanParam = index.getClassByName(targetType.name());
-                this.scannerContext.getResolverStack().push(TypeResolver.forClass(index, beanParam, targetType));
+                this.scannerContext.getResolverStack().push(TypeResolver.forClass(this.scannerContext, beanParam, targetType));
                 readParametersInherited(beanParam, annotation, overriddenParametersOnly);
                 this.scannerContext.getResolverStack().pop();
             }

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -177,7 +177,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
 
         SpringLogging.log.processingController(controllerClass.simpleName());
 
-        TypeResolver resolver = TypeResolver.forClass(context.getAugmentedIndex(), controllerClass, null);
+        TypeResolver resolver = TypeResolver.forClass(context, controllerClass, null);
         context.getResolverStack().push(resolver);
 
         OpenAPI openApi = new OpenAPIImpl();

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
@@ -148,7 +148,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
 
         VertxLogging.log.processingRouteClass(routeClass.simpleName());
 
-        TypeResolver resolver = TypeResolver.forClass(context.getAugmentedIndex(), routeClass, null);
+        TypeResolver resolver = TypeResolver.forClass(context, routeClass, null);
         context.getResolverStack().push(resolver);
 
         OpenAPI openApi = new OpenAPIImpl();


### PR DESCRIPTION
Fixes #712 

The naming strategy code is based on the Apache Johnzon [implementation](https://github.com/apache/johnzon/blob/master/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/PropertyNamingStrategyFactory.java).