### PR TITLE
Remove graphviz installation, check import sorting in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           java-version: ${{matrix.java}}
 
-      - name: Install graphviz
-        run: sudo apt install graphviz
-
       - name: maven cache
         uses: actions/cache@v1
         with:
@@ -46,7 +43,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: build with maven
-        run: mvn -B formatter:validate verify --file pom.xml
+        run: mvn -B formatter:validate impsort:check verify --file pom.xml
 
       - uses: actions/upload-artifact@v2
         name: tck-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           java-version: 11
 
-      - name: Install graphviz
-        run: sudo apt install graphviz
-
       - name: maven release ${{steps.metadata.outputs.current-version}}
         run: |
           java -version


### PR DESCRIPTION
As far as I can tell, graphviz was added for an alternate JavaDoc doclet configuration, removed in 2d65f32. Also check import sorting in CI to avoid issues in release like #1059.