### PR TITLE
Use resource class for class-based operation naming strategies

### DIFF
--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -406,7 +406,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
                         .orElse(null));
 
         // Process any @Operation annotation
-        Optional<Operation> maybeOperation = processOperation(context, method);
+        Optional<Operation> maybeOperation = processOperation(context, resourceClass, method);
         if (!maybeOperation.isPresent()) {
             return; // If the operation is marked as hidden, just bail here because we don't want it as part of the model.
         }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationIdTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationIdTest.java
@@ -4,6 +4,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -12,6 +13,9 @@ import io.smallrye.openapi.api.OpenApiConfigImpl;
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.runtime.OpenApiProcessor;
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
+import test.io.smallrye.openapi.runtime.scanner.resources.jakarta.Salutation;
+import test.io.smallrye.openapi.runtime.scanner.resources.jakarta.SalutationEnglish;
+import test.io.smallrye.openapi.runtime.scanner.resources.jakarta.SalutationSpanish;
 
 /**
  * Basic tests to check the operation Id autogeneration
@@ -45,4 +49,16 @@ class OperationIdTest extends JaxRsDataObjectScannerTestBase {
         }
     }
 
+    @Test
+    void testInheritedOperationIdsUtilizeConcreteClassName() throws Exception {
+        try {
+            OpenApiConfig config = dynamicConfig(OpenApiConstants.OPERATION_ID_STRAGEGY, "CLASS_METHOD");
+            Index index = indexOf(Salutation.class, SalutationEnglish.class, SalutationSpanish.class);
+            OpenAPI result = OpenApiProcessor.bootstrap(config, index);
+            printToConsole(result);
+            assertJsonEquals("resource.testOperationIdWithInheritance.json", result);
+        } finally {
+            System.clearProperty(OpenApiConstants.OPERATION_ID_STRAGEGY);
+        }
+    }
 }

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/jakarta/Salutation.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/jakarta/Salutation.java
@@ -1,0 +1,13 @@
+package test.io.smallrye.openapi.runtime.scanner.resources.jakarta;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+public interface Salutation {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get();
+
+}

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/jakarta/SalutationEnglish.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/jakarta/SalutationEnglish.java
@@ -1,0 +1,13 @@
+package test.io.smallrye.openapi.runtime.scanner.resources.jakarta;
+
+import jakarta.ws.rs.Path;
+
+@Path("/english")
+public class SalutationEnglish implements Salutation {
+
+    @Override
+    public String get() {
+        return "hello";
+    }
+
+}

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/jakarta/SalutationSpanish.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/jakarta/SalutationSpanish.java
@@ -1,0 +1,13 @@
+package test.io.smallrye.openapi.runtime.scanner.resources.jakarta;
+
+import jakarta.ws.rs.Path;
+
+@Path("/spanish")
+public class SalutationSpanish implements Salutation {
+
+    @Override
+    public String get() {
+        return "hola";
+    }
+
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdWithInheritance.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testOperationIdWithInheritance.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/english": {
+      "get": {
+        "operationId": "SalutationEnglish_get",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/spanish": {
+      "get": {
+        "operationId": "SalutationSpanish_get",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -298,7 +298,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
                 context.getConfig().getDefaultProduces().orElse(OpenApiConstants.DEFAULT_MEDIA_TYPES.get())).orElse(null));
 
         // Process any @Operation annotation
-        Optional<Operation> maybeOperation = processOperation(context, method);
+        Optional<Operation> maybeOperation = processOperation(context, resourceClass, method);
         if (!maybeOperation.isPresent()) {
             return; // If the operation is marked as hidden, just bail here because we don't want it as part of the model.
         }

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
@@ -259,7 +259,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
                     context.getConfig().getDefaultProduces().orElse(OpenApiConstants.DEFAULT_MEDIA_TYPES.get())).orElse(null));
 
             // Process any @Operation annotation
-            Optional<Operation> maybeOperation = processOperation(context, method);
+            Optional<Operation> maybeOperation = processOperation(context, resourceClass, method);
             if (!maybeOperation.isPresent()) {
                 return; // If the operation is marked as hidden, just bail here because we don't want it as part of the model.
             }


### PR DESCRIPTION
Fixes #819 

- Move operation Id strategy logic to scanner after reading operation annotation