### PR TITLE
maven plugin - add option to attach schemas as build artifacts

### DIFF
--- a/tools/maven-plugin/README.adoc
+++ b/tools/maven-plugin/README.adoc
@@ -31,7 +31,8 @@ The schema will appear as `target/generated/openapi.yaml` and `target/generated/
 - `includeDependenciesScopes` - If the above `includeDependencies` is true, you can control what scopes should be included. Default is `compile, system`
 - `includeDependenciesTypes` - If the above `includeDependencies` is true, you can control what types should be included. Default is `jar`
 - `configProperties` - Load any properties from a file. Example `${basedir}/src/main/resources/application.properties`
-    
+- `attachArtifacts` - Attach the built OpenAPI schema as build artifacts.
+
 == MicroProfile OpenAPI Properties
 
 All properties from the MicroProfile OpenAPI Spec is supported. Properties set here will override the properties from `configProperties`.


### PR DESCRIPTION
Often, the schema from service a is used in project b, to e.g. generate a rest client.
This process is easier, when the schema is just available as another dependency.

This adds an option to attach all generated schemas as build artifacts, using following gavct:
project-groupid:project-artifactid:project-version:schemaName:json|yaml