### PR TITLE
Add integration test for the maven-plugin info parameters

### DIFF
--- a/tools/maven-plugin/pom.xml
+++ b/tools/maven-plugin/pom.xml
@@ -14,6 +14,8 @@
     
     <properties>
         <sonar.skip>true</sonar.skip>
+
+        <itf-maven.version>0.11.0</itf-maven.version>
     </properties>
     
     <dependencies>
@@ -52,6 +54,25 @@
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.soebes.itf.jupiter.extension</groupId>
+            <artifactId>itf-jupiter-extension</artifactId>
+            <version>${itf-maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.soebes.itf.jupiter.extension</groupId>
+            <artifactId>itf-assertj</artifactId>
+            <version>${itf-maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.soebes.itf.jupiter.extension</groupId>
+            <artifactId>itf-extension-maven</artifactId>
+            <version>${itf-maven.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -72,6 +93,33 @@
                     <execution>
                         <goals>
                             <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.soebes.itf.jupiter.extension</groupId>
+                <artifactId>itf-maven-plugin</artifactId>
+                <version>${itf-maven.version}</version>
+                <executions>
+                    <execution>
+                        <id>installing</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>resources-its</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenDependencyIndexCreator.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenDependencyIndexCreator.java
@@ -150,15 +150,20 @@ public class MavenDependencyIndexCreator {
 
     // index the classes of this Maven module
     private Index indexModuleClasses(MavenProject mavenProject) throws IOException {
+
         Indexer indexer = new Indexer();
 
-        try (Stream<Path> stream = Files.walk(new File(mavenProject.getBuild().getOutputDirectory()).toPath())) {
+        // Check first if the classes directory exists, before attempting to create an index for the classes
+        File outputDirectory = new File(mavenProject.getBuild().getOutputDirectory());
+        if (outputDirectory.exists()) {
+            try (Stream<Path> stream = Files.walk(outputDirectory.toPath())) {
 
-            List<Path> classFiles = stream
-                    .filter(path -> path.toString().endsWith(".class"))
-                    .collect(Collectors.toList());
-            for (Path path : classFiles) {
-                indexer.index(Files.newInputStream(path));
+                List<Path> classFiles = stream
+                        .filter(path -> path.toString().endsWith(".class"))
+                        .collect(Collectors.toList());
+                for (Path path : classFiles) {
+                    indexer.index(Files.newInputStream(path));
+                }
             }
         }
         return indexer.complete();

--- a/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/BasicIT.java
+++ b/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/BasicIT.java
@@ -1,0 +1,51 @@
+package io.smallrye.openapi.mavenplugin;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+
+import com.soebes.itf.jupiter.extension.MavenGoal;
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+@MavenJupiterExtension
+@MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate-schema")
+public class BasicIT extends SchemaTestBase {
+    @MavenTest
+    void basic_info(MavenExecutionResult result) throws IOException {
+
+        assertThat(result).isSuccessful();
+
+        // Test which checks that the configured info parameters match the resulting schema info texts
+        Properties properties = result.getMavenProjectResult().getModel().getProperties();
+        Consumer<OpenAPI> schemaConsumer = (schema) -> {
+            assertEquals(properties.get("openApiVersion"), schema.getOpenapi());
+            assertEquals(properties.get("infoTitle"), schema.getInfo().getTitle());
+            assertEquals(properties.get("infoDescription"), schema.getInfo().getDescription());
+            assertEquals(properties.get("infoTermsOfService"), schema.getInfo().getTermsOfService());
+            assertEquals(properties.get("infoContactName"), schema.getInfo().getContact().getName());
+            assertEquals(properties.get("infoContactUrl"), schema.getInfo().getContact().getUrl());
+            assertEquals(properties.get("infoContactEmail"), schema.getInfo().getContact().getEmail());
+            assertEquals(properties.get("infoLicenseName"), schema.getInfo().getLicense().getName());
+            assertEquals(properties.get("infoLicenseUrl"),
+                    schema.getInfo().getLicense().getUrl());
+            assertEquals(properties.get("infoVersion"), schema.getInfo().getVersion());
+
+            List<String> servers = schema.getServers().stream().map(Server::getUrl).collect(Collectors.toList());
+
+            assertTrue(servers.contains(properties.get("server1").toString()));
+            assertTrue(servers.contains(properties.get("server2").toString()));
+        };
+
+        testSchema(result, schemaConsumer);
+    }
+}

--- a/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/SchemaTestBase.java
+++ b/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/SchemaTestBase.java
@@ -1,0 +1,37 @@
+package io.smallrye.openapi.mavenplugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+public class SchemaTestBase {
+
+    /**
+     * Helper method to check that yaml and json schemas match against given test conditions, which are given as consumer.
+     * 
+     * @param result
+     * @param schemaConsumer
+     */
+    protected void testSchema(MavenExecutionResult result, Consumer<OpenAPI> schemaConsumer) throws IOException {
+        schemaConsumer.accept(readJson(result));
+        schemaConsumer.accept(readYaml(result));
+    }
+
+    private OpenAPI readJson(MavenExecutionResult result) throws IOException {
+        File openapiFile = new File(result.getMavenProjectResult().getTargetProjectDirectory(),
+                "target/generated/openapi.json");
+
+        return TestObjectMapperHolder.json().readValue(openapiFile, OpenAPI.class);
+    }
+
+    private OpenAPI readYaml(MavenExecutionResult result) throws IOException {
+        File openapiFile = new File(result.getMavenProjectResult().getTargetProjectDirectory(),
+                "target/generated/openapi.yaml");
+
+        return TestObjectMapperHolder.yaml().readValue(openapiFile, OpenAPI.class);
+    }
+}

--- a/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/TestObjectMapperHolder.java
+++ b/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/TestObjectMapperHolder.java
@@ -1,0 +1,77 @@
+package io.smallrye.openapi.mavenplugin;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.info.Contact;
+import org.eclipse.microprofile.openapi.models.info.Info;
+import org.eclipse.microprofile.openapi.models.info.License;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+
+import io.smallrye.openapi.api.models.OpenAPIImpl;
+import io.smallrye.openapi.api.models.PathsImpl;
+import io.smallrye.openapi.api.models.info.ContactImpl;
+import io.smallrye.openapi.api.models.info.InfoImpl;
+import io.smallrye.openapi.api.models.info.LicenseImpl;
+import io.smallrye.openapi.api.models.servers.ServerImpl;
+
+public class TestObjectMapperHolder {
+    private static ObjectMapper json;
+
+    private static ObjectMapper yaml;
+
+    public static ObjectMapper json() {
+        if (json != null) {
+            return json;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        configure(mapper);
+
+        json = mapper;
+
+        return mapper;
+    }
+
+    public static ObjectMapper yaml() {
+        if (yaml != null) {
+            return yaml;
+        }
+
+        YAMLFactory factory = new YAMLFactory();
+        factory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
+        factory.enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS);
+        ObjectMapper mapper = new ObjectMapper(factory);
+
+        configure(mapper);
+
+        yaml = mapper;
+
+        return mapper;
+    }
+
+    private static void configure(ObjectMapper mapper) {
+        {
+            SimpleModule module = new SimpleModule("AbstractTypeMapping", Version.unknownVersion());
+
+            SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
+            resolver.addMapping(OpenAPI.class, OpenAPIImpl.class);
+            resolver.addMapping(Info.class, InfoImpl.class);
+            resolver.addMapping(Contact.class, ContactImpl.class);
+            resolver.addMapping(License.class, LicenseImpl.class);
+            resolver.addMapping(Server.class, ServerImpl.class);
+            resolver.addMapping(Paths.class, PathsImpl.class);
+
+            module.setAbstractTypes(resolver);
+
+            mapper.registerModule(module);
+        }
+    }
+}

--- a/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/basic_info/pom.xml
+++ b/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/basic_info/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.smallrye.openapi.mavenplugin</groupId>
+    <artifactId>basic_info</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <openApiVersion>custom-openapi-version</openApiVersion>
+        <infoTitle>Smallrye OpenAPI</infoTitle>
+        <infoVersion>2.1.15</infoVersion>
+        <infoDescription>Description of this schema</infoDescription>
+        <infoTermsOfService>custom-tos</infoTermsOfService>
+        <infoContactEmail>custom-info-email</infoContactEmail>
+        <infoContactName>Max Mustermann</infoContactName>
+        <infoContactUrl>https://example.com/contact</infoContactUrl>
+        <infoLicenseName>Apache License V2.0</infoLicenseName>
+        <infoLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</infoLicenseUrl>
+        <server1>https://prod.example.com</server1>
+        <server2>https://staging.example.com</server2>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <goals>
+                    <goal>generate-schema</goal>
+                </goals>
+                <configuration>
+                    <openApiVersion>${openApiVersion}</openApiVersion>
+                    <infoTitle>${infoTitle}</infoTitle>
+                    <infoVersion>${infoVersion}</infoVersion>
+                    <infoDescription>${infoDescription}</infoDescription>
+                    <infoTermsOfService>${infoTermsOfService}</infoTermsOfService>
+                    <infoContactEmail>${infoContactEmail}</infoContactEmail>
+                    <infoContactName>${infoContactName}</infoContactName>
+                    <infoContactUrl>${infoContactUrl}</infoContactUrl>
+                    <infoLicenseName>${infoLicenseName}</infoLicenseName>
+                    <infoLicenseUrl>${infoLicenseUrl}</infoLicenseUrl>
+                    <servers>
+                        <server>
+                            ${server1}
+                        </server>
+                        <server>
+                            ${server2}
+                        </server>
+                    </servers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Adds a basic test which makes sure that the infoX Parameters from the plugin are correctly used in the openapi schema.

Uses the integration testing framework extension to make integration tests for the maven-plugin possible.
The test pom has to be in resources-its.
The directory structure is based upon the Fully Qualified Class Name of the Test Class, and the last directory is named after the test.

This also adds everything needed (imo) to test against yaml / json schemas (SchemaTestBase.java), which makes it easier to later write more integration tests.

For reference:
* https://github.com/khmarbaise/maven-it-extension
* https://blog.soebes.de/blog/2020/08/18/itf-part-i/