### PR TITLE
Disable non-public properties, rather than private

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -495,9 +495,9 @@ public class TypeResolver {
             properties.values()
                     .stream()
                     .filter(TypeResolver::isExposedByDefault)
-                    .filter(resolver -> isPrivateOrAbsent(resolver.field))
-                    .filter(resolver -> isPrivateOrAbsent(resolver.readMethod))
-                    .filter(resolver -> isPrivateOrAbsent(resolver.writeMethod))
+                    .filter(resolver -> isNonPublicOrAbsent(resolver.field))
+                    .filter(resolver -> isNonPublicOrAbsent(resolver.readMethod))
+                    .filter(resolver -> isNonPublicOrAbsent(resolver.writeMethod))
                     .forEach(property -> property.ignored = true);
         }
 
@@ -512,12 +512,12 @@ public class TypeResolver {
         return !Modifier.isStatic(field.flags()) && !field.isSynthetic();
     }
 
-    private static boolean isPrivateOrAbsent(FieldInfo field) {
-        return field == null || Modifier.isPrivate(field.flags());
+    private static boolean isNonPublicOrAbsent(FieldInfo field) {
+        return field == null || !Modifier.isPublic(field.flags());
     }
 
-    private static boolean isPrivateOrAbsent(MethodInfo method) {
-        return method == null || Modifier.isPrivate(method.flags());
+    private static boolean isNonPublicOrAbsent(MethodInfo method) {
+        return method == null || !Modifier.isPublic(method.flags());
     }
 
     /**

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -474,15 +474,19 @@ class TypeResolverTests extends IndexScannerTestBase {
         class Test {
             private String field1;
             public String field2;
+            protected String field3;
+            String field4;
         }
 
         Map<String, TypeResolver> properties = getProperties(Test.class,
                 dynamicConfig(OpenApiConstants.SMALLRYE_PRIVATE_PROPERTIES_ENABLE, false),
                 Test.class);
 
-        assertEquals(2, properties.size());
+        assertEquals(4, properties.size());
         assertTrue(properties.get("field1").isIgnored());
         assertFalse(properties.get("field2").isIgnored());
+        assertTrue(properties.get("field3").isIgnored());
+        assertTrue(properties.get("field4").isIgnored());
     }
 
     @Test
@@ -492,15 +496,21 @@ class TypeResolverTests extends IndexScannerTestBase {
             @Schema(hidden = false)
             private String field1;
             public String field2;
+            @Schema(hidden = false)
+            protected String field3;
+            @Schema(hidden = false)
+            String field4;
         }
 
         Map<String, TypeResolver> properties = getProperties(Test.class,
                 dynamicConfig(OpenApiConstants.SMALLRYE_PRIVATE_PROPERTIES_ENABLE, false),
                 Test.class);
 
-        assertEquals(2, properties.size());
+        assertEquals(4, properties.size());
         assertFalse(properties.get("field1").isIgnored());
         assertFalse(properties.get("field2").isIgnored());
+        assertFalse(properties.get("field3").isIgnored());
+        assertFalse(properties.get("field4").isIgnored());
     }
 
     @Test
@@ -510,26 +520,40 @@ class TypeResolverTests extends IndexScannerTestBase {
             private String field1;
             @Schema(hidden = true)
             public String field2;
+            protected String field3;
+            String field4;
         }
 
         Map<String, TypeResolver> properties = getProperties(Test.class,
                 dynamicConfig(OpenApiConstants.SMALLRYE_PRIVATE_PROPERTIES_ENABLE, false),
                 Test.class);
 
-        assertEquals(2, properties.size());
+        assertEquals(4, properties.size());
         assertTrue(properties.get("field1").isIgnored());
         assertTrue(properties.get("field2").isIgnored());
+        assertTrue(properties.get("field3").isIgnored());
+        assertTrue(properties.get("field4").isIgnored());
     }
 
     @Test
-    void testPrivatePropertyVisibleWithProtectedGetter() {
+    void testPrivatePropertyVisibleWithPublicGetter() {
         @SuppressWarnings("unused")
         class Test {
             private String field1;
             public String field2;
+            protected String field3;
+            String field4;
 
             public String getField1() {
                 return field1;
+            }
+
+            public String getField3() {
+                return field3;
+            }
+
+            public String getField4() {
+                return field4;
             }
         }
 
@@ -537,9 +561,11 @@ class TypeResolverTests extends IndexScannerTestBase {
                 dynamicConfig(OpenApiConstants.SMALLRYE_PRIVATE_PROPERTIES_ENABLE, false),
                 Test.class);
 
-        assertEquals(2, properties.size());
+        assertEquals(4, properties.size());
         assertFalse(properties.get("field1").isIgnored());
         assertFalse(properties.get("field2").isIgnored());
+        assertFalse(properties.get("field3").isIgnored());
+        assertFalse(properties.get("field4").isIgnored());
     }
 
     @Test
@@ -548,6 +574,8 @@ class TypeResolverTests extends IndexScannerTestBase {
         class Test {
             private String field1;
             private String field2;
+            private String field3;
+            private String field4;
 
             public String getField1() {
                 return field1;
@@ -556,15 +584,25 @@ class TypeResolverTests extends IndexScannerTestBase {
             private String getField2() {
                 return field2;
             }
+
+            protected String getField3() {
+                return field3;
+            }
+
+            String getField4() {
+                return field4;
+            }
         }
 
         Map<String, TypeResolver> properties = getProperties(Test.class,
                 dynamicConfig(OpenApiConstants.SMALLRYE_PRIVATE_PROPERTIES_ENABLE, false),
                 Test.class);
 
-        assertEquals(2, properties.size());
+        assertEquals(4, properties.size());
         assertFalse(properties.get("field1").isIgnored());
         assertTrue(properties.get("field2").isIgnored());
+        assertTrue(properties.get("field3").isIgnored());
+        assertTrue(properties.get("field4").isIgnored());
     }
 
     @Test
@@ -580,15 +618,25 @@ class TypeResolverTests extends IndexScannerTestBase {
             private String getField2() {
                 return "field2";
             }
+
+            protected String getField3() {
+                return "field3";
+            }
+
+            String getField4() {
+                return "field4";
+            }
         }
 
         Map<String, TypeResolver> properties = getProperties(Test.class,
                 dynamicConfig(OpenApiConstants.SMALLRYE_PRIVATE_PROPERTIES_ENABLE, false),
                 Test.class);
 
-        assertEquals(2, properties.size());
+        assertEquals(4, properties.size());
         assertFalse(properties.get("field1").isIgnored());
         assertTrue(properties.get("field2").isIgnored());
+        assertTrue(properties.get("field3").isIgnored());
+        assertTrue(properties.get("field4").isIgnored());
     }
 
     @Test


### PR DESCRIPTION
Update the private-properties.enable config property to enable or
disable non-public properties, rather than just private ones.

Fixes #825 

There wasn't much feedback on the issue so I've gone ahead and created this PR which changes the meaning of `private-properties.enable` to affect all non-public properties. Let me know if you'd prefer this was fixed in a different way, e.g. by introducing separate properties to configure protected or package scoped properties.