### PR TITLE
Fix compatiblity with eclipse EE9 transformer.

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -980,8 +980,8 @@ public abstract class AbstractParameterProcessor {
         return valueString;
     }
 
-    protected List<DotName> getDefaultAnnotationNames() {
-        return Collections.emptyList();
+    protected Set<DotName> getDefaultAnnotationNames() {
+        return Collections.emptySet();
     }
 
     protected String getDefaultAnnotationProperty() {
@@ -997,7 +997,7 @@ public abstract class AbstractParameterProcessor {
      * @return the default value
      */
     protected Object getDefaultValue(AnnotationTarget target) {
-        List<DotName> defaultAnnotationNames = getDefaultAnnotationNames();
+        Set<DotName> defaultAnnotationNames = getDefaultAnnotationNames();
         String annotationProperty = getDefaultAnnotationProperty();
 
         if (defaultAnnotationNames == null || defaultAnnotationNames.isEmpty() || annotationProperty == null) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/FrameworkParameter.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/FrameworkParameter.java
@@ -1,7 +1,7 @@
 package io.smallrye.openapi.runtime.scanner.spi;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
+import java.util.Set;
 
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
@@ -10,17 +10,17 @@ import org.jboss.jandex.DotName;
 
 public class FrameworkParameter {
 
-    public final List<DotName> names;
+    public final Set<DotName> names;
     public final Parameter.In location;
     public final Parameter.Style style;
     public final Parameter.Style defaultStyle;
     public final String mediaType;
 
     public FrameworkParameter(DotName name, In location, Style style, Style defaultStyle, String mediaType) {
-        this(Arrays.asList(name), location, style, defaultStyle, mediaType);
+        this(Collections.singleton(name), location, style, defaultStyle, mediaType);
     }
 
-    public FrameworkParameter(List<DotName> names, In location, Style style, Style defaultStyle, String mediaType) {
+    public FrameworkParameter(Set<DotName> names, In location, Style style, Style defaultStyle, String mediaType) {
         super();
         this.names = names;
         this.location = location;
@@ -29,7 +29,7 @@ public class FrameworkParameter {
         this.mediaType = mediaType;
     }
 
-    public List<DotName> getNames() {
+    public Set<DotName> getNames() {
         return names;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -339,7 +340,7 @@ public class JandexUtil {
      * @param names List of DotNames
      * @return AnnotationInstance
      */
-    public static AnnotationInstance getClassAnnotation(ClassInfo ct, List<DotName> names) {
+    public static AnnotationInstance getClassAnnotation(ClassInfo ct, Collection<DotName> names) {
         if (names == null || names.isEmpty()) {
             return null;
         }
@@ -370,7 +371,7 @@ public class JandexUtil {
      * @param names DotName
      * @return AnnotationInstance
      */
-    public static AnnotationInstance getAnnotation(FieldInfo field, List<DotName> names) {
+    public static AnnotationInstance getAnnotation(FieldInfo field, Collection<DotName> names) {
         if (names == null || names.isEmpty()) {
             return null;
         }
@@ -392,7 +393,7 @@ public class JandexUtil {
      * @param names DotName
      * @return AnnotationInstance
      */
-    public static AnnotationInstance getAnnotation(MethodInfo mi, List<DotName> names) {
+    public static AnnotationInstance getAnnotation(MethodInfo mi, Collection<DotName> names) {
         if (names == null || names.isEmpty()) {
             return null;
         }
@@ -424,7 +425,7 @@ public class JandexUtil {
      * @param annotations
      * @return
      */
-    public static boolean hasAnyOneOfAnnotation(final MethodInfo method, List<DotName> annotations) {
+    public static boolean hasAnyOneOfAnnotation(final MethodInfo method, Collection<DotName> annotations) {
         for (DotName dotName : annotations) {
             if (method.hasAnnotation(dotName)) {
                 return true;

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -670,7 +670,7 @@ public class TypeUtil {
                 .orElse(null);
     }
 
-    public static AnnotationInstance getAnnotation(AnnotationTarget annotationTarget, List<DotName> annotationNames) {
+    public static AnnotationInstance getAnnotation(AnnotationTarget annotationTarget, Collection<DotName> annotationNames) {
         if (annotationTarget == null) {
             return null;
         }

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -473,7 +473,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         }
     }
 
-    static Optional<String[]> getMediaTypes(MethodInfo resourceMethod, List<DotName> annotationName, String[] defaultValue) {
+    static Optional<String[]> getMediaTypes(MethodInfo resourceMethod, Set<DotName> annotationName, String[] defaultValue) {
         AnnotationInstance annotation = JandexUtil.getAnnotation(resourceMethod, annotationName);
 
         if (annotation == null) {

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsConstants.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsConstants.java
@@ -3,8 +3,8 @@ package io.smallrye.openapi.jaxrs;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.jboss.jandex.DotName;
 
@@ -16,82 +16,82 @@ import org.jboss.jandex.DotName;
  */
 public class JaxRsConstants {
 
-    static final List<DotName> APPLICATION = Arrays.asList(
+    static final Set<DotName> APPLICATION = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.core.Application"),
-            DotName.createSimple("jakarta.ws.rs.core.Application"));
-    static final List<DotName> APPLICATION_PATH = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.core.Application")));
+    static final Set<DotName> APPLICATION_PATH = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.ApplicationPath"),
-            DotName.createSimple("jakarta.ws.rs.ApplicationPath"));
-    static final List<DotName> PATH = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.ApplicationPath")));
+    static final Set<DotName> PATH = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.Path"),
-            DotName.createSimple("jakarta.ws.rs.Path"));
-    static final List<DotName> PRODUCES = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.Path")));
+    static final Set<DotName> PRODUCES = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.Produces"),
-            DotName.createSimple("jakarta.ws.rs.Produces"));
-    static final List<DotName> CONSUMES = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.Produces")));
+    static final Set<DotName> CONSUMES = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.Consumes"),
-            DotName.createSimple("jakarta.ws.rs.Consumes"));
-    static final List<DotName> EXCEPTION_MAPPER = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.Consumes")));
+    static final Set<DotName> EXCEPTION_MAPPER = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.ext.ExceptionMapper"),
-            DotName.createSimple("jakarta.ws.rs.ext.ExceptionMapper"));
-    static final List<DotName> QUERY_PARAM = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.ext.ExceptionMapper")));
+    static final Set<DotName> QUERY_PARAM = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.QueryParam"),
-            DotName.createSimple("jakarta.ws.rs.QueryParam"));
-    static final List<DotName> FORM_PARAM = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.QueryParam")));
+    static final Set<DotName> FORM_PARAM = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.FormParam"),
-            DotName.createSimple("jakarta.ws.rs.FormParam"));
-    static final List<DotName> COOKIE_PARAM = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.FormParam")));
+    static final Set<DotName> COOKIE_PARAM = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.CookieParam"),
-            DotName.createSimple("jakarta.ws.rs.CookieParam"));
-    static final List<DotName> PATH_PARAM = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.CookieParam")));
+    static final Set<DotName> PATH_PARAM = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.PathParam"),
-            DotName.createSimple("jakarta.ws.rs.PathParam"));
-    static final List<DotName> HEADER_PARAM = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.PathParam")));
+    static final Set<DotName> HEADER_PARAM = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.HeaderParam"),
-            DotName.createSimple("jakarta.ws.rs.HeaderParam"));
-    static final List<DotName> MATRIX_PARAM = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.HeaderParam")));
+    static final Set<DotName> MATRIX_PARAM = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.MatrixParam"),
-            DotName.createSimple("jakarta.ws.rs.MatrixParam"));
-    static final List<DotName> BEAN_PARAM = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.MatrixParam")));
+    static final Set<DotName> BEAN_PARAM = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.BeanParam"),
-            DotName.createSimple("jakarta.ws.rs.BeanParam"));
-    static final List<DotName> ASYNC_RESPONSE = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.BeanParam")));
+    static final Set<DotName> ASYNC_RESPONSE = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.container.AsyncResponse"),
-            DotName.createSimple("jakarta.ws.rs.container.AsyncResponse"));
-    static final List<DotName> DEFAULT_VALUE = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.container.AsyncResponse")));
+    static final Set<DotName> DEFAULT_VALUE = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.DefaultValue"),
-            DotName.createSimple("jakarta.ws.rs.DefaultValue"));
-    static final List<DotName> RESPONSE = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.DefaultValue")));
+    static final Set<DotName> RESPONSE = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.core.Response"),
-            DotName.createSimple("jakarta.ws.rs.core.Response"));
-    static final List<DotName> PATH_SEGMENT = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.core.Response")));
+    static final Set<DotName> PATH_SEGMENT = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.core.PathSegment"),
-            DotName.createSimple("jakarta.ws.rs.core.PathSegment"));
+            DotName.createSimple("jakarta.ws.rs.core.PathSegment")));
 
     static final DotName REGISTER_REST_CLIENT = DotName
             .createSimple("org.eclipse.microprofile.rest.client.inject.RegisterRestClient");
 
-    static final List<DotName> GET = Arrays.asList(
+    static final Set<DotName> GET = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.GET"),
-            DotName.createSimple("jakarta.ws.rs.GET"));
-    static final List<DotName> PUT = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.GET")));
+    static final Set<DotName> PUT = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.PUT"),
-            DotName.createSimple("jakarta.ws.rs.PUT"));
-    static final List<DotName> POST = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.PUT")));
+    static final Set<DotName> POST = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.POST"),
-            DotName.createSimple("jakarta.ws.rs.POST"));
-    static final List<DotName> DELETE = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.POST")));
+    static final Set<DotName> DELETE = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.DELETE"),
-            DotName.createSimple("jakarta.ws.rs.DELETE"));
-    static final List<DotName> HEAD = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.DELETE")));
+    static final Set<DotName> HEAD = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.HEAD"),
-            DotName.createSimple("jakarta.ws.rs.HEAD"));
-    static final List<DotName> OPTIONS = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.HEAD")));
+    static final Set<DotName> OPTIONS = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.OPTIONS"),
-            DotName.createSimple("jakarta.ws.rs.OPTIONS"));
-    static final List<DotName> PATCH = Arrays.asList(
+            DotName.createSimple("jakarta.ws.rs.OPTIONS")));
+    static final Set<DotName> PATCH = new TreeSet<>(Arrays.asList(
             DotName.createSimple("javax.ws.rs.PATCH"),
-            DotName.createSimple("jakarta.ws.rs.PATCH"));
+            DotName.createSimple("jakarta.ws.rs.PATCH")));
 
     static final String TO_RESPONSE_METHOD_NAME = "toResponse";
 

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameter.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameter.java
@@ -1,7 +1,7 @@
 package io.smallrye.openapi.jaxrs;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
+import java.util.Set;
 
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.jboss.jandex.DotName;
@@ -46,22 +46,22 @@ public enum JaxRsParameter {
 
     final FrameworkParameter parameter;
 
-    private JaxRsParameter(List<DotName> names, Parameter.In location, Parameter.Style style, Parameter.Style defaultStyle,
+    private JaxRsParameter(Set<DotName> names, Parameter.In location, Parameter.Style style, Parameter.Style defaultStyle,
             String mediaType) {
         this.parameter = new FrameworkParameter(names, location, style, defaultStyle, mediaType);
     }
 
     private JaxRsParameter(DotName name, Parameter.In location, Parameter.Style style, Parameter.Style defaultStyle,
             String mediaType) {
-        this(Arrays.asList(name), location, style, defaultStyle, mediaType);
+        this(Collections.singleton(name), location, style, defaultStyle, mediaType);
     }
 
-    private JaxRsParameter(List<DotName> names, Parameter.In location, Parameter.Style style, Parameter.Style defaultStyle) {
+    private JaxRsParameter(Set<DotName> names, Parameter.In location, Parameter.Style style, Parameter.Style defaultStyle) {
         this(names, location, style, defaultStyle, null);
     }
 
     private JaxRsParameter(DotName name, Parameter.In location, Parameter.Style style, Parameter.Style defaultStyle) {
-        this(Arrays.asList(name), location, style, defaultStyle);
+        this(Collections.singleton(name), location, style, defaultStyle);
     }
 
     static FrameworkParameter forName(DotName annotationName) {

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
@@ -3,6 +3,7 @@ package io.smallrye.openapi.jaxrs;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -218,7 +219,7 @@ public class JaxRsParameterProcessor extends AbstractParameterProcessor {
     }
 
     @Override
-    protected List<DotName> getDefaultAnnotationNames() {
+    protected Set<DotName> getDefaultAnnotationNames() {
         return JaxRsConstants.DEFAULT_VALUE;
     }
 

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringParameterProcessor.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringParameterProcessor.java
@@ -3,7 +3,7 @@ package io.smallrye.openapi.spring;
 import static org.jboss.jandex.AnnotationTarget.Kind.CLASS;
 import static org.jboss.jandex.AnnotationTarget.Kind.METHOD;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
@@ -143,8 +143,8 @@ public class SpringParameterProcessor extends AbstractParameterProcessor {
     }
 
     @Override
-    protected List<DotName> getDefaultAnnotationNames() {
-        return Arrays.asList(SpringConstants.QUERY_PARAM);
+    protected Set<DotName> getDefaultAnnotationNames() {
+        return Collections.singleton(SpringConstants.QUERY_PARAM);
     }
 
     @Override


### PR DESCRIPTION
The eclipse EE9 transformer (https://projects.eclipse.org/projects/technology.transformer), which is used by WildFly (and other EE8+9 servers), performs runtime transformation of "javax" -> "jakarta", including the strings in JaxRsConstants.
This results in lists containing 2 identical elements, which causes all sorts of issues, since the smallrye-open-api codebase assumes element uniqueness of these lists.
Converting these lists to sets solves the problem.