### PR TITLE
Update scanning config

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -33,22 +33,20 @@ public interface OpenApiConfig {
         return false;
     }
 
-    default Pattern scanPackages() {
+    default Set<String> scanPackages() {
         return null;
     }
 
-    default Pattern scanClasses() {
+    default Set<String> scanClasses() {
         return null;
     }
 
-    default Pattern scanExcludePackages() {
-        return Pattern.compile(
-                "(" + OpenApiConstants.NEVER_SCAN_PACKAGES.stream().map(Pattern::quote).collect(Collectors.joining("|")) + ")");
+    default Set<String> scanExcludePackages() {
+        return OpenApiConstants.NEVER_SCAN_PACKAGES;
     }
 
-    default Pattern scanExcludeClasses() {
-        return Pattern.compile(
-                "(" + OpenApiConstants.NEVER_SCAN_CLASSES.stream().map(Pattern::quote).collect(Collectors.joining("|")) + ")");
+    default Set<String> scanExcludeClasses() {
+        return OpenApiConstants.NEVER_SCAN_CLASSES;
     }
 
     default boolean scanBeanValidation() {

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -1,9 +1,10 @@
 package io.smallrye.openapi.api;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -26,10 +27,10 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     private String modelReader;
     private String filter;
     private Boolean scanDisable;
-    private Pattern scanPackages;
-    private Pattern scanClasses;
-    private Pattern scanExcludePackages;
-    private Pattern scanExcludeClasses;
+    private Set<String> scanPackages;
+    private Set<String> scanClasses;
+    private Set<String> scanExcludePackages;
+    private Set<String> scanExcludeClasses;
     private Boolean scanBeanValidation;
     private Set<String> servers;
     private Boolean scanDependenciesDisable;
@@ -116,9 +117,11 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      * @see io.smallrye.openapi.api.OpenApiConfig#scanPackages()
      */
     @Override
-    public Pattern scanPackages() {
+    public Set<String> scanPackages() {
         if (scanPackages == null) {
-            scanPackages = patternOf(getStringConfigValue(OASConfig.SCAN_PACKAGES));
+            scanPackages = getConfig().getOptionalValue(OASConfig.SCAN_PACKAGES, String.class)
+                    .map(this::asCsvSet)
+                    .orElseGet(Collections::emptySet);
         }
         return scanPackages;
     }
@@ -127,9 +130,11 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      * @see io.smallrye.openapi.api.OpenApiConfig#scanClasses()
      */
     @Override
-    public Pattern scanClasses() {
+    public Set<String> scanClasses() {
         if (scanClasses == null) {
-            scanClasses = patternOf(getStringConfigValue(OASConfig.SCAN_CLASSES));
+            scanClasses = getConfig().getOptionalValue(OASConfig.SCAN_CLASSES, String.class)
+                    .map(this::asCsvSet)
+                    .orElseGet(Collections::emptySet);
         }
         return scanClasses;
     }
@@ -138,10 +143,12 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      * @see io.smallrye.openapi.api.OpenApiConfig#scanExcludePackages()
      */
     @Override
-    public Pattern scanExcludePackages() {
+    public Set<String> scanExcludePackages() {
         if (scanExcludePackages == null) {
-            scanExcludePackages = patternOf(getStringConfigValue(OASConfig.SCAN_EXCLUDE_PACKAGES),
-                    OpenApiConstants.NEVER_SCAN_PACKAGES);
+            scanExcludePackages = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_PACKAGES, String.class)
+                    .map(this::asCsvSet)
+                    .orElseGet(HashSet::new);
+            scanExcludePackages.addAll(OpenApiConstants.NEVER_SCAN_PACKAGES);
         }
         return scanExcludePackages;
     }
@@ -150,10 +157,12 @@ public class OpenApiConfigImpl implements OpenApiConfig {
      * @see io.smallrye.openapi.api.OpenApiConfig#scanExcludeClasses()
      */
     @Override
-    public Pattern scanExcludeClasses() {
+    public Set<String> scanExcludeClasses() {
         if (scanExcludeClasses == null) {
-            scanExcludeClasses = patternOf(getStringConfigValue(OASConfig.SCAN_EXCLUDE_CLASSES),
-                    OpenApiConstants.NEVER_SCAN_CLASSES);
+            scanExcludeClasses = getConfig().getOptionalValue(OASConfig.SCAN_EXCLUDE_CLASSES, String.class)
+                    .map(this::asCsvSet)
+                    .orElseGet(HashSet::new);
+            scanExcludeClasses.addAll(OpenApiConstants.NEVER_SCAN_CLASSES);
         }
         return scanExcludeClasses;
     }

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenConfig.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenConfig.java
@@ -2,7 +2,6 @@ package io.smallrye.openapi.mavenplugin;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.openapi.OASConfig;
 
@@ -38,23 +37,27 @@ public class MavenConfig implements OpenApiConfig {
     }
 
     @Override
-    public Pattern scanPackages() {
-        return patternOf(properties.getOrDefault(OASConfig.SCAN_PACKAGES, null));
+    public Set<String> scanPackages() {
+        return asCsvSet(properties.getOrDefault(OASConfig.SCAN_PACKAGES, null));
     }
 
     @Override
-    public Pattern scanClasses() {
-        return patternOf(properties.getOrDefault(OASConfig.SCAN_CLASSES, null));
+    public Set<String> scanClasses() {
+        return asCsvSet(properties.getOrDefault(OASConfig.SCAN_CLASSES, null));
     }
 
     @Override
-    public Pattern scanExcludePackages() {
-        return patternOf(properties.getOrDefault(OASConfig.SCAN_EXCLUDE_PACKAGES, null), OpenApiConstants.NEVER_SCAN_PACKAGES);
+    public Set<String> scanExcludePackages() {
+        Set<String> result = asCsvSet(properties.getOrDefault(OASConfig.SCAN_EXCLUDE_PACKAGES, null));
+        result.addAll(OpenApiConstants.NEVER_SCAN_PACKAGES);
+        return result;
     }
 
     @Override
-    public Pattern scanExcludeClasses() {
-        return patternOf(properties.getOrDefault(OASConfig.SCAN_EXCLUDE_CLASSES, null), OpenApiConstants.NEVER_SCAN_CLASSES);
+    public Set<String> scanExcludeClasses() {
+        Set<String> result = asCsvSet(properties.getOrDefault(OASConfig.SCAN_EXCLUDE_CLASSES, null));
+        result.addAll(OpenApiConstants.NEVER_SCAN_CLASSES);
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Update scanning config to match https://github.com/eclipse/microprofile-open-api/pull/533

The existing scanning code had a problem when a single package was matched by more than value of the scanning config.

For example:
```mp.openapi.scan.packages=com.example.a,com.example.a.b.c```
Here, the package `com.example.a.b.c.d` matches both entries. To correctly follow the logic now defined by the spec, we need to ensure we get the longest match, whereas the previous code may return either match.

Changes:
* Split the config property value on `,` and match against each part separately
* Treat each part as a regex if it starts with `^` or ends with `$`
  * Previous code would treat the whole property as a regex
* If the config property is a regex, just try to match it against the whole string
  * Previous code would require that a package match was a prefix, even if the regex didn't start with `^`
  * Previous code would require that a class match ended with the entire simple class name, even if the regex didn't end with `$`

Enhancements beyond the spec requirements:
* Allow a string in `mp.openapi.scan.classes` or `mp.openapi.scan.classes.exclude` to match the simple class name, or the simple class name with a package suffix, in addition to matching the fully qualified class name
* Treat a config property part as a regex if it starts with `^` or ends with `$`

One other difference, potentially a bug:
* The spec says that `mp.openapi.scan.packages` and `mp.openapi.scan.packages.exclude` should match the package or any parent package. We are doing a string prefix match against the package name, which is not quite the same.
  * We would say that `com.example.f` matches `com.example.foo`, even though `com.example.f` is not a parent package of `com.example.foo`