### PR TITLE
Ignore synthetic implementations of annotated interfaces

### DIFF
--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -531,14 +531,14 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
 
         FilteredIndexView filteredIndex = context.getIndex();
 
-        if (filteredIndex.getAllKnownImplementors(clazz.name()).stream().anyMatch(this::notAbstract)) {
+        if (filteredIndex.getAllKnownImplementors(clazz.name()).stream().anyMatch(this::neitherAbstractNorSynthetic)) {
             return true;
         }
 
         return filteredIndex.explicitlyAccepts(clazz.name());
     }
 
-    private boolean notAbstract(ClassInfo clazz) {
-        return !Modifier.isAbstract(clazz.flags());
+    private boolean neitherAbstractNorSynthetic(ClassInfo clazz) {
+        return !Modifier.isAbstract(clazz.flags()) && !clazz.isSynthetic();
     }
 }


### PR DESCRIPTION
Fixes #915 

@phillip-kruger - this worked for me with a custom-built index from the example project linked from #915. If we want a new unit test it would likely involve some custom `ClassInfo` with the synthetic flag set. Let me know what you think.