### PR TITLE
Update quarkus-vertx-web dependency to quarkus-reactive-routes

### DIFF
--- a/extension-vertx/pom.xml
+++ b/extension-vertx/pom.xml
@@ -36,7 +36,7 @@
         <!-- Test Only Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-reactive-routes</artifactId>
             <version>${version.quarkus}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
To avoid having to go through a Maven relocation