### PR TITLE
maven-plugin - ignore resteasy-core

### DIFF
--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenDependencyIndexCreator.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenDependencyIndexCreator.java
@@ -59,6 +59,7 @@ public class MavenDependencyIndexCreator {
         ignoredArtifacts.add("com.thoughtworks.xstream:xstream");
         ignoredArtifacts.add("com.github.javaparser:javaparser-core");
         ignoredArtifacts.add("org.jboss:jandex");
+        ignoredArtifacts.add("org.jboss.resteasy:resteasy-core");
 
         ignoredArtifacts.add("antlr");
         ignoredArtifacts.add("io.netty");


### PR DESCRIPTION
It contains resources in org.jboss.resteasy.core.AsynchronousDispatcher, which we would include in the scheme.
This artifact is not part of the quarkus CombinedIndexBuildItem, so it seems ok to also ignore it for the maven plugin index.

closes #994