### PR TITLE
Refine scanning property schemas composed with type schemas

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -145,15 +145,10 @@ public class SchemaRegistry {
         return register(type, views, resolver, schema, (registry, key) -> registry.registerReference(key));
     }
 
-    static Schema register(Type type, Set<Type> views, TypeResolver resolver, Schema schema,
+    public static Schema register(Type type, Set<Type> views, TypeResolver resolver, Schema schema,
             BiFunction<SchemaRegistry, TypeKey, Schema> registrationAction) {
-        Type resolvedType;
 
-        if (resolver == null) {
-            resolvedType = type;
-        } else {
-            resolvedType = resolver.resolve(type);
-        }
+        final Type resolvedType = TypeResolver.resolve(type, resolver);
 
         switch (resolvedType.kind()) {
             case CLASS:
@@ -200,15 +195,7 @@ public class SchemaRegistry {
             return false;
         }
 
-        Type resolvedType;
-
-        if (resolver != null) {
-            resolvedType = resolver.resolve(type);
-        } else {
-            resolvedType = type;
-        }
-
-        return registry.hasSchema(resolvedType, views);
+        return registry.hasSchema(TypeResolver.resolve(type, resolver), views);
     }
 
     /**
@@ -432,7 +419,7 @@ public class SchemaRegistry {
      *
      * @author Michael Edgar {@literal <michael@xlate.io>}
      */
-    static class TypeKey {
+    public static final class TypeKey {
         private final Type type;
         private final Set<Type> views;
         private int hashCode = 0;

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -152,6 +152,13 @@ public class TypeResolver {
         return 0;
     }
 
+    public static Type resolve(Type type, TypeResolver resolver) {
+        if (resolver != null) {
+            return resolver.resolve(type);
+        }
+        return type;
+    }
+
     private TypeResolver(UnaryOperator<String> nameTranslator, String propertyName, FieldInfo field,
             Deque<Map<String, Type>> resolutionStack) {
         this.nameTranslator = nameTranslator;

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -378,7 +378,7 @@ public class TypeUtil {
      * @param typeSchema the schema for a class type
      */
     public static void clearMatchingDefaultAttributes(Schema fieldSchema, Schema typeSchema) {
-        clearIfEqual(fieldSchema.getType(), typeSchema.getType(), fieldSchema::setType);
+        //clearIfEqual(fieldSchema.getType(), typeSchema.getType(), fieldSchema::setType);
         clearIfEqual(fieldSchema.getFormat(), typeSchema.getFormat(), fieldSchema::setFormat);
         clearIfEqual(fieldSchema.getPattern(), typeSchema.getPattern(), fieldSchema::setPattern);
         clearIfEqual(fieldSchema.getExample(), typeSchema.getExample(), fieldSchema::setExample);

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.field-overrides-type.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.field-overrides-type.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "Bean": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "title": "In-lined schema with overridden attributes",
+            "description": "Not 'The first bean'",
+            "type": "object",
+            "properties": {
+              "prop1": {
+                "maxLength": 4,
+                "type": "string"
+              },
+              "prop2": {
+                "type": "integer"
+              }
+            }
+          },
+          "second": {
+            "title": "Property with `allOf` referring to `OtherBean`",
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OtherBean"
+              }
+            ]
+          },
+          "third": {
+            "$ref": "#/components/schemas/OtherBean"
+          }
+        }
+      },
+      "OtherBean": {
+        "description": "The first bean",
+        "type": "object",
+        "properties": {
+          "prop1": {
+            "maxLength": 5,
+            "type": "string"
+          },
+          "prop2": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.nested-parameterized-collection-types.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.nested-parameterized-collection-types.json
@@ -16,10 +16,10 @@
             }
           },
           "b_multivaluedEntryMap" : {
+            "type": "object",
+            "description" : "Reference to `MultivaluedMapStringEntryBean",
             "allOf" : [ {
               "$ref" : "#/components/schemas/MultivaluedMapStringEntryBean"
-            }, {
-              "description" : "Reference to `MultivaluedMapStringEntryBean"
             } ]
           },
           "c_mapStringListEntryBean" : {
@@ -62,10 +62,10 @@
             }
           },
           "f_listOfStringLists" : {
+            "type": "array",
+            "description" : "Reference to `MultivaluedCollectionString`",
             "allOf" : [ {
               "$ref" : "#/components/schemas/MultivaluedCollectionString"
-            }, {
-              "description" : "Reference to `MultivaluedCollectionString`"
             } ]
           }
         }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.optional-arraytype.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.optional-arraytype.json
@@ -8,12 +8,10 @@
           "arrayOfOptionalB": {
             "type": "array",
             "items": {
+              "nullable": true,
               "allOf": [
                 {
                   "$ref": "#/components/schemas/B"
-                },
-                {
-                  "nullable": true
                 }
               ]
             }
@@ -30,12 +28,10 @@
           "listOfOptionalB": {
             "type": "array",
             "items": {
+              "nullable": true,
               "allOf": [
                 {
                   "$ref": "#/components/schemas/B"
-                },
-                {
-                  "nullable": true
                 }
               ]
             }
@@ -55,12 +51,11 @@
             "nullable": true
           },
           "optionalOfB": {
+            "type": "object",
+            "nullable": true,
             "allOf": [
               {
                 "$ref": "#/components/schemas/B"
-              },
-              {
-                "nullable": true
               }
             ]
           }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.registered-schema-type-preserved.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.registered-schema-type-preserved.json
@@ -20,12 +20,11 @@
             "example": "F176f717c7a71"
           },
           "data": {
+            "type": "object",
+            "description": "The business data object",
             "allOf": [
               {
                 "$ref": "#/components/schemas/MessageDataItemsAnimal"
-              },
-              {
-                "description": "The business data object"
               }
             ]
           },

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-merge.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-merge.json
@@ -29,13 +29,12 @@
             "type": "object",
             "properties": {
               "lengthUnits": {
+                "type": "string",
+                "description": "The units of measure for length",
+                "default": "CM",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/LengthUnitsEnum"
-                  },
-                  {
-                    "description": "The units of measure for length",
-                    "default": "CM"
                   }
                 ]
               },

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.optional-types.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.optional-types.json
@@ -290,12 +290,11 @@
             "nullable": true
           },
           "nested": {
+            "type": "object",
+            "nullable": true,
             "allOf": [
               {
                 "$ref": "#/components/schemas/NestedBean"
-              },
-              {
-                "nullable": true
               }
             ]
           }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.uuid-params-responses.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.uuid-params-responses.json
@@ -59,12 +59,11 @@
         "type": "object",
         "properties": {
           "theUUID": {
+            "type": "string",
+            "description": "test",
             "allOf": [
               {
                 "$ref": "#/components/schemas/UUID"
-              },
-              {
-                "description": "test"
               }
             ]
           }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.complexNesting.expected.json
@@ -12,12 +12,11 @@
             "type": "object"
           },
           "foo": {
+            "type": "object",
+            "maxLength": 123456,
             "allOf": [
               {
                 "$ref": "#/components/schemas/FuzzStringDate"
-              },
-              {
-                "maxLength": 123456
               }
             ]
           }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.generic.nested.expected.json
@@ -29,12 +29,11 @@
             "type": "integer"
           },
           "foo": {
+            "type": "object",
+            "maxLength": 123456,
             "allOf": [
               {
                 "$ref": "#/components/schemas/KustomPairStringString"
-              },
-              {
-                "maxLength": 123456
               }
             ]
           }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
@@ -218,12 +218,11 @@
             "type": "integer"
           },
           "foo": {
+            "type": "object",
+            "maxLength": 123456,
             "allOf": [
               {
                 "$ref": "#/components/schemas/FuzzStringObject"
-              },
-              {
-                "maxLength": 123456
               }
             ]
           }
@@ -280,12 +279,11 @@
             "$ref": "#/components/schemas/FooExtendsFoo"
           },
           "qValue": {
+            "type": "object",
+            "description": "Ah, Q, my favourite variable!",
             "allOf": [
               {
                 "$ref": "#/components/schemas/FooExtendsFoo"
-              },
-              {
-                "description": "Ah, Q, my favourite variable!"
               }
             ]
           },
@@ -328,12 +326,11 @@
             "type": "integer"
           },
           "foo": {
+            "type": "object",
+            "maxLength": 123456,
             "allOf": [
               {
                 "$ref": "#/components/schemas/KustomPairStringString"
-              },
-              {
-                "maxLength": 123456
               }
             ]
           }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.testNestedSchemaOnParameter.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.resource.testNestedSchemaOnParameter.json
@@ -47,12 +47,11 @@
             "$ref": "#/components/schemas/NestedParameterTestChild"
           },
           "another_child": {
+            "type": "object",
+            "description": "This schema will be unioned to $ref to 'another_nested', name will be used for the property, and this description will be present on this property",
             "allOf": [
               {
                 "$ref": "#/components/schemas/another_nested"
-              },
-              {
-                "description": "This schema will be unioned to $ref to 'another_nested', name will be used for the property, and this description will be present on this property"
               }
             ]
           },

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.string-implementation-wrapped.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.string-implementation-wrapped.json
@@ -26,12 +26,11 @@
         "type": "object",
         "properties": {
           "message": {
+            "type": "string",
+            "description": "Used to send a message",
             "allOf": [
               {
                 "$ref": "#/components/schemas/SimpleString"
-              },
-              {
-                "description": "Used to send a message"
               }
             ]
           },

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.time.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.time.json
@@ -113,12 +113,11 @@
         "type": "object",
         "properties": {
           "utc": {
+            "type": "string",
+            "description": "Current time at offset '00:00'",
             "allOf": [
               {
                 "$ref": "#/components/schemas/OffsetTime"
-              },
-              {
-                "description": "Current time at offset '00:00'"
               }
             ]
           }


### PR DESCRIPTION
Fixes #1023 

The intent of this change is to enhance the handling of POJO fields that are themselves a type of POJO, for example:
```java
@Schema(description = "A property bean")
class PropertyBean {
    String propertyField;
}

class MainBean {
    @Schema(description = "A field of the main bean")
    PropertyBean beanField;
}
```
Previously, this would have resulted in the following schema:
```json
{
  "properties": {
    "beanField": {
      "allOf": [
         {
           "description": "A field of the main bean"
         },
         {
           "$ref": "#/components/schemas/PropertyBean"
         }
      ]
    }
  }
}
```
This leads to confusion and a less easily read schema. With this change, the `description` is available directly on the `beanField`.
```json
{
  "properties": {
    "beanField": {
      "type": "object",
      "description": "A field of the main bean",
      "allOf": [ {
        "$ref": "#/components/schemas/PropertyBean"
      } ]
    }
  }
}
```
If any validation properties (assertions) are present and disagree between the property's schema and the referenced type's schema, the referenced schema will instead be in-lined in the property, with the local assertions overriding the type's assertions. \

An example is included in the newly-added test case, property `first` in `Bean`: https://github.com/smallrye/smallrye-open-api/pull/1092/files#diff-80320aadf521d607aeb6722138541b8a3faa1f4a1ce65e892ebaa20301e904a5 and the associated expectation https://github.com/smallrye/smallrye-open-api/pull/1092/files#diff-5ec486829cbc26ab485ea062e75f3672c4a4b1a1715bd3e43b1a120e1f6a2a6b