### PR TITLE
Default to unsorted properties, add option to use sorted properties

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -91,6 +91,10 @@ public interface OpenApiConfig {
         return JsonbConstants.IDENTITY;
     }
 
+    default boolean sortedPropertiesEnable() {
+        return false;
+    }
+
     default Map<String, String> getSchemas() {
         return new HashMap<>();
     }

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -38,6 +38,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     private Boolean applicationPathDisable;
     private Boolean privatePropertiesEnable;
     private String propertyNamingStrategy;
+    private Boolean sortedPropertiesEnable;
     private Map<String, String> schemas;
     private String version;
     private String infoTitle;
@@ -263,6 +264,17 @@ public class OpenApiConfigImpl implements OpenApiConfig {
         }
 
         return propertyNamingStrategy;
+    }
+
+    @Override
+    public boolean sortedPropertiesEnable() {
+        if (sortedPropertiesEnable == null) {
+            sortedPropertiesEnable = getConfig()
+                    .getOptionalValue(OpenApiConstants.SMALLRYE_SORTED_PROPERTIES_ENABLE, Boolean.class)
+                    .orElse(OpenApiConfig.super.sortedPropertiesEnable());
+        }
+
+        return sortedPropertiesEnable;
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
@@ -24,6 +24,7 @@ public final class OpenApiConstants {
     public static final String SUFFIX_APP_PATH_DISABLE = "application-path.disable";
     public static final String SUFFIX_PRIVATE_PROPERTIES_ENABLE = "private-properties.enable";
     public static final String SUFFIX_PROPERTY_NAMING_STRATEGY = "property-naming-strategy";
+    public static final String SUFFIX_SORTED_PROPERTIES_ENABLE = "sorted-properties.enable";
 
     public static final String SCAN_DEPENDENCIES_DISABLE = OASConfig.EXTENSIONS_PREFIX + SUFFIX_SCAN_DEPENDENCIES_DISABLE;
     public static final String SCAN_DEPENDENCIES_JARS = OASConfig.EXTENSIONS_PREFIX + SUFFIX_SCAN_DEPENDENCIES_JARS;
@@ -40,6 +41,7 @@ public final class OpenApiConstants {
     public static final String SMALLRYE_APP_PATH_DISABLE = SMALLRYE_PREFIX + SUFFIX_APP_PATH_DISABLE;
     public static final String SMALLRYE_PRIVATE_PROPERTIES_ENABLE = SMALLRYE_PREFIX + SUFFIX_PRIVATE_PROPERTIES_ENABLE;
     public static final String SMALLRYE_PROPERTY_NAMING_STRATEGY = SMALLRYE_PREFIX + SUFFIX_PROPERTY_NAMING_STRATEGY;
+    public static final String SMALLRYE_SORTED_PROPERTIES_ENABLE = SMALLRYE_PREFIX + SUFFIX_SORTED_PROPERTIES_ENABLE;
 
     public static final String VERSION = SMALLRYE_PREFIX + "openapi";
     public static final String INFO_TITLE = SMALLRYE_PREFIX + "info.title";

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/FilteredIndexView.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/FilteredIndexView.java
@@ -10,6 +10,7 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.ModuleInfo;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 
@@ -225,7 +226,7 @@ public class FilteredIndexView implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getKnownClasses() {
-        return this.delegate.getKnownClasses().stream().filter(ci -> accepts(ci.name())).collect(Collectors.toList());
+        return filterClasses(this.delegate.getKnownClasses());
     }
 
     /**
@@ -245,8 +246,7 @@ public class FilteredIndexView implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getKnownDirectSubclasses(DotName className) {
-        return this.delegate.getKnownDirectSubclasses(className).stream().filter(ci -> accepts(ci.name()))
-                .collect(Collectors.toList());
+        return filterClasses(this.delegate.getKnownDirectSubclasses(className));
     }
 
     /**
@@ -254,8 +254,7 @@ public class FilteredIndexView implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getAllKnownSubclasses(DotName className) {
-        return this.delegate.getAllKnownSubclasses(className).stream().filter(ci -> accepts(ci.name()))
-                .collect(Collectors.toList());
+        return filterClasses(this.delegate.getAllKnownSubclasses(className));
     }
 
     /**
@@ -263,8 +262,7 @@ public class FilteredIndexView implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getKnownDirectImplementors(DotName className) {
-        return this.delegate.getKnownDirectImplementors(className).stream().filter(ci -> accepts(ci.name()))
-                .collect(Collectors.toList());
+        return filterClasses(this.delegate.getKnownDirectImplementors(className));
     }
 
     /**
@@ -272,8 +270,7 @@ public class FilteredIndexView implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getAllKnownImplementors(DotName interfaceName) {
-        return this.delegate.getAllKnownImplementors(interfaceName).stream().filter(ci -> accepts(ci.name()))
-                .collect(Collectors.toList());
+        return filterClasses(this.delegate.getAllKnownImplementors(interfaceName));
     }
 
     /**
@@ -290,6 +287,21 @@ public class FilteredIndexView implements IndexView {
     @Override
     public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName, IndexView annotationIndex) {
         return filterInstances(this.delegate.getAnnotationsWithRepeatable(annotationName, annotationIndex));
+    }
+
+    @Override
+    public Collection<ModuleInfo> getKnownModules() {
+        return delegate.getKnownModules();
+    }
+
+    @Override
+    public ModuleInfo getModuleByName(DotName moduleName) {
+        return delegate.getModuleByName(moduleName);
+    }
+
+    @Override
+    public Collection<ClassInfo> getKnownUsers(DotName className) {
+        return filterClasses(this.delegate.getKnownUsers(className));
     }
 
     private Collection<AnnotationInstance> filterInstances(Collection<AnnotationInstance> annotations) {
@@ -317,4 +329,9 @@ public class FilteredIndexView implements IndexView {
         }
     }
 
+    private Collection<ClassInfo> filterClasses(Collection<ClassInfo> classes) {
+        return classes.stream()
+                .filter(classInfo -> accepts(classInfo.name()))
+                .collect(Collectors.toList());
+    }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
@@ -6,6 +6,7 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.ModuleInfo;
 import org.jboss.jandex.Type;
 
 import io.smallrye.openapi.runtime.util.TypeUtil;
@@ -92,6 +93,23 @@ public class AugmentedIndexView implements IndexView {
     public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName, IndexView annotationIndex) {
         validateInput(annotationName, annotationIndex);
         return index.getAnnotationsWithRepeatable(annotationName, annotationIndex);
+    }
+
+    @Override
+    public Collection<ModuleInfo> getKnownModules() {
+        return index.getKnownModules();
+    }
+
+    @Override
+    public ModuleInfo getModuleByName(DotName moduleName) {
+        validateInput(moduleName);
+        return index.getModuleByName(moduleName);
+    }
+
+    @Override
+    public Collection<ClassInfo> getKnownUsers(DotName className) {
+        validateInput(className);
+        return index.getKnownUsers(className);
     }
 
     private void validateInput(Object... inputs) {

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -17,6 +17,8 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.constants.OpenApiConstants;
@@ -242,8 +244,8 @@ class TypeResolverTests extends IndexScannerTestBase {
         Iterator<Entry<String, TypeResolver>> iter = properties.entrySet().iterator();
         assertEquals("comment", iter.next().getValue().getPropertyName());
         assertEquals("name2", iter.next().getValue().getPropertyName());
-        assertEquals("comment2", iter.next().getValue().getPropertyName());
         assertEquals("name", iter.next().getValue().getPropertyName());
+        assertEquals("comment2", iter.next().getValue().getPropertyName());
     }
 
     @Test
@@ -660,5 +662,27 @@ class TypeResolverTests extends IndexScannerTestBase {
         Map<String, TypeResolver> properties = getProperties(Test.class, emptyConfig(), Test.class);
         assertEquals(1, properties.size());
         assertEquals("b", properties.keySet().iterator().next());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "false, c, b, a",
+            "true, a, b, c",
+    })
+    void testSortedPropertyNames(boolean unsortedEnabled, String first, String second, String third) {
+        @SuppressWarnings("unused")
+        class Test {
+            int c;
+            int b;
+            int a;
+        }
+
+        OpenApiConfig config = dynamicConfig(OpenApiConstants.SMALLRYE_SORTED_PROPERTIES_ENABLE, unsortedEnabled);
+        Map<String, TypeResolver> properties = getProperties(Test.class, config, Test.class);
+        assertEquals(3, properties.size());
+        Iterator<String> keys = properties.keySet().iterator();
+        assertEquals(first, keys.next());
+        assertEquals(second, keys.next());
+        assertEquals(third, keys.next());
     }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsDataObjectScannerTestBase.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsDataObjectScannerTestBase.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
+import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.api.util.ClassLoaderUtil;
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 
@@ -48,7 +49,8 @@ public class JaxRsDataObjectScannerTestBase extends IndexScannerTestBase {
 
     @BeforeEach
     public void createContext() {
-        context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(), emptyConfig());
+        context = new AnnotationScannerContext(index, ClassLoaderUtil.getDefaultClassLoader(),
+                dynamicConfig(OpenApiConstants.SMALLRYE_SORTED_PROPERTIES_ENABLE, Boolean.TRUE));
     }
 
     @AfterEach

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
@@ -91,14 +91,14 @@
         "required": [
             "arrayListNotNullAndNotEmptyAndMaxItems",
             "arrayListNullableAndMinItemsAndMaxItems",
-            "booleanNotNull",
-            "jacksonRequiredTrueString",
             "mapObjectNotNullAndNotEmptyAndMaxProperties",
             "mapObjectNullableAndMinPropertiesAndMaxProperties",
-            "stringNotBlankDigits",
             "stringNotBlankNotNull",
+            "stringNotBlankDigits",
             "stringNotEmptyMaxSize",
-            "stringNotEmptySizeRange"
+            "stringNotEmptySizeRange",
+            "booleanNotNull",
+            "jacksonRequiredTrueString"
         ],
         "properties": {
           "arrayListNotNullAndNotEmptyAndMaxItems": {

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.hidden-setter-readonly-props.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.hidden-setter-readonly-props.json
@@ -22,8 +22,8 @@
     "schemas": {
       "Policy437": {
         "required": [
-          "conditions",
-          "name"
+          "name",
+          "conditions"
         ],
         "type": "object",
         "properties": {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-parent</artifactId>
-        <version>30</version>
+        <version>31</version>
     </parent>
 
     <artifactId>smallrye-open-api-parent</artifactId>


### PR DESCRIPTION
Fixes #87 . Makes the default object property order the same as the order from the class file, as read by Jandex 2.4.0. This also adds a new option to restore the previous sorted property order. Can not be merged without smallrye/smallrye-parent#270 and a new parent version.