### PR TITLE
Support for SecurityRequirementsSet

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionConstant.java
@@ -21,6 +21,7 @@ public class DefinitionConstant {
     public static final String PROP_TAGS = "tags";
     public static final String PROP_COMPONENTS = "components";
     public static final String PROP_SECURITY = "security";
+    public static final String PROP_SECURITY_SET = "securitySet";
     public static final String PROP_OPENAPI = "openapi";
 
     private DefinitionConstant() {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
@@ -50,7 +50,9 @@ public class DefinitionReader {
         openApi.setServers(
                 ServerReader.readServers(annotationInstance.value(DefinitionConstant.PROP_SERVERS)).orElse(null));
         openApi.setSecurity(SecurityRequirementReader
-                .readSecurityRequirements(annotationInstance.value(DefinitionConstant.PROP_SECURITY)).orElse(null));
+                .readSecurityRequirements(annotationInstance.value(DefinitionConstant.PROP_SECURITY),
+                        annotationInstance.value(DefinitionConstant.PROP_SECURITY_SET))
+                .orElse(null));
         openApi.setExternalDocs(
                 ExternalDocsReader
                         .readExternalDocs(context, annotationInstance.value(ExternalDocsConstant.PROP_EXTERNAL_DOCS)));

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationConstant.java
@@ -20,6 +20,7 @@ public class OperationConstant {
     public static final String PROP_EXTENSIONS = "extensions";
     public static final String PROP_DESCRIPTION = "description";
     public static final String PROP_SECURITY = "security";
+    public static final String PROP_SECURITY_SET = "securitySet";
     public static final String PROP_REQUEST_BODY = "requestBody";
     public static final String PROP_PARAMETERS = "parameters";
     public static final String PROP_SERVERS = "servers";

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationReader.java
@@ -60,7 +60,9 @@ public class OperationReader {
             operation.setResponses(ResponseReader.readResponses(context,
                     annotationInstance.value(OperationConstant.PROP_RESPONSES)));
             operation.setSecurity(SecurityRequirementReader
-                    .readSecurityRequirements(annotationInstance.value(OperationConstant.PROP_SECURITY)).orElse(null));
+                    .readSecurityRequirements(annotationInstance.value(OperationConstant.PROP_SECURITY),
+                            annotationInstance.value(OperationConstant.PROP_SECURITY_SET))
+                    .orElse(null));
             operation.setExtensions(
                     ExtensionReader.readExtensions(context,
                             annotationInstance.value(OperationConstant.PROP_EXTENSIONS)));

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementConstant.java
@@ -2,6 +2,8 @@ package io.smallrye.openapi.runtime.io.securityrequirement;
 
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirements;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSets;
 import org.jboss.jandex.DotName;
 
 /**
@@ -17,6 +19,8 @@ public class SecurityRequirementConstant {
 
     static final DotName DOTNAME_SECURITY_REQUIREMENT = DotName.createSimple(SecurityRequirement.class.getName());
     static final DotName DOTNAME_SECURITY_REQUIREMENTS = DotName.createSimple(SecurityRequirements.class.getName());
+    static final DotName DOTNAME_SECURITY_REQUIREMENTS_SET = DotName.createSimple(SecurityRequirementsSet.class.getName());
+    static final DotName DOTNAME_SECURITY_REQUIREMENTS_SETS = DotName.createSimple(SecurityRequirementsSets.class.getName());
 
     public static final String PROP_NAME = "name";
     public static final String PROP_SCOPES = "scopes";

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
@@ -102,6 +102,7 @@ public class SecurityRequirementReader {
         SecurityRequirement requirement = new SecurityRequirementImpl();
         addSecurityRequirement(requirement, annotationInstance);
         if (requirement.getSchemes().isEmpty()) {
+            // Should only happen if the annotation was missing the required "name" property
             return null;
         } else {
             return requirement;

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
@@ -34,26 +34,43 @@ public class SecurityRequirementReader {
     }
 
     /**
-     * Reads any SecurityRequirement annotations. The annotation value is an array of
-     * SecurityRequirement annotations.
+     * Reads any SecurityRequirement and SecurityRequirementsSet annotations.
      * 
-     * @param annotationValue Array of {@literal @}SecurityRequirement annotations
+     * @param securityRequirements Array of {@literal @}SecurityRequirement annotations
+     * @param securityRequirementsSets Array of {@literal @}SecurityRequirementsSet annotation
      * @return List of SecurityRequirement models
      */
-    public static Optional<List<SecurityRequirement>> readSecurityRequirements(final AnnotationValue annotationValue) {
-        if (annotationValue != null) {
+    public static Optional<List<SecurityRequirement>> readSecurityRequirements(final AnnotationValue securityRequirements,
+            final AnnotationValue securityRequirementsSets) {
+        if (securityRequirements == null && securityRequirementsSets == null) {
+            return Optional.empty();
+        }
+
+        List<SecurityRequirement> requirements = new ArrayList<>();
+
+        if (securityRequirements != null) {
             IoLogging.logger.annotationsArray("@SecurityRequirement");
-            AnnotationInstance[] nestedArray = annotationValue.asNestedArray();
-            List<SecurityRequirement> requirements = new ArrayList<>();
+            AnnotationInstance[] nestedArray = securityRequirements.asNestedArray();
             for (AnnotationInstance requirementAnno : nestedArray) {
                 SecurityRequirement requirement = readSecurityRequirement(requirementAnno);
                 if (requirement != null) {
                     requirements.add(requirement);
                 }
             }
-            return Optional.of(requirements);
         }
-        return Optional.empty();
+
+        if (securityRequirementsSets != null) {
+            IoLogging.logger.annotationsArray("@SecurityRequirementsSet");
+            AnnotationInstance[] nestedArray = securityRequirementsSets.asNestedArray();
+            for (AnnotationInstance requirementSetAnno : nestedArray) {
+                SecurityRequirement requirement = readSecurityRequirementsSet(requirementSetAnno);
+                if (requirement != null) {
+                    requirements.add(requirement);
+                }
+            }
+        }
+
+        return Optional.of(requirements);
     }
 
     /**
@@ -82,19 +99,43 @@ public class SecurityRequirementReader {
      * @return SecurityRequirement model
      */
     public static SecurityRequirement readSecurityRequirement(AnnotationInstance annotationInstance) {
+        SecurityRequirement requirement = new SecurityRequirementImpl();
+        addSecurityRequirement(requirement, annotationInstance);
+        if (requirement.getSchemes().isEmpty()) {
+            return null;
+        } else {
+            return requirement;
+        }
+    }
+
+    /**
+     * Reads a single SecurityRequirementsSet annotation
+     * 
+     * @param annotationInstance the {@literal @}SecurityRequirementsSet annotation
+     * @return SecurityRequirement model
+     */
+    public static SecurityRequirement readSecurityRequirementsSet(AnnotationInstance annotationInstance) {
+        AnnotationValue value = annotationInstance.value();
+        SecurityRequirement requirement = new SecurityRequirementImpl();
+        if (value != null) {
+            for (AnnotationInstance securityRequirementInstance : value.asNestedArray()) {
+                addSecurityRequirement(requirement, securityRequirementInstance);
+            }
+        }
+        return requirement;
+    }
+
+    private static void addSecurityRequirement(SecurityRequirement requirement, AnnotationInstance annotationInstance) {
         String name = JandexUtil.stringValue(annotationInstance, SecurityRequirementConstant.PROP_NAME);
         if (name != null) {
             Optional<List<String>> maybeScopes = JandexUtil.stringListValue(annotationInstance,
                     SecurityRequirementConstant.PROP_SCOPES);
-            SecurityRequirement requirement = new SecurityRequirementImpl();
             if (maybeScopes.isPresent()) {
                 requirement.addScheme(name, maybeScopes.get());
             } else {
                 requirement.addScheme(name);
             }
-            return requirement;
         }
-        return null;
     }
 
     /**
@@ -132,5 +173,17 @@ public class SecurityRequirementReader {
         return JandexUtil.getRepeatableAnnotation(target,
                 SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENT,
                 SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS);
+    }
+
+    // helper methods for scanners
+    public static AnnotationInstance getSecurityRequirementsSetsAnnotation(final AnnotationTarget target) {
+        return TypeUtil.getAnnotation(target, SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS_SETS);
+    }
+
+    // helper methods for scanners
+    public static List<AnnotationInstance> getSecurityRequirementsSetAnnotations(final AnnotationTarget target) {
+        return JandexUtil.getRepeatableAnnotation(target,
+                SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS_SET,
+                SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS_SETS);
     }
 }


### PR DESCRIPTION
Support SecurityRequriementsSet, passing the TCKs added to
https://github.com/eclipse/microprofile-open-api/pull/519

Objects which support security requirements now support having both
individual security requirements and security requirements sets.

An individual security requirement is equivalent to a security
requirement set with a single element. Therefore, when reading
annotations, we always process both lists together.

I've opened this against the `jakarta` branch, since it requires changes which will be in MP OpenAPI 3.1 and left it as draft for the moment since there isn't a release available yet which includes these changes.