### PR TITLE
Add JDK 16 to build matrix (test latest in addition to LTS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11]
+        java: [11, 16]
     name: build with jdk ${{matrix.java}}
 
     steps:


### PR DESCRIPTION
@phillip-kruger - it would be good to have the latest JDK and any LTS we want to support in the build matrix (i.e. replace 16 with 17 when released). w.d.y.t? Maybe this will fix the build from thinking that it still needs to build JDK 8 :-)