### PR TITLE
Support `RestResponse` in JAX-RS scanner (Quarkus 2.1.0.CR1 test dep)

### DIFF
--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -67,6 +67,12 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
     }
 
     @Override
+    public boolean isWrapperType(Type type) {
+        return type.name().equals(RestEasyConstants.REACTIVE_REST_RESPONSE)
+                && type.kind().equals(Type.Kind.PARAMETERIZED_TYPE);
+    }
+
+    @Override
     public boolean isAsyncResponse(final MethodInfo method) {
         return method.parameters()
                 .stream()

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/RestEasyConstants.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/RestEasyConstants.java
@@ -42,6 +42,8 @@ public class RestEasyConstants {
             .createSimple("org.jboss.resteasy.reactive.RestHeader");
     public static final DotName REACTIVE_REST_MATRIX = DotName
             .createSimple("org.jboss.resteasy.reactive.RestMatrix");
+    public static final DotName REACTIVE_REST_RESPONSE = DotName
+            .createSimple("org.jboss.resteasy.reactive.RestResponse");
 
     // RestEasy multi-part form annotations
     public static final DotName MULTIPART_FORM = DotName

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/RestEasyReactiveAllTheParamsTestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/RestEasyReactiveAllTheParamsTestResource.java
@@ -21,6 +21,7 @@ import org.jboss.resteasy.reactive.RestHeader;
 import org.jboss.resteasy.reactive.RestMatrix;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
+import org.jboss.resteasy.reactive.RestResponse;
 
 @Path(value = "/all/the/params/{id1}/{id2}")
 @SuppressWarnings(value = "unused")
@@ -58,7 +59,7 @@ public class RestEasyReactiveAllTheParamsTestResource {
 
     @GET
     @Produces(value = MediaType.APPLICATION_JSON)
-    public Widget get(@RestQuery(value = "q1") @Deprecated long q1, @RestQuery(value = "q2") String notQ2) {
+    public RestResponse<Widget> get(@RestQuery(value = "q1") @Deprecated long q1, @RestQuery(value = "q2") String notQ2) {
         return null;
     }
 

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/RestEasyReactiveAllTheParamsTestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/RestEasyReactiveAllTheParamsTestResource.java
@@ -11,6 +11,7 @@ import org.jboss.resteasy.reactive.RestHeader;
 import org.jboss.resteasy.reactive.RestMatrix;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
+import org.jboss.resteasy.reactive.RestResponse;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BeanParam;
@@ -59,7 +60,7 @@ public class RestEasyReactiveAllTheParamsTestResource {
 
     @GET
     @Produces(value = MediaType.APPLICATION_JSON)
-    public Widget get(@RestQuery(value = "q1") @Deprecated long q1, @RestQuery(value = "q2") String notQ2) {
+    public RestResponse<Widget> get(@RestQuery(value = "q1") @Deprecated long q1, @RestQuery(value = "q2") String notQ2) {
         return null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <version.arquillian.jetty>1.0.0.CR3</version.arquillian.jetty>
         <version.jetty>9.3.29.v20201019</version.jetty>
         <version.resteasy>4.7.0.Final</version.resteasy>
-        <version.quarkus>2.0.3.Final</version.quarkus>
+        <version.quarkus>2.1.0.CR1</version.quarkus>
 
         <!--
             xmlReportPaths must contain an entry for each project that reports coverage.
@@ -215,7 +215,7 @@
                 <artifactId>javax.annotation-api</artifactId>
                 <version>1.3.2</version>
             </dependency>
-        
+
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
@@ -285,7 +285,7 @@
         <!-- We add the test dependencies here, to control the Jakarta EE versions.
              This allows us to create both javax.* and jakarta.* namespace tests.
              The implementation itself does not depend on any Jakarta EE libraries -->
-        
+
         <!-- CDI -->
         <dependency>
             <groupId>jakarta.enterprise</groupId>


### PR DESCRIPTION
Fixes #844 