### PR TITLE
Keep a reference to the Java method parameter for later use in OASFilter

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/models/OperationImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/OperationImpl.java
@@ -335,4 +335,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
         this.methodRef = methodRef;
     }
 
+    static public String getMethodRef(Operation operation) {
+        return (operation instanceof OperationImpl) ? ((OperationImpl) operation).getMethodRef() : null;
+    }
 }

--- a/core/src/main/java/io/smallrye/openapi/api/models/parameters/ParameterImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/parameters/ParameterImpl.java
@@ -33,6 +33,8 @@ public class ParameterImpl extends ExtensibleImpl<Parameter> implements Paramete
     private Map<String, Example> examples;
     private Content content;
 
+    private String paramRef;
+
     /**
      * @see org.eclipse.microprofile.openapi.models.Reference#getRef()
      */
@@ -279,6 +281,23 @@ public class ParameterImpl extends ExtensibleImpl<Parameter> implements Paramete
             this.required = true;
         }
         this.in = in;
+    }
+
+    /**
+     * Implementation specific, set a reference to the Java method parameter, so that we can bind back to it later if needed
+     *
+     * @return reference to the method parameter that we scanned this on
+     */
+    public String getParamRef() {
+        return paramRef;
+    }
+
+    public void setParamRef(String paramRef) {
+        this.paramRef = paramRef;
+    }
+
+    static public String getParamRef(Parameter parameter) {
+        return (parameter instanceof ParameterImpl) ? ((ParameterImpl) parameter).getParamRef() : null;
     }
 
     public static boolean isHidden(Parameter parameter) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/parameter/ParameterReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/parameter/ParameterReader.java
@@ -153,7 +153,7 @@ public class ParameterReader {
             return null;
         }
         IoLogging.logger.singleAnnotation("@Parameter");
-        Parameter parameter = new ParameterImpl();
+        ParameterImpl parameter = new ParameterImpl();
         parameter.setName(JandexUtil.stringValue(annotationInstance, Parameterizable.PROP_NAME));
         parameter.setIn(JandexUtil.enumValue(annotationInstance, ParameterConstant.PROP_IN,
                 org.eclipse.microprofile.openapi.models.parameters.Parameter.In.class));
@@ -199,6 +199,8 @@ public class ParameterReader {
                 default:
                     break;
             }
+
+            parameter.setParamRef(JandexUtil.createUniqueAnnotationTargetRef(annotationInstance.target()));
         }
 
         return parameter;

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -469,11 +469,12 @@ public abstract class AbstractParameterProcessor {
      * @return a new ParameterContext if the parameter is found, otherwise null
      */
     protected ParameterContext getUnannotatedPathParameter(MethodInfo resourceMethod, String name) {
+        System.out.println("getUnannotatedPathParameter()");
         return null;
     }
 
     private Parameter mapParameter(MethodInfo resourceMethod, ParameterContext context) {
-        Parameter param = context.oaiParam != null ? context.oaiParam : new ParameterImpl();
+        ParameterImpl param = context.oaiParam != null ? (ParameterImpl) context.oaiParam : new ParameterImpl();
 
         param.setName(context.name);
 
@@ -494,6 +495,10 @@ public abstract class AbstractParameterProcessor {
 
         if (param.getRequired() == null && TypeUtil.isOptional(context.targetType)) {
             param.setRequired(Boolean.FALSE);
+        }
+
+        if (param.getParamRef() == null && context.target != null) {
+            param.setParamRef(JandexUtil.createUniqueAnnotationTargetRef(context.target));
         }
 
         return param;

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -78,8 +78,33 @@ public class JandexUtil {
     private JandexUtil() {
     }
 
+    public static String createUniqueAnnotationTargetRef(AnnotationTarget annotationTarget) {
+        switch (annotationTarget.kind()) {
+            case FIELD:
+                return JandexUtil.createUniqueFieldRef(annotationTarget.asField());
+            case METHOD:
+                ClassInfo classInfo = annotationTarget.asMethod().declaringClass();
+                return JandexUtil.createUniqueMethodReference(classInfo, annotationTarget.asMethod());
+            case METHOD_PARAMETER:
+                return JandexUtil.createUniqueMethodParameterRef(annotationTarget.asMethodParameter());
+            default:
+                return null;
+        }
+    }
+
+    public static String createUniqueFieldRef(FieldInfo fieldInfo) {
+        ClassInfo classInfo = fieldInfo.declaringClass();
+        return "f" + classInfo.hashCode() + "_" + fieldInfo.hashCode();
+    }
+
     public static String createUniqueMethodReference(ClassInfo classInfo, MethodInfo methodInfo) {
-        return "" + classInfo.hashCode() + "_" + methodInfo.hashCode();
+        return "m" + classInfo.hashCode() + "_" + methodInfo.hashCode();
+    }
+
+    public static String createUniqueMethodParameterRef(MethodParameterInfo methodParameter) {
+        final MethodInfo methodInfo = methodParameter.method();
+        final ClassInfo classInfo = methodInfo.declaringClass();
+        return "p" + classInfo.hashCode() + "_" + methodInfo.hashCode() + "_" + methodParameter.position();
     }
 
     /**

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
@@ -16,6 +16,7 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.Type;
 
 import io.smallrye.openapi.api.models.media.EncodingImpl;
@@ -126,7 +127,9 @@ public class JaxRsParameterProcessor extends AbstractParameterProcessor {
                 if (!JaxRsAnnotationScanner.containsJavaxAnnotations(annotations) &&
                         !JaxRsAnnotationScanner.containsJakartaAnnotations(annotations)) {
                     // If the parameter has annotations, use the first entry's target for use later when searching for BV constraints and extensions
-                    AnnotationTarget target = annotations.isEmpty() ? null : annotations.get(0).target();
+                    // else if the parameter has no annotations, create the target so that it can be matched by filters
+                    AnnotationTarget target = annotations.isEmpty() ? MethodParameterInfo.create(resourceMethod, (short) i)
+                            : annotations.get(0).target();
                     Type arg = methodParameters.get(i);
                     return new ParameterContext(name, JaxRsParameter.RESTEASY_REACTIVE_PATH_PARAM.parameter, target, arg);
                 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -26,6 +26,7 @@ class ParameterScanTests extends IndexScannerTestBase {
         OpenAPI result = scanner.scan();
         printToConsole(result);
         assertJsonEquals(expectedResource, result);
+        verifyMethodAndParamRefsPresent(result);
     }
 
     @Test


### PR DESCRIPTION
While `OperationImpl` has a `methodRef` property that can be used to match the method (as done in Quarkus `AutoRolesAllowedFilter`, `AutoTagFilter` etc.), `ParameterImpl` does not contain any information about the parameter's name or position. This PR introduces a `paramRef` for `Parameter` similar to `methodRef`.