### PR TITLE
MicroProfile OpenAPI 3.1 / Jakarta migration

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>smallrye-open-api-core</artifactId>

--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-open-api-jaxrs</artifactId>
@@ -111,7 +111,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <!-- Overriding version from smallrye-parent. JUnit 5 Tests not executed otherwise. -->
+                    <!-- Overriding version from smallrye-jakarta-parent. JUnit 5 Tests not executed otherwise. -->
                     <version>3.0.0-M6</version>
                 </plugin>
             </plugins>

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigSchemaTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigSchemaTest.java
@@ -2,7 +2,7 @@ package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
 
-import javax.json.Json;
+import jakarta.json.Json;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
@@ -7,12 +7,12 @@ import java.util.HashMap;
 import java.util.UUID;
 import java.util.zip.GZIPInputStream;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.openapi.OASConfig;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/util/JandexUtilTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/util/JandexUtilTests.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 
-import javax.ws.rs.Path;
+import jakarta.ws.rs.Path;
 
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/FieldNameOverride.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/entities/FieldNameOverride.java
@@ -1,6 +1,6 @@
 package test.io.smallrye.openapi.runtime.scanner.entities;
 
-import javax.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbProperty;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 

--- a/extension-spring/pom.xml
+++ b/extension-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-open-api-spring</artifactId>

--- a/extension-vertx/pom.xml
+++ b/extension-vertx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-open-api-vertx</artifactId>

--- a/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingDeleteRoute.java
+++ b/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingDeleteRoute.java
@@ -1,6 +1,6 @@
 package test.io.smallrye.openapi.runtime.scanner.resources;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkus.vertx.web.Param;
 import io.quarkus.vertx.web.Route;

--- a/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingGetRoute.java
+++ b/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingGetRoute.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingPostRoute.java
+++ b/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingPostRoute.java
@@ -1,6 +1,6 @@
 package test.io.smallrye.openapi.runtime.scanner.resources;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingPutRoute.java
+++ b/extension-vertx/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingPutRoute.java
@@ -1,6 +1,6 @@
 package test.io.smallrye.openapi.runtime.scanner.resources;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-open-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 
     <parent>
         <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-parent</artifactId>
+        <artifactId>smallrye-jakarta-parent</artifactId>
         <version>35</version>
     </parent>
 
     <artifactId>smallrye-open-api-parent</artifactId>
-    <version>2.1.23-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>SmallRye: OpenAPI Parent</name>
@@ -19,23 +19,23 @@
     <properties>
         <version.buildhelper.plugin>3.3.0</version.buildhelper.plugin>
         <jackson-bom.version>2.13.2.1</jackson-bom.version>
-        <version.eclipse.microprofile.config>2.0.1</version.eclipse.microprofile.config>
-        <version.io.smallrye.smallrye-config>2.10.0</version.io.smallrye.smallrye-config>
-        <version.eclipse.microprofile.openapi>2.0.1</version.eclipse.microprofile.openapi>
+        <version.eclipse.microprofile.config>3.0</version.eclipse.microprofile.config>
+        <version.io.smallrye.smallrye-config>3.0.0-RC1</version.io.smallrye.smallrye-config>
+        <version.eclipse.microprofile.openapi>3.1-SNAPSHOT</version.eclipse.microprofile.openapi>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>
         <version.maven-resources-plugin>3.2.0</version.maven-resources-plugin>
         <version.com.github.eirslett.frontend-maven-plugin>1.12.1</version.com.github.eirslett.frontend-maven-plugin>
 
-        <artifactId.arquillian.jetty>arquillian-jetty-embedded-9</artifactId.arquillian.jetty>
-        <version.arquillian.jetty>1.0.0.CR3</version.arquillian.jetty>
-        <version.jetty>9.3.30.v20211001</version.jetty>
-        <version.resteasy>4.7.5.Final</version.resteasy>
+        <artifactId.arquillian.jetty>arquillian-jetty-embedded-11</artifactId.arquillian.jetty>
+        <version.arquillian.jetty>1.0.0.CR4</version.arquillian.jetty>
+        <version.jetty>11.0.7</version.jetty>
+        <version.resteasy>6.0.0.Final</version.resteasy>
         <!-- RESTEasy REST Client relocated to another GAV, so these props are for jakarta auto migration -->
-        <groupId.resteasy.client>org.jboss.resteasy</groupId.resteasy.client>
-        <artifactId.resteasy.client>resteasy-client-microprofile</artifactId.resteasy.client>
-        <version.resteasy.client>4.7.5.Final</version.resteasy.client>
+        <groupId.resteasy.client>org.jboss.resteasy.microprofile</groupId.resteasy.client>
+        <artifactId.resteasy.client>microprofile-rest-client</artifactId.resteasy.client>
+        <version.resteasy.client>2.0.0.Beta1</version.resteasy.client>
         <version.quarkus>2.8.1.Final</version.quarkus>
 
         <!--
@@ -409,7 +409,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <!-- Version managed by smallrye-parent -->
+                <!-- Version managed by smallrye-jakarta-parent -->
                 <configuration>
                     <gpgArguments>
                         <arg>--pinentry-mode</arg>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-open-api-release</artifactId>

--- a/testsuite/extra/pom.xml
+++ b/testsuite/extra/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-testsuite</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/apppath/ApplicationPathApp.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/apppath/ApplicationPathApp.java
@@ -16,8 +16,8 @@
 
 package io.smallrye.openapi.tck.extra.apppath;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/restapi/v1")
 public class ApplicationPathApp extends Application {

--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/apppath/ApplicationPathResource.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/apppath/ApplicationPathResource.java
@@ -19,11 +19,11 @@ package io.smallrye.openapi.tck.extra.apppath;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.PathParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.PathParam;
 
 /**
  * @author eric.wittmann@gmail.com

--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/complex/ComplexResource.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/complex/ComplexResource.java
@@ -20,9 +20,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com

--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/extensions/ExtensionResource.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/extensions/ExtensionResource.java
@@ -16,7 +16,7 @@
 
 package io.smallrye.openapi.tck.extra.extensions;
 
-import javax.ws.rs.*;
+import jakarta.ws.rs.*;
 
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extensions;

--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/jaxrs/WidgetResource.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/jaxrs/WidgetResource.java
@@ -19,12 +19,12 @@ package io.smallrye.openapi.tck.extra.jaxrs;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 
 /**
  * @author eric.wittmann@gmail.com

--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/jsonignoreproperties/JsonIgnorePropertiesResource.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/jsonignoreproperties/JsonIgnorePropertiesResource.java
@@ -16,9 +16,9 @@
 
 package io.smallrye.openapi.tck.extra.jsonignoreproperties;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
 
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 

--- a/testsuite/extra/src/test/java/test/io/smallrye/openapi/tck/ExtraSuiteTestBase.java
+++ b/testsuite/extra/src/test/java/test/io/smallrye/openapi/tck/ExtraSuiteTestBase.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.tck.utils.YamlToJsonFilter;

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-open-api-parent</artifactId>
-    <version>2.1.23-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-open-api-testsuite</artifactId>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-open-api-testsuite</artifactId>
-    <version>2.1.23-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-open-api-testsuite-tck</artifactId>

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiApplication.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiApplication.java
@@ -1,7 +1,7 @@
 package io.smallrye.openapi.tck;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 /**
  * RESTEasy Servlet initializer requires a REST Application to start. Some TCKs don't have an Application class, so we

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiEndpoint.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiEndpoint.java
@@ -3,19 +3,19 @@ package io.smallrye.openapi.tck;
 import static io.smallrye.openapi.runtime.io.Format.JSON;
 import static io.smallrye.openapi.runtime.io.Format.YAML;
 import static io.smallrye.openapi.runtime.io.OpenApiSerializer.serialize;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 import java.util.stream.Stream;
 
-import javax.annotation.PostConstruct;
-import javax.servlet.ServletContext;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Response;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.ServletContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiRegistration.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiRegistration.java
@@ -8,11 +8,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/TestApplication.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/TestApplication.java
@@ -1,18 +1,18 @@
 package io.smallrye.openapi.tck;
 
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;

--- a/tools/maven-plugin/pom.xml
+++ b/tools/maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-tools</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>smallrye-open-api-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>smallrye-open-api-tools</artifactId>

--- a/ui/open-api-ui-forms/pom.xml
+++ b/ui/open-api-ui-forms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-ui-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-open-api-ui-forms</artifactId>

--- a/ui/open-api-ui/pom.xml
+++ b/ui/open-api-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-ui-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-open-api-ui</artifactId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-parent</artifactId>
-        <version>2.1.23-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>smallrye-open-api-ui-parent</artifactId>


### PR DESCRIPTION
- Run Jakarta namespace migration
- Set `main` versions to 3.1-SNAPSHOT
- Update MP OpenAPI version to 3.1-SNAPSHOT

Note: TCK expected to fail due to unimplemented features from MP 3.1.