### PR TITLE
Add multipleOf test

### DIFF
--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaPropertyTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaPropertyTest.java
@@ -52,7 +52,8 @@ class SchemaPropertyTest extends IndexScannerTestBase {
             @SchemaProperty(name = "lengthUnits", defaultValue = "CM")
     })
     static class Snake extends Reptile {
-        int length;
+        @Schema(multipleOf = 0.1)
+        double length;
         @Schema(description = "The units of measure for length", defaultValue = "MM")
         LengthUnits lengthUnits;
     }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-merge.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-merge.json
@@ -40,8 +40,9 @@
                 ]
               },
               "length": {
-                "format": "int32",
-                "type": "integer"
+                "format": "double",
+                "type": "number",
+                "multipleOf": 0.1
               }
             }
           }


### PR DESCRIPTION
`0.1` is used as the value here as it's not unusual and jandex currently has issues reading it.

This test won't pass until a new version of jandex is released and dependencies updated.

For #869 