### PR TITLE
maven plugin - Reduce amount of created jandex indexes.

### DIFF
--- a/tools/maven-plugin/pom.xml
+++ b/tools/maven-plugin/pom.xml
@@ -28,8 +28,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>2.2.1</version>
+            <artifactId>maven-core</artifactId>
         </dependency>
         
         <dependency>
@@ -64,6 +63,18 @@
                 <configuration>
                     <goalPrefix>smallrye-open-api</goalPrefix>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+                <version>2.1.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenDependencyIndexCreator.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenDependencyIndexCreator.java
@@ -1,0 +1,177 @@
+package io.smallrye.openapi.mavenplugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.jboss.jandex.CompositeIndex;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.JarIndexer;
+import org.jboss.jandex.Result;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+@Component(role = MavenDependencyIndexCreator.class, instantiationStrategy = "singleton")
+public class MavenDependencyIndexCreator {
+
+    private final Cache<String, IndexView> indexCache = CacheBuilder.newBuilder().build();
+
+    private final Set<String> ignoredArtifacts = new HashSet<>();
+
+    @Requirement
+    private Logger logger;
+
+    public MavenDependencyIndexCreator() {
+        ignoredArtifacts.add("org.graalvm.sdk:graal-sdk");
+        ignoredArtifacts.add("org.yaml:snakeyaml");
+        ignoredArtifacts.add("org.wildfly.common:wildfly-common");
+        ignoredArtifacts.add("com.fasterxml.jackson.core:jackson-core");
+        ignoredArtifacts.add("com.fasterxml.jackson.core:jackson-databind");
+        ignoredArtifacts.add("io.smallrye.reactive:smallrye-mutiny-vertx-core");
+        ignoredArtifacts.add("commons-io:commons-io");
+        ignoredArtifacts.add("io.smallrye.reactive:mutiny");
+        ignoredArtifacts.add("org.jboss.narayana.jta:narayana-jta");
+        ignoredArtifacts.add("org.glassfish.jaxb:jaxb-runtime");
+        ignoredArtifacts.add("com.github.ben-manes.caffeine:caffeine");
+        ignoredArtifacts.add("org.hibernate.validator:hibernate-validator");
+        ignoredArtifacts.add("io.smallrye.config:smallrye-config-core");
+        ignoredArtifacts.add("com.thoughtworks.xstream:xstream");
+        ignoredArtifacts.add("com.github.javaparser:javaparser-core");
+        ignoredArtifacts.add("org.jboss:jandex");
+
+        ignoredArtifacts.add("antlr");
+        ignoredArtifacts.add("io.netty");
+        ignoredArtifacts.add("org.drools");
+        ignoredArtifacts.add("net.bytebuddy");
+        ignoredArtifacts.add("org.hibernate");
+        ignoredArtifacts.add("org.kie");
+        ignoredArtifacts.add("org.postgresql");
+        ignoredArtifacts.add("org.apache.httpcomponents");
+    }
+
+    public IndexView createIndex(MavenProject mavenProject, boolean scanDependenciesDisable,
+            List<String> includeDependenciesScopes, List<String> includeDependenciesTypes) throws Exception {
+
+        List<Map.Entry<Artifact, Duration>> indexDurations = new ArrayList<>();
+
+        IndexView moduleIndex = timeAndCache(indexDurations, mavenProject.getArtifact(), () -> {
+            try {
+                return indexModuleClasses(mavenProject);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Can't compute index", e);
+            }
+        });
+
+        if (scanDependenciesDisable) {
+            return moduleIndex;
+        }
+
+        List<IndexView> indexes = new ArrayList<>();
+        indexes.add(moduleIndex);
+        for (Artifact artifact : mavenProject.getArtifacts()) {
+            if (isIgnored(artifact, includeDependenciesScopes, includeDependenciesTypes)) {
+                continue;
+            }
+
+            IndexView artifactIndex = timeAndCache(indexDurations, artifact, () -> {
+                try {
+                    Result result = JarIndexer.createJarIndex(artifact.getFile(), new Indexer(),
+                            false, false, false);
+                    return result.getIndex();
+                } catch (Exception e) {
+                    logger.error("Can't compute index of " + artifact.getFile().getAbsolutePath() + ", skipping", e);
+                    return null;
+                }
+            });
+
+            if (artifactIndex != null) {
+                indexes.add(artifactIndex);
+            }
+        }
+
+        printIndexDurations(indexDurations);
+
+        return CompositeIndex.create(indexes);
+    }
+
+    private void printIndexDurations(List<Map.Entry<Artifact, Duration>> indexDurations) {
+        if (logger.isDebugEnabled()) {
+            indexDurations.sort(Map.Entry.comparingByValue());
+
+            indexDurations.forEach(e -> {
+                if (e.getValue().toMillis() > 25) {
+                    logger.debug(buildGAVCTString(e.getKey()) + " " + e.getValue());
+                }
+            });
+        }
+    }
+
+    private boolean isIgnored(Artifact artifact, List<String> includeDependenciesScopes,
+            List<String> includeDependenciesTypes) {
+        return !includeDependenciesScopes.contains(artifact.getScope())
+                || !includeDependenciesTypes.contains(artifact.getType())
+                || ignoredArtifacts.contains(artifact.getGroupId())
+                || ignoredArtifacts.contains(artifact.getGroupId() + ":" + artifact.getArtifactId());
+    }
+
+    private IndexView timeAndCache(List<Map.Entry<Artifact, Duration>> indexDurations, Artifact artifact,
+            Callable<IndexView> callable) throws Exception {
+        LocalDateTime start = LocalDateTime.now();
+        IndexView result = indexCache.get(buildGAVCTString(artifact), callable);
+        LocalDateTime end = LocalDateTime.now();
+
+        Duration duration = Duration.between(start, end);
+        indexDurations.add(new AbstractMap.SimpleEntry<>(artifact, duration));
+
+        return result;
+    }
+
+    // index the classes of this Maven module
+    private Index indexModuleClasses(MavenProject mavenProject) throws IOException {
+        Indexer indexer = new Indexer();
+
+        try (Stream<Path> stream = Files.walk(new File(mavenProject.getBuild().getOutputDirectory()).toPath())) {
+
+            List<Path> classFiles = stream
+                    .filter(path -> path.toString().endsWith(".class"))
+                    .collect(Collectors.toList());
+            for (Path path : classFiles) {
+                indexer.index(Files.newInputStream(path));
+            }
+        }
+        return indexer.complete();
+    }
+
+    private String buildGAVCTString(Artifact artifact) {
+        return artifact.getGroupId() +
+                ":" +
+                artifact.getArtifactId() +
+                ":" +
+                artifact.getVersion() +
+                ":" +
+                artifact.getClassifier() +
+                ":" +
+                artifact.getType();
+    }
+}


### PR DESCRIPTION
This introduces a blacklist of artifacts, for which no jandex index is ever created, since they won't have impact on the generated scheme.
Also, cache the indexes that are created using their gavct as key.

I tested this with a project with 2 modules, each module having 4 executions of the maven-plugin.
[sroa-scanpackages.zip](https://github.com/smallrye/smallrye-open-api/files/7492927/sroa-scanpackages.zip)
I ran `mvn clean compile` 3 times, taking the average reported by mvn as total time.

2.1.15: 19.067s
only blacklist: 7.003s
only cache: 5.471s
blacklist and cache: 4.447s

closes #954 