### PR TITLE
Support APIReponse on resource class

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
@@ -13,7 +13,6 @@ import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
-import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
@@ -263,13 +262,13 @@ public class ResponseReader {
         return responseAnnotation.value(ResponseConstant.PROP_RESPONSE_CODE) != null;
     }
 
-    public static AnnotationInstance getResponseAnnotation(final ClassInfo classInfo) {
-        return classInfo.classAnnotation(ResponseConstant.DOTNAME_API_RESPONSE);
-    }
-
-    public static AnnotationInstance getResponseAnnotation(final MethodInfo method) {
-        return method.annotation(ResponseConstant.DOTNAME_API_RESPONSE);
-    }
+    //    public static AnnotationInstance getResponseAnnotation(final ClassInfo classInfo) {
+    //        return classInfo.classAnnotation(ResponseConstant.DOTNAME_API_RESPONSE);
+    //    }
+    //
+    //    public static AnnotationInstance getResponseAnnotation(final MethodInfo method) {
+    //        return method.annotation(ResponseConstant.DOTNAME_API_RESPONSE);
+    //    }
 
     public static AnnotationInstance getResponsesAnnotation(final MethodInfo method) {
         return method.annotation(ResponseConstant.DOTNAME_API_RESPONSES);

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
@@ -13,6 +13,7 @@ import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
@@ -258,12 +259,12 @@ public class ResponseReader {
                 ResponseConstant.DOTNAME_API_RESPONSES);
     }
 
-    public static boolean hasResponseCodeValue(final MethodInfo method) {
-        if (method.hasAnnotation(ResponseConstant.DOTNAME_API_RESPONSE)) {
-            AnnotationInstance annotation = getResponseAnnotation(method);
-            return annotation.value(ResponseConstant.PROP_RESPONSE_CODE) != null;
-        }
-        return false;
+    public static boolean hasResponseCodeValue(final AnnotationInstance responseAnnotation) {
+        return responseAnnotation.value(ResponseConstant.PROP_RESPONSE_CODE) != null;
+    }
+
+    public static AnnotationInstance getResponseAnnotation(final ClassInfo classInfo) {
+        return classInfo.classAnnotation(ResponseConstant.DOTNAME_API_RESPONSE);
     }
 
     public static AnnotationInstance getResponseAnnotation(final MethodInfo method) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -340,7 +340,7 @@ public interface AnnotationScanner {
 
     default void processResponse(final AnnotationScannerContext context, final ClassInfo resourceClass, final MethodInfo method,
             Operation operation,
-            Map<DotName, AnnotationInstance> exceptionAnnotationMap) {
+            Map<DotName, List<AnnotationInstance>> exceptionAnnotationMap) {
 
         List<AnnotationInstance> classApiResponseAnnotations = ResponseReader.getResponseAnnotations(resourceClass);
         for (AnnotationInstance annotation : classApiResponseAnnotations) {
@@ -377,11 +377,12 @@ public interface AnnotationScanner {
         for (Type type : methodExceptions) {
             DotName exceptionDotName = type.name();
             if (exceptionAnnotationMap != null && !exceptionAnnotationMap.isEmpty()
-                    && exceptionAnnotationMap.keySet().contains(exceptionDotName)) {
-                AnnotationInstance exMapperApiResponseAnnotation = exceptionAnnotationMap.get(exceptionDotName);
-                if (!this.responseCodeExistInMethodAnnotations(context, exMapperApiResponseAnnotation,
-                        methodApiResponseAnnotations)) {
-                    addApiReponseFromAnnotation(context, exMapperApiResponseAnnotation, operation);
+                    && exceptionAnnotationMap.containsKey(exceptionDotName)) {
+                for (AnnotationInstance exMapperApiResponseAnnotation : exceptionAnnotationMap.get(exceptionDotName)) {
+                    if (!this.responseCodeExistInMethodAnnotations(context, exMapperApiResponseAnnotation,
+                            methodApiResponseAnnotations)) {
+                        addApiReponseFromAnnotation(context, exMapperApiResponseAnnotation, operation);
+                    }
                 }
             }
         }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -338,11 +338,18 @@ public interface AnnotationScanner {
         return Optional.of(operation);
     }
 
-    default void processResponse(final AnnotationScannerContext context, final MethodInfo method, Operation operation,
+    default void processResponse(final AnnotationScannerContext context, final ClassInfo resourceClass, final MethodInfo method,
+            Operation operation,
             Map<DotName, AnnotationInstance> exceptionAnnotationMap) {
 
-        List<AnnotationInstance> apiResponseAnnotations = ResponseReader.getResponseAnnotations(method);
-        for (AnnotationInstance annotation : apiResponseAnnotations) {
+        List<AnnotationInstance> classApiResponseAnnotations = ResponseReader.getResponseAnnotations(resourceClass);
+        for (AnnotationInstance annotation : classApiResponseAnnotations) {
+            addApiReponseFromAnnotation(context, annotation, operation);
+        }
+
+        // Method annotations override class annotations
+        List<AnnotationInstance> methodApiResponseAnnotations = ResponseReader.getResponseAnnotations(method);
+        for (AnnotationInstance annotation : methodApiResponseAnnotations) {
             addApiReponseFromAnnotation(context, annotation, operation);
         }
 
@@ -373,7 +380,7 @@ public interface AnnotationScanner {
                     && exceptionAnnotationMap.keySet().contains(exceptionDotName)) {
                 AnnotationInstance exMapperApiResponseAnnotation = exceptionAnnotationMap.get(exceptionDotName);
                 if (!this.responseCodeExistInMethodAnnotations(context, exMapperApiResponseAnnotation,
-                        apiResponseAnnotations)) {
+                        methodApiResponseAnnotations)) {
                     addApiReponseFromAnnotation(context, exMapperApiResponseAnnotation, operation);
                 }
             }

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -264,7 +264,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         Set<String> tagRefs = processTags(context, resourceClass, openApi, false);
 
         // Process exception mapper to auto generate api response based on method exceptions
-        Map<DotName, AnnotationInstance> exceptionAnnotationMap = processExceptionMappers(context);
+        Map<DotName, List<AnnotationInstance>> exceptionAnnotationMap = processExceptionMappers(context);
 
         for (MethodInfo methodInfo : getResourceMethods(context, resourceClass)) {
             final AtomicInteger resourceCount = new AtomicInteger(0);
@@ -290,7 +290,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
      * Build a map between exception class name and its corresponding @ApiResponse annotation in the jax-rs exception mapper
      * 
      */
-    private Map<DotName, AnnotationInstance> processExceptionMappers(final AnnotationScannerContext context) {
+    private Map<DotName, List<AnnotationInstance>> processExceptionMappers(final AnnotationScannerContext context) {
         Collection<ClassInfo> exceptionMappers = new ArrayList<>();
 
         for (DotName dn : JaxRsConstants.EXCEPTION_MAPPER) {
@@ -303,7 +303,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
 
-    private Stream<Entry<DotName, AnnotationInstance>> exceptionResponseAnnotations(ClassInfo classInfo) {
+    private Stream<Entry<DotName, List<AnnotationInstance>>> exceptionResponseAnnotations(ClassInfo classInfo) {
 
         Type exceptionType = classInfo.interfaceTypes()
                 .stream()
@@ -318,22 +318,24 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             return Stream.empty();
         }
 
-        AnnotationInstance methodAnnotation = Stream.of(classInfo.method(JaxRsConstants.TO_RESPONSE_METHOD_NAME, exceptionType))
+        Stream<AnnotationInstance> methodAnnotations = Stream
+                .of(classInfo.method(JaxRsConstants.TO_RESPONSE_METHOD_NAME, exceptionType))
                 .filter(Objects::nonNull)
-                .map(ResponseReader::getResponseAnnotation)
-                .filter(Objects::nonNull)
-                .findAny()
-                .orElse(null);
-        if (methodAnnotation != null && ResponseReader.hasResponseCodeValue(methodAnnotation)) {
-            return Stream.of(entryOf(exceptionType.name(), methodAnnotation));
-        }
+                .flatMap(m -> ResponseReader.getResponseAnnotations(m).stream());
 
-        AnnotationInstance classAnnotation = ResponseReader.getResponseAnnotation(classInfo);
-        if (classAnnotation != null && ResponseReader.hasResponseCodeValue(classAnnotation)) {
-            return Stream.of(entryOf(exceptionType.name(), classAnnotation));
-        }
+        Stream<AnnotationInstance> classAnnotations = ResponseReader.getResponseAnnotations(classInfo).stream();
 
-        return Stream.empty();
+        // Later annotations will eventually override earlier ones, so put class before method
+        List<AnnotationInstance> annotations = Stream
+                .concat(classAnnotations, methodAnnotations)
+                .filter(ResponseReader::hasResponseCodeValue)
+                .collect(Collectors.toList());
+
+        if (annotations.isEmpty()) {
+            return Stream.empty();
+        } else {
+            return Stream.of(entryOf(exceptionType.name(), annotations));
+        }
     }
 
     // Replace with Map.entry when available (Java 9+)
@@ -421,7 +423,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             final PathItem.HttpMethod methodType,
             Set<String> resourceTags,
             List<Parameter> locatorPathParameters,
-            Map<DotName, AnnotationInstance> exceptionAnnotationMap) {
+            Map<DotName, List<AnnotationInstance>> exceptionAnnotationMap) {
 
         JaxRsLogging.log.processingMethod(method.toString());
 

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -440,7 +440,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         }
 
         // Process @APIResponse annotations
-        processResponse(context, method, operation, exceptionAnnotationMap);
+        processResponse(context, resourceClass, method, operation, exceptionAnnotationMap);
 
         // Process @SecurityRequirement annotations
         processSecurityRequirementAnnotation(resourceClass, method, operation);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
@@ -53,4 +53,11 @@ class ExceptionMapperScanTests extends IndexScannerTestBase {
                 test.io.smallrye.openapi.runtime.scanner.jakarta.ExceptionHandler2.class,
                 test.io.smallrye.openapi.runtime.scanner.jakarta.ResteasyReactiveExceptionMapper.class);
     }
+
+    @Test
+    void testJakartaExceptionMapperMultipleResponse() throws IOException, JSONException {
+        test("responses.exception-mapper-multiple-response-generation.json",
+                test.io.smallrye.openapi.runtime.scanner.jakarta.TestResource.class,
+                test.io.smallrye.openapi.runtime.scanner.jakarta.ExceptionHandler3.class);
+    }
 }

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/ExceptionHandler3.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/ExceptionHandler3.java
@@ -1,0 +1,20 @@
+package test.io.smallrye.openapi.runtime.scanner.jakarta;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+@APIResponse(responseCode = "500", description = "Internal Server Error")
+@APIResponse(responseCode = "400", description = "Bad Request")
+public class ExceptionHandler3 implements ExceptionMapper<WebApplicationException> {
+
+    @Override
+    @APIResponse(responseCode = "503", description = "Service Unavailable")
+    @APIResponse(responseCode = "500", description = "Unexpected Error") // Method annotation should override class
+    public Response toResponse(WebApplicationException exception) {
+        return null;
+    }
+
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.exception-mapper-multiple-response-generation.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.exception-mapper-multiple-response-generation.json
@@ -1,0 +1,44 @@
+{
+  "openapi" : "3.0.3",
+  "paths" : {
+    "/resources" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Unexpected Error"
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -324,7 +324,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
         }
 
         // Process @APIResponse annotations
-        processResponse(context, method, operation, null);
+        processResponse(context, resourceClass, method, operation, null);
 
         // Process @SecurityRequirement annotations
         processSecurityRequirementAnnotation(resourceClass, method, operation);

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
@@ -286,7 +286,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
             }
 
             // Process @APIResponse annotations
-            processResponse(context, method, operation, null);
+            processResponse(context, resourceClass, method, operation, null);
 
             // Process @SecurityRequirement annotations
             processSecurityRequirementAnnotation(resourceClass, method, operation);


### PR DESCRIPTION
Scan for `APIResponse` annotations on resource classes and merge any
responses with those on the method.

`APIResponse` annotations on the method override `APIResponse` annotations
on the resource class with the same response code.

Implementation for eclipse/microprofile-open-api#524 I've opened this as a draft against the `jakarta` branch because it requires API updates planned for MP OpenAPI 3.1.