### PR TITLE
Read extension attribute from all annotations

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/components/ComponentsReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/components/ComponentsReader.java
@@ -54,7 +54,7 @@ public class ComponentsReader {
                 CallbackReader.readCallbacks(context, nested.value(ComponentsConstant.PROP_CALLBACKS)));
         components.setExamples(ExampleReader.readExamples(context, nested.value(ComponentsConstant.PROP_EXAMPLES)));
         components.setHeaders(HeaderReader.readHeaders(context, nested.value(ComponentsConstant.PROP_HEADERS)));
-        components.setLinks(LinkReader.readLinks(nested.value(ComponentsConstant.PROP_LINKS)));
+        components.setLinks(LinkReader.readLinks(context, nested.value(ComponentsConstant.PROP_LINKS)));
         components.setParameters(
                 ParameterReader.readParameters(context, nested.value(ComponentsConstant.PROP_PARAMETERS)));
         components.setRequestBodies(RequestBodyReader.readRequestBodies(context,
@@ -64,6 +64,7 @@ public class ComponentsReader {
         components.setSchemas(SchemaReader.readSchemas(context, nested.value(ComponentsConstant.PROP_SCHEMAS)));
         components.setSecuritySchemes(
                 SecuritySchemeReader.readSecuritySchemes(context, nested.value(ComponentsConstant.PROP_SECURITY_SCHEMES)));
+        components.setExtensions(ExtensionReader.readExtensions(context, nested));
 
         return components;
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/contact/ContactReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/contact/ContactReader.java
@@ -10,6 +10,7 @@ import io.smallrye.openapi.api.models.info.ContactImpl;
 import io.smallrye.openapi.runtime.io.IoLogging;
 import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -31,7 +32,7 @@ public class ContactReader {
      * @param annotationValue the {@literal @}Contact annotation
      * @return Contact model
      */
-    public static Contact readContact(final AnnotationValue annotationValue) {
+    public static Contact readContact(final AnnotationScannerContext context, final AnnotationValue annotationValue) {
         if (annotationValue == null) {
             return null;
         }
@@ -41,6 +42,7 @@ public class ContactReader {
         contact.setName(JandexUtil.stringValue(nested, ContactConstant.PROP_NAME));
         contact.setUrl(JandexUtil.stringValue(nested, ContactConstant.PROP_URL));
         contact.setEmail(JandexUtil.stringValue(nested, ContactConstant.PROP_EMAIL));
+        contact.setExtensions(ExtensionReader.readExtensions(context, nested));
         return contact;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/definition/DefinitionReader.java
@@ -45,10 +45,10 @@ public class DefinitionReader {
             final AnnotationInstance annotationInstance) {
         IoLogging.logger.annotation("@OpenAPIDefinition");
 
-        openApi.setInfo(InfoReader.readInfo(annotationInstance.value(DefinitionConstant.PROP_INFO)));
+        openApi.setInfo(InfoReader.readInfo(context, annotationInstance.value(DefinitionConstant.PROP_INFO)));
         openApi.setTags(TagReader.readTags(context, annotationInstance.value(DefinitionConstant.PROP_TAGS)).orElse(null));
         openApi.setServers(
-                ServerReader.readServers(annotationInstance.value(DefinitionConstant.PROP_SERVERS)).orElse(null));
+                ServerReader.readServers(context, annotationInstance.value(DefinitionConstant.PROP_SERVERS)).orElse(null));
         openApi.setSecurity(SecurityRequirementReader
                 .readSecurityRequirements(annotationInstance.value(DefinitionConstant.PROP_SECURITY),
                         annotationInstance.value(DefinitionConstant.PROP_SECURITY_SETS))

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/encoding/EncodingReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/encoding/EncodingReader.java
@@ -95,6 +95,7 @@ public class EncodingReader {
                 JandexUtil.booleanValue(annotationInstance, EncodingConstant.PROP_ALLOW_RESERVED).orElse(null));
         encoding.setHeaders(
                 HeaderReader.readHeaders(context, annotationInstance.value(EncodingConstant.PROP_HEADERS)));
+        encoding.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return encoding;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/example/ExampleReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/example/ExampleReader.java
@@ -100,6 +100,7 @@ public class ExampleReader {
         example.setDescription(JandexUtil.stringValue(annotationInstance, ExampleConstant.PROP_DESCRIPTION));
         example.setValue(parseValue(context, JandexUtil.stringValue(annotationInstance, ExampleConstant.PROP_VALUE)));
         example.setExternalValue(JandexUtil.stringValue(annotationInstance, ExampleConstant.PROP_EXTERNAL_VALUE));
+        example.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
 
         return example;
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/header/HeaderReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/header/HeaderReader.java
@@ -105,6 +105,7 @@ public class HeaderReader {
         header.setDeprecated(JandexUtil.booleanValue(annotationInstance, Parameterizable.PROP_DEPRECATED).orElse(null));
         header.setAllowEmptyValue(
                 JandexUtil.booleanValue(annotationInstance, Parameterizable.PROP_ALLOW_EMPTY_VALUE).orElse(null));
+        header.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return header;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/info/InfoReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/info/InfoReader.java
@@ -12,6 +12,7 @@ import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.contact.ContactReader;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
 import io.smallrye.openapi.runtime.io.license.LicenseReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -33,7 +34,7 @@ public class InfoReader {
      * @param annotationValue the {@literal @}Info annotation
      * @return Info model
      */
-    public static Info readInfo(final AnnotationValue annotationValue) {
+    public static Info readInfo(final AnnotationScannerContext context, final AnnotationValue annotationValue) {
         if (annotationValue == null) {
             return null;
         }
@@ -44,9 +45,10 @@ public class InfoReader {
         info.setTitle(JandexUtil.stringValue(nested, InfoConstant.PROP_TITLE));
         info.setDescription(JandexUtil.stringValue(nested, InfoConstant.PROP_DESCRIPTION));
         info.setTermsOfService(JandexUtil.stringValue(nested, InfoConstant.PROP_TERMS_OF_SERVICE));
-        info.setContact(ContactReader.readContact(nested.value(InfoConstant.PROP_CONTACT)));
-        info.setLicense(LicenseReader.readLicense(nested.value(InfoConstant.PROP_LICENSE)));
+        info.setContact(ContactReader.readContact(context, nested.value(InfoConstant.PROP_CONTACT)));
+        info.setLicense(LicenseReader.readLicense(context, nested.value(InfoConstant.PROP_LICENSE)));
         info.setVersion(JandexUtil.stringValue(nested, InfoConstant.PROP_VERSION));
+        info.setExtensions(ExtensionReader.readExtensions(context, nested));
         return info;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/license/LicenseReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/license/LicenseReader.java
@@ -10,6 +10,7 @@ import io.smallrye.openapi.api.models.info.LicenseImpl;
 import io.smallrye.openapi.runtime.io.IoLogging;
 import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -31,7 +32,7 @@ public class LicenseReader {
      * @param annotationValue the {@literal @}License annotation
      * @return License model
      */
-    public static License readLicense(final AnnotationValue annotationValue) {
+    public static License readLicense(final AnnotationScannerContext context, final AnnotationValue annotationValue) {
         if (annotationValue == null) {
             return null;
         }
@@ -40,6 +41,7 @@ public class LicenseReader {
         License license = new LicenseImpl();
         license.setName(JandexUtil.stringValue(nested, LicenseConstant.PROP_NAME));
         license.setUrl(JandexUtil.stringValue(nested, LicenseConstant.PROP_URL));
+        license.setExtensions(ExtensionReader.readExtensions(context, nested));
         return license;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/link/LinkReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/link/LinkReader.java
@@ -18,6 +18,7 @@ import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.Referenceable;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
 import io.smallrye.openapi.runtime.io.server.ServerReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -39,7 +40,7 @@ public class LinkReader {
      * @param annotationValue map of {@literal @}Link annotations
      * @return Map of Link model
      */
-    public static Map<String, Link> readLinks(final AnnotationValue annotationValue) {
+    public static Map<String, Link> readLinks(final AnnotationScannerContext context, final AnnotationValue annotationValue) {
         if (annotationValue == null) {
             return null;
         }
@@ -52,7 +53,7 @@ public class LinkReader {
                 name = JandexUtil.nameFromRef(nested);
             }
             if (name != null) {
-                links.put(name, readLink(nested));
+                links.put(name, readLink(context, nested));
             }
         }
         return links;
@@ -85,7 +86,7 @@ public class LinkReader {
      * @param annotationInstance {@literal @}Link annotation
      * @return Link model
      */
-    private static Link readLink(final AnnotationInstance annotationInstance) {
+    private static Link readLink(final AnnotationScannerContext context, final AnnotationInstance annotationInstance) {
         if (annotationInstance == null) {
             return null;
         }
@@ -96,8 +97,9 @@ public class LinkReader {
         link.setParameters(readLinkParameters(annotationInstance.value(LinkConstant.PROP_PARAMETERS)));
         link.setDescription(JandexUtil.stringValue(annotationInstance, LinkConstant.PROP_DESCRIPTION));
         link.setRequestBody(JandexUtil.stringValue(annotationInstance, LinkConstant.PROP_REQUEST_BODY));
-        link.setServer(ServerReader.readServer(annotationInstance.value(LinkConstant.PROP_SERVER)));
+        link.setServer(ServerReader.readServer(context, annotationInstance.value(LinkConstant.PROP_SERVER)));
         link.setRef(JandexUtil.refValue(annotationInstance, JandexUtil.RefType.LINK));
+        link.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return link;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/oauth/OAuthReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/oauth/OAuthReader.java
@@ -18,6 +18,7 @@ import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.extension.ExtensionConstant;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
 import io.smallrye.openapi.runtime.io.securityscheme.SecuritySchemeConstant;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -40,7 +41,7 @@ public class OAuthReader {
      * @param annotationValue the annotation value
      * @return OAuthFlows model
      */
-    public static OAuthFlows readOAuthFlows(final AnnotationValue annotationValue) {
+    public static OAuthFlows readOAuthFlows(final AnnotationScannerContext context, final AnnotationValue annotationValue) {
         if (annotationValue == null) {
             return null;
         }
@@ -51,6 +52,7 @@ public class OAuthReader {
         flows.setPassword(readOAuthFlow(annotation.value(SecuritySchemeConstant.PROP_PASSWORD)));
         flows.setClientCredentials(readOAuthFlow(annotation.value(SecuritySchemeConstant.PROP_CLIENT_CREDENTIALS)));
         flows.setAuthorizationCode(readOAuthFlow(annotation.value(SecuritySchemeConstant.PROP_AUTHORIZATION_CODE)));
+        flows.setExtensions(ExtensionReader.readExtensions(context, annotation));
         return flows;
     }
 
@@ -91,6 +93,7 @@ public class OAuthReader {
         flow.setTokenUrl(JandexUtil.stringValue(annotation, SecuritySchemeConstant.PROP_TOKEN_URL));
         flow.setRefreshUrl(JandexUtil.stringValue(annotation, SecuritySchemeConstant.PROP_REFRESH_URL));
         flow.setScopes(readOAuthScopes(annotation.value(SecuritySchemeConstant.PROP_SCOPES)));
+        flow.setExtensions(ExtensionReader.readExtensions(null, annotation));
         return flow;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/response/ResponseReader.java
@@ -183,7 +183,7 @@ public class ResponseReader {
         response.setDescription(JandexUtil.stringValue(annotationInstance, ResponseConstant.PROP_DESCRIPTION));
         response.setHeaders(
                 HeaderReader.readHeaders(context, annotationInstance.value(ResponseConstant.PROP_HEADERS)));
-        response.setLinks(LinkReader.readLinks(annotationInstance.value(ResponseConstant.PROP_LINKS)));
+        response.setLinks(LinkReader.readLinks(context, annotationInstance.value(ResponseConstant.PROP_LINKS)));
         response.setContent(
                 ContentReader.readContent(context, annotationInstance.value(ResponseConstant.PROP_CONTENT),
                         ContentDirection.OUTPUT));

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/securityscheme/SecuritySchemeReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/securityscheme/SecuritySchemeReader.java
@@ -107,7 +107,8 @@ public class SecuritySchemeReader {
         securityScheme.setScheme(JandexUtil.stringValue(annotationInstance, SecuritySchemeConstant.PROP_SCHEME));
         securityScheme.setBearerFormat(
                 JandexUtil.stringValue(annotationInstance, SecuritySchemeConstant.PROP_BEARER_FORMAT));
-        securityScheme.setFlows(OAuthReader.readOAuthFlows(annotationInstance.value(SecuritySchemeConstant.PROP_FLOWS)));
+        securityScheme
+                .setFlows(OAuthReader.readOAuthFlows(context, annotationInstance.value(SecuritySchemeConstant.PROP_FLOWS)));
         securityScheme
                 .setOpenIdConnectUrl(
                         JandexUtil.stringValue(annotationInstance, SecuritySchemeConstant.PROP_OPEN_ID_CONNECT_URL));

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/server/ServerReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/server/ServerReader.java
@@ -17,6 +17,7 @@ import io.smallrye.openapi.runtime.io.IoLogging;
 import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
 import io.smallrye.openapi.runtime.io.servervariable.ServerVariableReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -38,13 +39,14 @@ public class ServerReader {
      * @param annotationValue an Array of {@literal @}Server annotations
      * @return a List of Server models
      */
-    public static Optional<List<Server>> readServers(final AnnotationValue annotationValue) {
+    public static Optional<List<Server>> readServers(final AnnotationScannerContext context,
+            final AnnotationValue annotationValue) {
         if (annotationValue != null) {
             IoLogging.logger.annotationsArray("@Server");
             AnnotationInstance[] nestedArray = annotationValue.asNestedArray();
             List<Server> servers = new ArrayList<>();
             for (AnnotationInstance serverAnno : nestedArray) {
-                servers.add(readServer(serverAnno));
+                servers.add(readServer(context, serverAnno));
             }
             return Optional.of(servers);
         }
@@ -76,9 +78,9 @@ public class ServerReader {
      * @param annotationValue the {@literal @}Server annotation
      * @return a Server model
      */
-    public static Server readServer(final AnnotationValue annotationValue) {
+    public static Server readServer(final AnnotationScannerContext context, final AnnotationValue annotationValue) {
         if (annotationValue != null) {
-            return readServer(annotationValue.asNested());
+            return readServer(context, annotationValue.asNested());
         }
         return null;
     }
@@ -89,14 +91,15 @@ public class ServerReader {
      * @param annotationInstance the {@literal @}Server annotations instance
      * @return Server model
      */
-    public static Server readServer(final AnnotationInstance annotationInstance) {
+    public static Server readServer(final AnnotationScannerContext context, final AnnotationInstance annotationInstance) {
         if (annotationInstance != null) {
             IoLogging.logger.singleAnnotation("@Server");
             Server server = new ServerImpl();
             server.setUrl(JandexUtil.stringValue(annotationInstance, ServerConstant.PROP_URL));
             server.setDescription(JandexUtil.stringValue(annotationInstance, ServerConstant.PROP_DESCRIPTION));
             server.setVariables(
-                    ServerVariableReader.readServerVariables(annotationInstance.value(ServerConstant.PROP_VARIABLES)));
+                    ServerVariableReader.readServerVariables(context, annotationInstance.value(ServerConstant.PROP_VARIABLES)));
+            server.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
             return server;
         }
         return null;

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/servervariable/ServerVariableReader.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/servervariable/ServerVariableReader.java
@@ -17,6 +17,7 @@ import io.smallrye.openapi.runtime.io.IoLogging;
 import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.extension.ExtensionConstant;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerContext;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 
 /**
@@ -40,7 +41,8 @@ public class ServerVariableReader {
      * @param annotationValue an arrays of {@literal @}ServerVariable annotations
      * @return a Map of Variable name and ServerVariable model
      */
-    public static Map<String, ServerVariable> readServerVariables(final AnnotationValue annotationValue) {
+    public static Map<String, ServerVariable> readServerVariables(final AnnotationScannerContext context,
+            final AnnotationValue annotationValue) {
         if (annotationValue == null) {
             return null;
         }
@@ -50,7 +52,7 @@ public class ServerVariableReader {
         for (AnnotationInstance serverVariableAnno : nestedArray) {
             String name = JandexUtil.stringValue(serverVariableAnno, ServerVariableConstant.PROP_NAME);
             if (name != null) {
-                variables.put(name, readServerVariable(serverVariableAnno));
+                variables.put(name, readServerVariable(context, serverVariableAnno));
             }
         }
         return variables;
@@ -85,7 +87,8 @@ public class ServerVariableReader {
      * @param annotationInstance the {@literal @}ServerVariable annotation
      * @return the ServerVariable model
      */
-    private static ServerVariable readServerVariable(final AnnotationInstance annotationInstance) {
+    private static ServerVariable readServerVariable(final AnnotationScannerContext context,
+            final AnnotationInstance annotationInstance) {
         if (annotationInstance == null) {
             return null;
         }
@@ -97,6 +100,7 @@ public class ServerVariableReader {
                 JandexUtil.stringListValue(annotationInstance, ServerVariableConstant.PROP_ENUMERATION).orElse(null));
         variable.setDefaultValue(
                 JandexUtil.stringValue(annotationInstance, ServerVariableConstant.PROP_DEFAULT_VALUE));
+        variable.setExtensions(ExtensionReader.readExtensions(context, annotationInstance));
         return variable;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -168,10 +168,10 @@ public interface AnnotationScanner {
      * @param targetClass the class that contain the server annotation
      * @param openApi the current OpenApi model being created
      */
-    default void processServerAnnotation(final ClassInfo targetClass, OpenAPI openApi) {
+    default void processServerAnnotation(final AnnotationScannerContext context, final ClassInfo targetClass, OpenAPI openApi) {
         List<AnnotationInstance> serverAnnotations = ServerReader.getServerAnnotations(targetClass);
         for (AnnotationInstance annotation : serverAnnotations) {
-            Server server = ServerReader.readServer(annotation);
+            Server server = ServerReader.readServer(context, annotation);
             openApi.addServer(server);
         }
     }
@@ -754,13 +754,13 @@ public interface AnnotationScanner {
      * @param method the method that contain the server annotation
      * @param operation the current Operation model being created
      */
-    default void processServerAnnotation(final MethodInfo method, Operation operation) {
+    default void processServerAnnotation(final AnnotationScannerContext context, final MethodInfo method, Operation operation) {
         List<AnnotationInstance> serverAnnotations = ServerReader.getServerAnnotations(method);
         if (serverAnnotations.isEmpty()) {
             serverAnnotations.addAll(ServerReader.getServerAnnotations(method.declaringClass()));
         }
         for (AnnotationInstance annotation : serverAnnotations) {
-            Server server = ServerReader.readServer(annotation);
+            Server server = ServerReader.readServer(context, annotation);
             operation.addServer(server);
         }
     }

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -208,7 +208,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         processSecuritySchemeAnnotation(context, applicationClass, openApi);
 
         // Process @Server annotations
-        processServerAnnotation(applicationClass, openApi);
+        processServerAnnotation(context, applicationClass, openApi);
 
         return openApi;
     }
@@ -471,7 +471,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
         processCallback(context, method, operation);
 
         // Process @Server annotations
-        processServerAnnotation(method, operation);
+        processServerAnnotation(context, method, operation);
 
         // Process @Extension annotations
         processExtensions(context, method, operation);

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -200,7 +200,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
         processSecuritySchemeAnnotation(context, controllerClass, openApi);
 
         // Process @Server annotations
-        processServerAnnotation(controllerClass, openApi);
+        processServerAnnotation(context, controllerClass, openApi);
 
         // Process Java security
         processJavaSecurity(controllerClass, openApi);
@@ -333,7 +333,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
         processCallback(context, method, operation);
 
         // Process @Server annotations
-        processServerAnnotation(method, operation);
+        processServerAnnotation(context, method, operation);
 
         // Process @Extension annotations
         processExtensions(context, method, operation);

--- a/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
+++ b/extension-vertx/src/main/java/io/smallrye/openapi/vertx/VertxAnnotationScanner.java
@@ -171,7 +171,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
         processSecuritySchemeAnnotation(context, routeClass, openApi);
 
         // Process @Server annotations
-        processServerAnnotation(routeClass, openApi);
+        processServerAnnotation(context, routeClass, openApi);
 
         // Process Java security
         processJavaSecurity(routeClass, openApi);
@@ -295,7 +295,7 @@ public class VertxAnnotationScanner extends AbstractAnnotationScanner {
             processCallback(context, method, operation);
 
             // Process @Server annotations
-            processServerAnnotation(method, operation);
+            processServerAnnotation(context, method, operation);
 
             // Process @Extension annotations
             processExtensions(context, method, operation);


### PR DESCRIPTION
Certain annotation readers were not reading the extensions attribute for
the annotation.

Fixes #1159 