### PR TITLE
Use `type: string` with `format: binary` for `InputStream` and `byte[]`

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -139,7 +139,9 @@ public class AnnotationTargetProcessor implements RequirementHandler {
             typeSchema = typeProcessor.getSchema();
 
             // Set any default values that apply to the type schema as a result of the TypeProcessor
-            TypeUtil.applyTypeAttributes(fieldType, typeSchema);
+            if (!TypeUtil.isTypeOverridden(fieldType, schemaAnnotation)) {
+                TypeUtil.applyTypeAttributes(fieldType, typeSchema);
+            }
 
             // The registeredTypeSchema will be a reference to typeSchema if registration occurs
             Type registrationType = TypeUtil.isWrappedType(entityType) ? fieldType : entityType;
@@ -315,7 +317,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
         // Provide inferred type and format if relevant.
         Map<String, Object> defaults;
 
-        if (JandexUtil.isArraySchema(annotation)) {
+        if (JandexUtil.isArraySchema(annotation) || TypeUtil.isTypeOverridden(postProcessedField, annotation)) {
             defaults = Collections.emptyMap();
         } else {
             defaults = TypeUtil.getTypeAttributes(postProcessedField);

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -524,7 +524,7 @@ public abstract class AbstractParameterProcessor {
             Type paramType = JandexUtil.value(schemaAnnotation, SchemaConstant.PROP_IMPLEMENTATION, context.targetType);
             Map<String, Object> defaults;
 
-            if (JandexUtil.isArraySchema(schemaAnnotation)) {
+            if (JandexUtil.isArraySchema(schemaAnnotation) || TypeUtil.isTypeOverridden(context.targetType, schemaAnnotation)) {
                 defaults = Collections.emptyMap();
             } else {
                 defaults = TypeUtil.getTypeAttributes(paramType);

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -270,7 +270,7 @@ public class JandexUtil {
      * @return Value of property
      */
     public static <T extends Enum<?>> T enumValue(AnnotationInstance annotation, String propertyName, Class<T> clazz) {
-        AnnotationValue value = annotation.value(propertyName);
+        AnnotationValue value = annotation != null ? annotation.value(propertyName) : null;
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -53,6 +53,7 @@ public class TypeUtil {
     private static final Type OBJECT_TYPE = Type.create(DOTNAME_OBJECT, Type.Kind.CLASS);
     private static final String UUID_PATTERN = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
     private static final TypeWithFormat STRING_FORMAT = TypeWithFormat.of(SchemaType.STRING).build();
+    private static final TypeWithFormat BINARY_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.BINARY).build();
     private static final TypeWithFormat BYTE_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.BYTE).build();
     private static final TypeWithFormat CHAR_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.BYTE).build();
     private static final TypeWithFormat UUID_FORMAT = TypeWithFormat.of(SchemaType.STRING).format(DataFormat.UUID)
@@ -113,6 +114,10 @@ public class TypeUtil {
         TYPE_MAP.put(DotName.createSimple(byte.class.getName()), BYTE_FORMAT);
         TYPE_MAP.put(DotName.createSimple(Character.class.getName()), CHAR_FORMAT);
         TYPE_MAP.put(DotName.createSimple(char.class.getName()), CHAR_FORMAT);
+
+        // Binary (any sequence of octets)
+        TYPE_MAP.put(DotName.createSimple(byte[].class.getName()), BINARY_FORMAT);
+        TYPE_MAP.put(DotName.createSimple(java.io.InputStream.class.getName()), BINARY_FORMAT);
 
         // Number
         TYPE_MAP.put(DotName.createSimple(Number.class.getName()), NUMBER_FORMAT);
@@ -270,7 +275,7 @@ public class TypeUtil {
      */
     private static TypeWithFormat getTypeFormat(Type type) {
         if (type.kind() == Type.Kind.ARRAY) {
-            return arrayFormat();
+            return TYPE_MAP.getOrDefault(type.name(), arrayFormat());
         }
 
         return TYPE_MAP.getOrDefault(getName(type), objectFormat());
@@ -448,19 +453,24 @@ public class TypeUtil {
     }
 
     public static boolean isTerminalType(Type type) {
-        if (type.kind() == Type.Kind.TYPE_VARIABLE ||
-                type.kind() == Type.Kind.WILDCARD_TYPE ||
-                type.kind() == Type.Kind.ARRAY) {
-            return false;
+        boolean terminal;
+
+        switch (type.kind()) {
+            case PRIMITIVE:
+            case VOID:
+                terminal = true;
+                break;
+            case TYPE_VARIABLE:
+            case WILDCARD_TYPE:
+                terminal = false;
+                break;
+            default:
+                // If is known type.
+                terminal = !getTypeFormat(type).isSchemaType(SchemaType.ARRAY, SchemaType.OBJECT);
+                break;
         }
 
-        if (type.kind() == Type.Kind.PRIMITIVE ||
-                type.kind() == Type.Kind.VOID) {
-            return true;
-        }
-
-        // If is known type.
-        return !getTypeFormat(type).isSchemaType(SchemaType.ARRAY, SchemaType.OBJECT);
+        return terminal;
     }
 
     public static boolean isWrappedType(Type type) {
@@ -901,6 +911,7 @@ public class TypeUtil {
         static final String INT64 = "int64";
         static final String FLOAT = "float";
         static final String DOUBLE = "double";
+        static final String BINARY = "binary";
         static final String BYTE = "byte";
         static final String DATE = "date";
         static final String DATE_TIME = "date-time";

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -318,6 +318,21 @@ public class TypeUtil {
     }
 
     /**
+     * Check if the default schema type that applies to the provided classType
+     * differs from any value specified by the user via schemaAnnotation.
+     * 
+     * @param classType class type to find a default schema type
+     * @param schemaAnnotation schema annotation (possibly null) which may have an overridden type value
+     * @return true if the annotation has a type specified that is different from the default type for classType, otherwise
+     *         false
+     */
+    public static boolean isTypeOverridden(Type classType, AnnotationInstance schemaAnnotation) {
+        SchemaType providedType = JandexUtil.enumValue(schemaAnnotation, SchemaConstant.PROP_TYPE, SchemaType.class);
+        TypeWithFormat typeFormat = getTypeFormat(classType);
+        return providedType != null && !typeFormat.isSchemaType(providedType);
+    }
+
+    /**
      * Sets the default schema attributes for the given type on the provided schema
      * instance.
      * 

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -486,9 +486,9 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
             @Schema(type = SchemaType.STRING)
             public char[] chars;
             @Schema(type = SchemaType.ARRAY)
-            public byte[] arrayFromSchema;
+            public char[] arrayFromSchema;
             @Schema
-            public byte[] arrayFromType;
+            public char[] arrayFromType;
         }
 
         Index index = indexOf(Sample.class);

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/MultipartFormTestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/MultipartFormTestResource.java
@@ -1,6 +1,7 @@
 package test.io.smallrye.openapi.runtime.scanner;
 
 import java.io.InputStream;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import javax.validation.constraints.NotNull;
@@ -53,6 +54,12 @@ public class MultipartFormTestResource {
         @PartType(value = MediaType.APPLICATION_OCTET_STREAM)
         @Schema(hidden = true)
         private InputStream undocumentedFile;
+        @FormParam(value = "listOfFileStreams")
+        @Schema(description = "List of streams")
+        private List<InputStream> files1;
+        @FormParam(value = "listOfBinaryArrays")
+        @Schema(description = "List of byte arrays")
+        private List<byte[]> files2;
     }
 
     @POST

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/MultipartFormTestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/MultipartFormTestResource.java
@@ -1,6 +1,7 @@
 package test.io.smallrye.openapi.runtime.scanner.jakarta;
 
 import java.io.InputStream;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -32,7 +33,6 @@ public class MultipartFormTestResource {
     }
 
     public static class Bean {
-
         @org.jboss.resteasy.annotations.jaxrs.FormParam
         @DefaultValue(value = "f1-default")
         String formField1;
@@ -54,6 +54,12 @@ public class MultipartFormTestResource {
         @PartType(value = MediaType.APPLICATION_OCTET_STREAM)
         @Schema(hidden = true)
         private InputStream undocumentedFile;
+        @FormParam(value = "listOfFileStreams")
+        @Schema(description = "List of streams")
+        private List<InputStream> files1;
+        @FormParam(value = "listOfBinaryArrays")
+        @Schema(description = "List of byte arrays")
+        private List<byte[]> files2;
     }
 
     @POST

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.beanparam-multipartform-inherited.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.beanparam-multipartform-inherited.json
@@ -73,11 +73,8 @@
                     "type": "string"
                   },
                   "icon": {
-                    "type": "array",
-                    "items": {
-                      "format": "byte",
-                      "type": "string"
-                    }
+                    "type" : "string",
+                    "format" : "binary"
                   }
                 }
               }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.multipart-form.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.multipart-form.json
@@ -57,8 +57,24 @@
                     "format": "binary"
                   },
                   "file": {
-                    "type": "string",
-                    "format": "binary"
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "listOfFileStreams": {
+                    "description": "List of streams",
+                    "type": "array",
+                    "items": {
+                      "format": "binary",
+                      "type": "string"
+                    }
+                  },
+                  "listOfBinaryArrays": {
+                    "description": "List of byte arrays",
+                    "type": "array",
+                    "items": {
+                      "format": "binary",
+                      "type": "string"
+                    }
                   }
                 }
               },


### PR DESCRIPTION
Looking at #857, I realized that we are not supporting the `binary` string format (https://swagger.io/specification/#data-types). @phillip-kruger, does this seem reasonable? The change is to default `InputStream` and `byte[]` to be strings of format `binary`. As mentioned in that issue, I'm don't think that `File` can be used for JAX-RS.