### PR TITLE
maven plugin - Generate schema during incremental compilation

### DIFF
--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenDependencyIndexCreator.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenDependencyIndexCreator.java
@@ -75,13 +75,14 @@ public class MavenDependencyIndexCreator {
 
         List<Map.Entry<Artifact, Duration>> indexDurations = new ArrayList<>();
 
-        IndexView moduleIndex = timeAndCache(indexDurations, mavenProject.getArtifact(), () -> {
-            try {
-                return indexModuleClasses(mavenProject);
-            } catch (IOException e) {
-                throw new MojoExecutionException("Can't compute index", e);
-            }
-        });
+        // Don't' cache the moduleindex. Incremental compilation in IDE's would otherwise use the cached index instead of new one.
+        // Right now, support for incremental compilation inside eclipse is blocked by: https://github.com/eclipse-m2e/m2e-core/issues/364#issuecomment-939987848
+        IndexView moduleIndex;
+        try {
+            moduleIndex = indexModuleClasses(mavenProject);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Can't compute index", e);
+        }
 
         if (scanDependenciesDisable) {
             return moduleIndex;

--- a/tools/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tools/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<lifecycleMappingMetadata>
+    <pluginExecutions>
+        <pluginExecution>
+            <pluginExecutionFilter>
+                <goals>
+                    <goal>generate-schema</goal>
+                </goals>
+            </pluginExecutionFilter>
+            <action>
+                <execute>
+                    <runOnIncremental>true</runOnIncremental>
+                    <runOnConfiguration>false</runOnConfiguration>
+                </execute>
+            </action>
+        </pluginExecution>
+    </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
This triggers the schema build, whenever m2e decides to do an incremental build.
Right now, it is not possible to use the incremental build api (BuildContext class), since it is not compatibly with current maven versions. Therefore, index caching of the maven project artifact itself is removed for now.
This also adds the necessary metadata for eclipse to circumvent the infamous error "Plugin execution not covered by lifecycle configuration".

As reference, please see: 
* https://www.eclipse.org/m2e/documentation/m2e-making-maven-plugins-compat.html
* https://github.com/eclipse-m2e/m2e-core/issues/364#issuecomment-939987848

Draft for now, since this depends on #957 being merged first. That branch also fixes some NPEs when running inside m2e, e.g. Parameter${project.build.outputDirectory} resolves as null, but using the (imo cleaner) MavenProject API works fine.

![demo-build-on-save-eclipse](https://user-images.githubusercontent.com/1223135/140787591-c92cc74a-0886-431b-9805-55511b6d4689.gif)

