### PR TITLE
Support JAX-RS Response in Kotlin Continuation; ignore synthetic methods

### DIFF
--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
@@ -300,4 +300,33 @@ class ApiResponseTests extends IndexScannerTestBase {
         printToConsole(result);
         assertJsonEquals("responses.standin-generic-type-resolved.json", result);
     }
+
+    @Test
+    void testKotlinContinuationOpaqueResponse() throws IOException, JSONException {
+        @jakarta.ws.rs.Path("/")
+        class Resource {
+            @jakarta.ws.rs.POST
+            @jakarta.ws.rs.Produces({ "text/plain" })
+            @jakarta.ws.rs.Consumes({ "application/json" })
+            @jakarta.ws.rs.Path("1")
+            public Object wrongRequestBody(kotlin.Pair<String, String> var1,
+                    kotlin.coroutines.Continuation<? super jakarta.ws.rs.core.Response> $completion) {
+                return null;
+            }
+
+            @jakarta.ws.rs.POST
+            @jakarta.ws.rs.Produces({ "text/plain" })
+            @jakarta.ws.rs.Consumes({ "application/json" })
+            @jakarta.ws.rs.Path("2")
+            public jakarta.ws.rs.core.Response alsoWrong(kotlin.Pair<String, String> aPair) {
+                return null;
+            }
+        }
+
+        Index index = Index.of(Resource.class, kotlin.Pair.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+        OpenAPI result = scanner.scan();
+        printToConsole(result);
+        assertJsonEquals("responses.kotlin-continuation-opaque.json", result);
+    }
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.kotlin-continuation-opaque.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.kotlin-continuation-opaque.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/1": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PairStringString"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/2": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PairStringString"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PairStringString": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string"
+          },
+          "second": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #893 (@Turtle32 - please review and confirm if you have a chance)
Fixes #895 (@cogman - please review and confirm if you have a chance)

Relates to quarkusio/quarkus#18468