### PR TITLE
Handle non-parameterized ancestor in standin type parameter resolution

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -1090,6 +1090,10 @@ public class TypeResolver {
     }
 
     private static ParameterizedType createParameterizedType(Type targetType, Map<String, Type> resolutionMap) {
+        if (targetType.kind() != Type.Kind.PARAMETERIZED_TYPE) {
+            return ParameterizedType.create(targetType.name(), Type.EMPTY_ARRAY, null);
+        }
+
         Type[] resolvedArgs = resolveArguments(targetType.asParameterizedType(), t -> resolveType(t, resolutionMap));
         return ParameterizedType.create(targetType.name(), resolvedArgs, null);
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -487,6 +487,12 @@ public class TypeUtil {
             case WILDCARD_TYPE:
                 terminal = false;
                 break;
+            case CLASS:
+                if (DOTNAME_OBJECT.equals(type.name())) {
+                    terminal = true;
+                    break;
+                }
+                // Fall through
             default:
                 // If is known type.
                 terminal = !getTypeFormat(type).isSchemaType(SchemaType.ARRAY, SchemaType.OBJECT);

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.nonparameterized-ancestry-chain-link.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.nonparameterized-ancestry-chain-link.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "1PairStringString": {
+        "type": "array",
+        "items": {
+          "type": "object"
+        }
+      },
+      "TestBean": {
+        "type": "object",
+        "properties": {
+          "pair": {
+            "$ref": "#/components/schemas/1PairStringString"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #944 

- Create zero-arg parameterized type to complete inheritance chain toward parameterized ancestor
- Treat `java.lang.Object` as terminal type in `TypeUtil`