### PR TITLE
Release 2.1.18

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye OpenAPI
 release:
-  current-version: 2.1.17
-  next-version: 2.1.18-SNAPSHOT
+  current-version: 2.1.18
+  next-version: 2.1.19-SNAPSHOT


### PR DESCRIPTION
The first attempt at releasing 2.1.18 (#1059 ) had an issue due to the sorting of imports, fixed by #1060 