### PR TITLE
Implemented equals and hashCode in TagImpl

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/models/tags/TagImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/tags/TagImpl.java
@@ -74,12 +74,14 @@ public class TagImpl extends ExtensibleImpl<Tag> implements Tag, ModelImpl {
             return false;
         }
         TagImpl tag = (TagImpl) o;
-        return Objects.equals(name, tag.name) && Objects.equals(description, tag.description)
-                && Objects.equals(externalDocs, tag.externalDocs);
+        return Objects.equals(name, tag.name)
+                && Objects.equals(description, tag.description)
+                && Objects.equals(externalDocs, tag.externalDocs)
+                && Objects.equals(getExtensions(), tag.getExtensions());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, externalDocs);
+        return Objects.hash(name, description, externalDocs, getExtensions());
     }
 }

--- a/core/src/main/java/io/smallrye/openapi/api/models/tags/TagImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/tags/TagImpl.java
@@ -1,5 +1,7 @@
 package io.smallrye.openapi.api.models.tags;
 
+import java.util.Objects;
+
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
 
@@ -63,4 +65,21 @@ public class TagImpl extends ExtensibleImpl<Tag> implements Tag, ModelImpl {
         this.externalDocs = externalDocs;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TagImpl tag = (TagImpl) o;
+        return Objects.equals(name, tag.name) && Objects.equals(description, tag.description)
+                && Objects.equals(externalDocs, tag.externalDocs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, externalDocs);
+    }
 }


### PR DESCRIPTION
It would be nice to have `equals` and `hashCode` implemented in `TagImpl`, so we can compare instances of `org.eclipse.microprofile.openapi.models.tags.Tag`.