### PR TITLE
Consolidate MicroProfile OpenAPI 3.1 Updates

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionConstant.java
@@ -21,7 +21,7 @@ public class DefinitionConstant {
     public static final String PROP_TAGS = "tags";
     public static final String PROP_COMPONENTS = "components";
     public static final String PROP_SECURITY = "security";
-    public static final String PROP_SECURITY_SET = "securitySet";
+    public static final String PROP_SECURITY_SETS = "securitySets";
     public static final String PROP_OPENAPI = "openapi";
 
     private DefinitionConstant() {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionConstant.java
@@ -21,6 +21,7 @@ public class DefinitionConstant {
     public static final String PROP_TAGS = "tags";
     public static final String PROP_COMPONENTS = "components";
     public static final String PROP_SECURITY = "security";
+    public static final String PROP_SECURITY_SET = "securitySet";
     public static final String PROP_OPENAPI = "openapi";
 
     private DefinitionConstant() {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
@@ -50,7 +50,9 @@ public class DefinitionReader {
         openApi.setServers(
                 ServerReader.readServers(annotationInstance.value(DefinitionConstant.PROP_SERVERS)).orElse(null));
         openApi.setSecurity(SecurityRequirementReader
-                .readSecurityRequirements(annotationInstance.value(DefinitionConstant.PROP_SECURITY)).orElse(null));
+                .readSecurityRequirements(annotationInstance.value(DefinitionConstant.PROP_SECURITY),
+                        annotationInstance.value(DefinitionConstant.PROP_SECURITY_SET))
+                .orElse(null));
         openApi.setExternalDocs(
                 ExternalDocsReader
                         .readExternalDocs(context, annotationInstance.value(ExternalDocsConstant.PROP_EXTERNAL_DOCS)));

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
@@ -51,7 +51,7 @@ public class DefinitionReader {
                 ServerReader.readServers(annotationInstance.value(DefinitionConstant.PROP_SERVERS)).orElse(null));
         openApi.setSecurity(SecurityRequirementReader
                 .readSecurityRequirements(annotationInstance.value(DefinitionConstant.PROP_SECURITY),
-                        annotationInstance.value(DefinitionConstant.PROP_SECURITY_SET))
+                        annotationInstance.value(DefinitionConstant.PROP_SECURITY_SETS))
                 .orElse(null));
         openApi.setExternalDocs(
                 ExternalDocsReader

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationConstant.java
@@ -20,6 +20,7 @@ public class OperationConstant {
     public static final String PROP_EXTENSIONS = "extensions";
     public static final String PROP_DESCRIPTION = "description";
     public static final String PROP_SECURITY = "security";
+    public static final String PROP_SECURITY_SET = "securitySet";
     public static final String PROP_REQUEST_BODY = "requestBody";
     public static final String PROP_PARAMETERS = "parameters";
     public static final String PROP_SERVERS = "servers";

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationConstant.java
@@ -20,7 +20,7 @@ public class OperationConstant {
     public static final String PROP_EXTENSIONS = "extensions";
     public static final String PROP_DESCRIPTION = "description";
     public static final String PROP_SECURITY = "security";
-    public static final String PROP_SECURITY_SET = "securitySet";
+    public static final String PROP_SECURITY_SETS = "securitySets";
     public static final String PROP_REQUEST_BODY = "requestBody";
     public static final String PROP_PARAMETERS = "parameters";
     public static final String PROP_SERVERS = "servers";

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationReader.java
@@ -60,7 +60,9 @@ public class OperationReader {
             operation.setResponses(ResponseReader.readResponses(context,
                     annotationInstance.value(OperationConstant.PROP_RESPONSES)));
             operation.setSecurity(SecurityRequirementReader
-                    .readSecurityRequirements(annotationInstance.value(OperationConstant.PROP_SECURITY)).orElse(null));
+                    .readSecurityRequirements(annotationInstance.value(OperationConstant.PROP_SECURITY),
+                            annotationInstance.value(OperationConstant.PROP_SECURITY_SET))
+                    .orElse(null));
             operation.setExtensions(
                     ExtensionReader.readExtensions(context,
                             annotationInstance.value(OperationConstant.PROP_EXTENSIONS)));

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/operation/OperationReader.java
@@ -61,7 +61,7 @@ public class OperationReader {
                     annotationInstance.value(OperationConstant.PROP_RESPONSES)));
             operation.setSecurity(SecurityRequirementReader
                     .readSecurityRequirements(annotationInstance.value(OperationConstant.PROP_SECURITY),
-                            annotationInstance.value(OperationConstant.PROP_SECURITY_SET))
+                            annotationInstance.value(OperationConstant.PROP_SECURITY_SETS))
                     .orElse(null));
             operation.setExtensions(
                     ExtensionReader.readExtensions(context,

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
@@ -13,7 +13,6 @@ import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
-import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
@@ -263,13 +262,13 @@ public class ResponseReader {
         return responseAnnotation.value(ResponseConstant.PROP_RESPONSE_CODE) != null;
     }
 
-    public static AnnotationInstance getResponseAnnotation(final ClassInfo classInfo) {
-        return classInfo.classAnnotation(ResponseConstant.DOTNAME_API_RESPONSE);
-    }
-
-    public static AnnotationInstance getResponseAnnotation(final MethodInfo method) {
-        return method.annotation(ResponseConstant.DOTNAME_API_RESPONSE);
-    }
+    //    public static AnnotationInstance getResponseAnnotation(final ClassInfo classInfo) {
+    //        return classInfo.classAnnotation(ResponseConstant.DOTNAME_API_RESPONSE);
+    //    }
+    //
+    //    public static AnnotationInstance getResponseAnnotation(final MethodInfo method) {
+    //        return method.annotation(ResponseConstant.DOTNAME_API_RESPONSE);
+    //    }
 
     public static AnnotationInstance getResponsesAnnotation(final MethodInfo method) {
         return method.annotation(ResponseConstant.DOTNAME_API_RESPONSES);

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
@@ -13,6 +13,7 @@ import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
@@ -258,12 +259,12 @@ public class ResponseReader {
                 ResponseConstant.DOTNAME_API_RESPONSES);
     }
 
-    public static boolean hasResponseCodeValue(final MethodInfo method) {
-        if (method.hasAnnotation(ResponseConstant.DOTNAME_API_RESPONSE)) {
-            AnnotationInstance annotation = getResponseAnnotation(method);
-            return annotation.value(ResponseConstant.PROP_RESPONSE_CODE) != null;
-        }
-        return false;
+    public static boolean hasResponseCodeValue(final AnnotationInstance responseAnnotation) {
+        return responseAnnotation.value(ResponseConstant.PROP_RESPONSE_CODE) != null;
+    }
+
+    public static AnnotationInstance getResponseAnnotation(final ClassInfo classInfo) {
+        return classInfo.classAnnotation(ResponseConstant.DOTNAME_API_RESPONSE);
     }
 
     public static AnnotationInstance getResponseAnnotation(final MethodInfo method) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementConstant.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementConstant.java
@@ -2,6 +2,8 @@ package io.smallrye.openapi.runtime.io.securityrequirement;
 
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirements;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSets;
 import org.jboss.jandex.DotName;
 
 /**
@@ -17,6 +19,8 @@ public class SecurityRequirementConstant {
 
     static final DotName DOTNAME_SECURITY_REQUIREMENT = DotName.createSimple(SecurityRequirement.class.getName());
     static final DotName DOTNAME_SECURITY_REQUIREMENTS = DotName.createSimple(SecurityRequirements.class.getName());
+    static final DotName DOTNAME_SECURITY_REQUIREMENTS_SET = DotName.createSimple(SecurityRequirementsSet.class.getName());
+    static final DotName DOTNAME_SECURITY_REQUIREMENTS_SETS = DotName.createSimple(SecurityRequirementsSets.class.getName());
 
     public static final String PROP_NAME = "name";
     public static final String PROP_SCOPES = "scopes";

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
@@ -102,6 +102,7 @@ public class SecurityRequirementReader {
         SecurityRequirement requirement = new SecurityRequirementImpl();
         addSecurityRequirement(requirement, annotationInstance);
         if (requirement.getSchemes().isEmpty()) {
+            // Should only happen if the annotation was missing the required "name" property
             return null;
         } else {
             return requirement;

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityrequirement/SecurityRequirementReader.java
@@ -34,26 +34,43 @@ public class SecurityRequirementReader {
     }
 
     /**
-     * Reads any SecurityRequirement annotations. The annotation value is an array of
-     * SecurityRequirement annotations.
+     * Reads any SecurityRequirement and SecurityRequirementsSet annotations.
      * 
-     * @param annotationValue Array of {@literal @}SecurityRequirement annotations
+     * @param securityRequirements Array of {@literal @}SecurityRequirement annotations
+     * @param securityRequirementsSets Array of {@literal @}SecurityRequirementsSet annotation
      * @return List of SecurityRequirement models
      */
-    public static Optional<List<SecurityRequirement>> readSecurityRequirements(final AnnotationValue annotationValue) {
-        if (annotationValue != null) {
+    public static Optional<List<SecurityRequirement>> readSecurityRequirements(final AnnotationValue securityRequirements,
+            final AnnotationValue securityRequirementsSets) {
+        if (securityRequirements == null && securityRequirementsSets == null) {
+            return Optional.empty();
+        }
+
+        List<SecurityRequirement> requirements = new ArrayList<>();
+
+        if (securityRequirements != null) {
             IoLogging.logger.annotationsArray("@SecurityRequirement");
-            AnnotationInstance[] nestedArray = annotationValue.asNestedArray();
-            List<SecurityRequirement> requirements = new ArrayList<>();
+            AnnotationInstance[] nestedArray = securityRequirements.asNestedArray();
             for (AnnotationInstance requirementAnno : nestedArray) {
                 SecurityRequirement requirement = readSecurityRequirement(requirementAnno);
                 if (requirement != null) {
                     requirements.add(requirement);
                 }
             }
-            return Optional.of(requirements);
         }
-        return Optional.empty();
+
+        if (securityRequirementsSets != null) {
+            IoLogging.logger.annotationsArray("@SecurityRequirementsSet");
+            AnnotationInstance[] nestedArray = securityRequirementsSets.asNestedArray();
+            for (AnnotationInstance requirementSetAnno : nestedArray) {
+                SecurityRequirement requirement = readSecurityRequirementsSet(requirementSetAnno);
+                if (requirement != null) {
+                    requirements.add(requirement);
+                }
+            }
+        }
+
+        return Optional.of(requirements);
     }
 
     /**
@@ -82,19 +99,43 @@ public class SecurityRequirementReader {
      * @return SecurityRequirement model
      */
     public static SecurityRequirement readSecurityRequirement(AnnotationInstance annotationInstance) {
+        SecurityRequirement requirement = new SecurityRequirementImpl();
+        addSecurityRequirement(requirement, annotationInstance);
+        if (requirement.getSchemes().isEmpty()) {
+            return null;
+        } else {
+            return requirement;
+        }
+    }
+
+    /**
+     * Reads a single SecurityRequirementsSet annotation
+     * 
+     * @param annotationInstance the {@literal @}SecurityRequirementsSet annotation
+     * @return SecurityRequirement model
+     */
+    public static SecurityRequirement readSecurityRequirementsSet(AnnotationInstance annotationInstance) {
+        AnnotationValue value = annotationInstance.value();
+        SecurityRequirement requirement = new SecurityRequirementImpl();
+        if (value != null) {
+            for (AnnotationInstance securityRequirementInstance : value.asNestedArray()) {
+                addSecurityRequirement(requirement, securityRequirementInstance);
+            }
+        }
+        return requirement;
+    }
+
+    private static void addSecurityRequirement(SecurityRequirement requirement, AnnotationInstance annotationInstance) {
         String name = JandexUtil.stringValue(annotationInstance, SecurityRequirementConstant.PROP_NAME);
         if (name != null) {
             Optional<List<String>> maybeScopes = JandexUtil.stringListValue(annotationInstance,
                     SecurityRequirementConstant.PROP_SCOPES);
-            SecurityRequirement requirement = new SecurityRequirementImpl();
             if (maybeScopes.isPresent()) {
                 requirement.addScheme(name, maybeScopes.get());
             } else {
                 requirement.addScheme(name);
             }
-            return requirement;
         }
-        return null;
     }
 
     /**
@@ -132,5 +173,17 @@ public class SecurityRequirementReader {
         return JandexUtil.getRepeatableAnnotation(target,
                 SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENT,
                 SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS);
+    }
+
+    // helper methods for scanners
+    public static AnnotationInstance getSecurityRequirementsSetsAnnotation(final AnnotationTarget target) {
+        return TypeUtil.getAnnotation(target, SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS_SETS);
+    }
+
+    // helper methods for scanners
+    public static List<AnnotationInstance> getSecurityRequirementsSetAnnotations(final AnnotationTarget target) {
+        return JandexUtil.getRepeatableAnnotation(target,
+                SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS_SET,
+                SecurityRequirementConstant.DOTNAME_SECURITY_REQUIREMENTS_SETS);
     }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -529,7 +529,9 @@ public abstract class AbstractParameterProcessor {
         AnnotationInstance schemaAnnotation = TypeUtil.getAnnotation(context.target, SchemaConstant.DOTNAME_SCHEMA);
         Schema schema;
 
-        if (schemaAnnotation != null) {
+        if (schemaAnnotation != null && Boolean.TRUE.equals(JandexUtil.value(schemaAnnotation, SchemaConstant.PROP_HIDDEN))) {
+            schema = null;
+        } else if (schemaAnnotation != null) {
             Type paramType = JandexUtil.value(schemaAnnotation, SchemaConstant.PROP_IMPLEMENTATION, context.targetType);
             Map<String, Object> defaults;
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -660,48 +660,66 @@ public interface AnnotationScanner {
     default void processSecurityRequirementAnnotation(final ClassInfo resourceClass, final MethodInfo method,
             Operation operation) {
 
-        List<AnnotationInstance> requirements;
+        List<AnnotationInstance> requirements = SecurityRequirementReader.getSecurityRequirementAnnotations(method);
+        List<AnnotationInstance> requirementSets = SecurityRequirementReader.getSecurityRequirementsSetAnnotations(method);
+        boolean emptyContainerPresent = isEmptySecurityRequirements(method);
 
-        if (isEmptySecurityRequirements(method)) {
+        if (requirements.isEmpty() && requirementSets.isEmpty() && !emptyContainerPresent) {
+            requirements = SecurityRequirementReader.getSecurityRequirementAnnotations(resourceClass);
+            requirementSets = SecurityRequirementReader.getSecurityRequirementsSetAnnotations(resourceClass);
+            emptyContainerPresent = isEmptySecurityRequirements(resourceClass);
+        }
+
+        for (AnnotationInstance annotation : requirements) {
+            SecurityRequirement requirement = SecurityRequirementReader.readSecurityRequirement(annotation);
+            if (requirement != null) {
+                operation.addSecurityRequirement(requirement);
+            }
+        }
+
+        for (AnnotationInstance annotation : requirementSets) {
+            SecurityRequirement requirement = SecurityRequirementReader.readSecurityRequirementsSet(annotation);
+            if (requirement != null) {
+                operation.addSecurityRequirement(requirement);
+            }
+        }
+
+        if (requirements.isEmpty() && requirementSets.isEmpty() && emptyContainerPresent) {
             operation.setSecurity(new ArrayList<>(0));
-        } else {
-            requirements = SecurityRequirementReader.getSecurityRequirementAnnotations(method);
-
-            if (requirements.isEmpty()) {
-                if (isEmptySecurityRequirements(resourceClass)) {
-                    operation.setSecurity(new ArrayList<>(0));
-                } else {
-                    requirements = SecurityRequirementReader.getSecurityRequirementAnnotations(resourceClass);
-                }
-            }
-
-            for (AnnotationInstance annotation : requirements) {
-                SecurityRequirement requirement = SecurityRequirementReader.readSecurityRequirement(annotation);
-                if (requirement != null) {
-                    operation.addSecurityRequirement(requirement);
-                }
-            }
         }
     }
 
     /**
      * Determines whether the target is annotated with an empty <code>@SecurityRequirements</code>
-     * annotation.
+     * or <code>@SecurityRequirementsSets</code> annotation.
      * 
      * @param target
      * @return true if an empty annotation is present, otherwise false
      */
     default boolean isEmptySecurityRequirements(AnnotationTarget target) {
-        AnnotationInstance securityRequirements = SecurityRequirementReader.getSecurityRequirementsAnnotation(target);
+        boolean foundEmptyAnnotation = false;
 
+        AnnotationInstance securityRequirements = SecurityRequirementReader.getSecurityRequirementsAnnotation(target);
         if (securityRequirements != null) {
             AnnotationInstance[] values = JandexUtil.value(securityRequirements, "value");
             if (values == null || values.length == 0) {
-                return true;
+                foundEmptyAnnotation = true;
+            } else {
+                return false;
             }
         }
 
-        return false;
+        AnnotationInstance securityRequirementsSets = SecurityRequirementReader.getSecurityRequirementsSetsAnnotation(target);
+        if (securityRequirementsSets != null) {
+            AnnotationInstance[] values = JandexUtil.value(securityRequirementsSets, "value");
+            if (values == null || values.length == 0) {
+                foundEmptyAnnotation = true;
+            } else {
+                return false;
+            }
+        }
+
+        return foundEmptyAnnotation;
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -340,7 +340,7 @@ public interface AnnotationScanner {
 
     default void processResponse(final AnnotationScannerContext context, final ClassInfo resourceClass, final MethodInfo method,
             Operation operation,
-            Map<DotName, AnnotationInstance> exceptionAnnotationMap) {
+            Map<DotName, List<AnnotationInstance>> exceptionAnnotationMap) {
 
         List<AnnotationInstance> classApiResponseAnnotations = ResponseReader.getResponseAnnotations(resourceClass);
         for (AnnotationInstance annotation : classApiResponseAnnotations) {
@@ -377,11 +377,12 @@ public interface AnnotationScanner {
         for (Type type : methodExceptions) {
             DotName exceptionDotName = type.name();
             if (exceptionAnnotationMap != null && !exceptionAnnotationMap.isEmpty()
-                    && exceptionAnnotationMap.keySet().contains(exceptionDotName)) {
-                AnnotationInstance exMapperApiResponseAnnotation = exceptionAnnotationMap.get(exceptionDotName);
-                if (!this.responseCodeExistInMethodAnnotations(context, exMapperApiResponseAnnotation,
-                        methodApiResponseAnnotations)) {
-                    addApiReponseFromAnnotation(context, exMapperApiResponseAnnotation, operation);
+                    && exceptionAnnotationMap.containsKey(exceptionDotName)) {
+                for (AnnotationInstance exMapperApiResponseAnnotation : exceptionAnnotationMap.get(exceptionDotName)) {
+                    if (!this.responseCodeExistInMethodAnnotations(context, exMapperApiResponseAnnotation,
+                            methodApiResponseAnnotations)) {
+                        addApiReponseFromAnnotation(context, exMapperApiResponseAnnotation, operation);
+                    }
                 }
             }
         }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -338,11 +338,18 @@ public interface AnnotationScanner {
         return Optional.of(operation);
     }
 
-    default void processResponse(final AnnotationScannerContext context, final MethodInfo method, Operation operation,
+    default void processResponse(final AnnotationScannerContext context, final ClassInfo resourceClass, final MethodInfo method,
+            Operation operation,
             Map<DotName, AnnotationInstance> exceptionAnnotationMap) {
 
-        List<AnnotationInstance> apiResponseAnnotations = ResponseReader.getResponseAnnotations(method);
-        for (AnnotationInstance annotation : apiResponseAnnotations) {
+        List<AnnotationInstance> classApiResponseAnnotations = ResponseReader.getResponseAnnotations(resourceClass);
+        for (AnnotationInstance annotation : classApiResponseAnnotations) {
+            addApiReponseFromAnnotation(context, annotation, operation);
+        }
+
+        // Method annotations override class annotations
+        List<AnnotationInstance> methodApiResponseAnnotations = ResponseReader.getResponseAnnotations(method);
+        for (AnnotationInstance annotation : methodApiResponseAnnotations) {
             addApiReponseFromAnnotation(context, annotation, operation);
         }
 
@@ -373,7 +380,7 @@ public interface AnnotationScanner {
                     && exceptionAnnotationMap.keySet().contains(exceptionDotName)) {
                 AnnotationInstance exMapperApiResponseAnnotation = exceptionAnnotationMap.get(exceptionDotName);
                 if (!this.responseCodeExistInMethodAnnotations(context, exMapperApiResponseAnnotation,
-                        apiResponseAnnotations)) {
+                        methodApiResponseAnnotations)) {
                     addApiReponseFromAnnotation(context, exMapperApiResponseAnnotation, operation);
                 }
             }

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -264,7 +264,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         Set<String> tagRefs = processTags(context, resourceClass, openApi, false);
 
         // Process exception mapper to auto generate api response based on method exceptions
-        Map<DotName, AnnotationInstance> exceptionAnnotationMap = processExceptionMappers(context);
+        Map<DotName, List<AnnotationInstance>> exceptionAnnotationMap = processExceptionMappers(context);
 
         for (MethodInfo methodInfo : getResourceMethods(context, resourceClass)) {
             final AtomicInteger resourceCount = new AtomicInteger(0);
@@ -290,7 +290,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
      * Build a map between exception class name and its corresponding @ApiResponse annotation in the jax-rs exception mapper
      * 
      */
-    private Map<DotName, AnnotationInstance> processExceptionMappers(final AnnotationScannerContext context) {
+    private Map<DotName, List<AnnotationInstance>> processExceptionMappers(final AnnotationScannerContext context) {
         Collection<ClassInfo> exceptionMappers = new ArrayList<>();
 
         for (DotName dn : JaxRsConstants.EXCEPTION_MAPPER) {
@@ -303,7 +303,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
 
-    private Stream<Entry<DotName, AnnotationInstance>> exceptionResponseAnnotations(ClassInfo classInfo) {
+    private Stream<Entry<DotName, List<AnnotationInstance>>> exceptionResponseAnnotations(ClassInfo classInfo) {
 
         Type exceptionType = classInfo.interfaceTypes()
                 .stream()
@@ -318,22 +318,24 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             return Stream.empty();
         }
 
-        AnnotationInstance methodAnnotation = Stream.of(classInfo.method(JaxRsConstants.TO_RESPONSE_METHOD_NAME, exceptionType))
+        Stream<AnnotationInstance> methodAnnotations = Stream
+                .of(classInfo.method(JaxRsConstants.TO_RESPONSE_METHOD_NAME, exceptionType))
                 .filter(Objects::nonNull)
-                .map(ResponseReader::getResponseAnnotation)
-                .filter(Objects::nonNull)
-                .findAny()
-                .orElse(null);
-        if (methodAnnotation != null && ResponseReader.hasResponseCodeValue(methodAnnotation)) {
-            return Stream.of(entryOf(exceptionType.name(), methodAnnotation));
-        }
+                .flatMap(m -> ResponseReader.getResponseAnnotations(m).stream());
 
-        AnnotationInstance classAnnotation = ResponseReader.getResponseAnnotation(classInfo);
-        if (classAnnotation != null && ResponseReader.hasResponseCodeValue(classAnnotation)) {
-            return Stream.of(entryOf(exceptionType.name(), classAnnotation));
-        }
+        Stream<AnnotationInstance> classAnnotations = ResponseReader.getResponseAnnotations(classInfo).stream();
 
-        return Stream.empty();
+        // Later annotations will eventually override earlier ones, so put class before method
+        List<AnnotationInstance> annotations = Stream
+                .concat(classAnnotations, methodAnnotations)
+                .filter(ResponseReader::hasResponseCodeValue)
+                .collect(Collectors.toList());
+
+        if (annotations.isEmpty()) {
+            return Stream.empty();
+        } else {
+            return Stream.of(entryOf(exceptionType.name(), annotations));
+        }
     }
 
     // Replace with Map.entry when available (Java 9+)
@@ -421,7 +423,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             final PathItem.HttpMethod methodType,
             Set<String> resourceTags,
             List<Parameter> locatorPathParameters,
-            Map<DotName, AnnotationInstance> exceptionAnnotationMap) {
+            Map<DotName, List<AnnotationInstance>> exceptionAnnotationMap) {
 
         JaxRsLogging.log.processingMethod(method.toString());
 

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -440,7 +440,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         }
 
         // Process @APIResponse annotations
-        processResponse(context, method, operation, exceptionAnnotationMap);
+        processResponse(context, resourceClass, method, operation, exceptionAnnotationMap);
 
         // Process @SecurityRequirement annotations
         processSecurityRequirementAnnotation(resourceClass, method, operation);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExceptionMapperScanTests.java
@@ -53,4 +53,11 @@ class ExceptionMapperScanTests extends IndexScannerTestBase {
                 test.io.smallrye.openapi.runtime.scanner.jakarta.ExceptionHandler2.class,
                 test.io.smallrye.openapi.runtime.scanner.jakarta.ResteasyReactiveExceptionMapper.class);
     }
+
+    @Test
+    void testJakartaExceptionMapperMultipleResponse() throws IOException, JSONException {
+        test("responses.exception-mapper-multiple-response-generation.json",
+                test.io.smallrye.openapi.runtime.scanner.jakarta.TestResource.class,
+                test.io.smallrye.openapi.runtime.scanner.jakarta.ExceptionHandler3.class);
+    }
 }

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/ExceptionHandler3.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/ExceptionHandler3.java
@@ -1,0 +1,20 @@
+package test.io.smallrye.openapi.runtime.scanner.jakarta;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+@APIResponse(responseCode = "500", description = "Internal Server Error")
+@APIResponse(responseCode = "400", description = "Bad Request")
+public class ExceptionHandler3 implements ExceptionMapper<WebApplicationException> {
+
+    @Override
+    @APIResponse(responseCode = "503", description = "Service Unavailable")
+    @APIResponse(responseCode = "500", description = "Unexpected Error") // Method annotation should override class
+    public Response toResponse(WebApplicationException exception) {
+        return null;
+    }
+
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.exception-mapper-multiple-response-generation.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.exception-mapper-multiple-response-generation.json
@@ -1,0 +1,44 @@
+{
+  "openapi" : "3.0.3",
+  "paths" : {
+    "/resources" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Unexpected Error"
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -324,7 +324,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
         }
 
         // Process @APIResponse annotations
-        processResponse(context, method, operation, null);
+        processResponse(context, resourceClass, method, operation, null);
 
         // Process @SecurityRequirement annotations
         processSecurityRequirementAnnotation(resourceClass, method, operation);

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
@@ -286,7 +286,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
             }
 
             // Process @APIResponse annotations
-            processResponse(context, method, operation, null);
+            processResponse(context, resourceClass, method, operation, null);
 
             // Process @SecurityRequirement annotations
             processSecurityRequirementAnnotation(resourceClass, method, operation);


### PR DESCRIPTION
Combining all MP 3.1 changes to get a clean build.

- Includes #1097 - Support SecurityRequriementsSet, passing the TCKs added to https://github.com/eclipse/microprofile-open-api/pull/519
- Includes #1122 - Support APIReponse on resource class https://github.com/eclipse/microprofile-open-api/pull/524
- Support for `@Schema(hidden = true)` on REST parameters https://github.com/eclipse/microprofile-open-api/pull/525
