### PR TITLE
Parse schema example using extension-provided parser

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -34,7 +34,6 @@ import io.smallrye.openapi.api.models.media.SchemaImpl;
 import io.smallrye.openapi.api.util.MergeUtil;
 import io.smallrye.openapi.runtime.io.CurrentScannerInfo;
 import io.smallrye.openapi.runtime.io.IoLogging;
-import io.smallrye.openapi.runtime.io.JsonUtil;
 import io.smallrye.openapi.runtime.io.extension.ExtensionReader;
 import io.smallrye.openapi.runtime.io.externaldocs.ExternalDocsConstant;
 import io.smallrye.openapi.runtime.io.externaldocs.ExternalDocsReader;
@@ -181,7 +180,7 @@ public class SchemaFactory {
         schema.setExternalDocs(ExternalDocsReader.readExternalDocs(context, externalDocsAnnotation));
         schema.setDeprecated(readAttr(annotation, SchemaConstant.PROP_DEPRECATED, defaults));
         schema.setType(readSchemaType(annotation, schema, defaults));
-        schema.setExample(parseSchemaAttr(annotation, SchemaConstant.PROP_EXAMPLE, defaults, schema.getType()));
+        schema.setExample(parseSchemaAttr(context, annotation, SchemaConstant.PROP_EXAMPLE, defaults, schema.getType()));
         schema.setDefaultValue(readAttr(annotation, SchemaConstant.PROP_DEFAULT_VALUE, defaults));
         schema.setDiscriminator(
                 readDiscriminator(context,
@@ -314,21 +313,28 @@ public class SchemaFactory {
      * they key. Array-typed annotation values will be converted to List.
      *
      * @param <T> the type of the annotation attribute value
+     * @param context scanning context
      * @param annotation the annotation to read
      * @param propertyName the name of the attribute to read
      * @param defaults map of default values
      * @param schemaType related schema type for this attribute
      * @return the annotation attribute value, a default value, or null
      */
-    static Object parseSchemaAttr(AnnotationInstance annotation, String propertyName, Map<String, Object> defaults,
-            SchemaType schemaType) {
+    static Object parseSchemaAttr(AnnotationScannerContext context, AnnotationInstance annotation, String propertyName,
+            Map<String, Object> defaults, SchemaType schemaType) {
         return readAttr(annotation, propertyName, value -> {
             if (!(value instanceof String)) {
                 return value;
             }
             String stringValue = ((String) value);
             if (schemaType != SchemaType.STRING) {
-                return JsonUtil.parseValue(stringValue);
+                Object parsedValue;
+                for (AnnotationScannerExtension e : context.getExtensions()) {
+                    parsedValue = e.parseValue(stringValue);
+                    if (parsedValue != null) {
+                        return parsedValue;
+                    }
+                }
             }
             return stringValue;
         }, defaults);

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <jackson-bom.version>2.13.3</jackson-bom.version>
         <version.eclipse.microprofile.config>3.0</version.eclipse.microprofile.config>
         <version.io.smallrye.smallrye-config>3.0.0-RC2</version.io.smallrye.smallrye-config>
-        <version.eclipse.microprofile.openapi>3.1-SNAPSHOT</version.eclipse.microprofile.openapi>
+        <version.eclipse.microprofile.openapi>3.1-RC1</version.eclipse.microprofile.openapi>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>


### PR DESCRIPTION
Also bumps MP OpenAPI to 3.1-RC1. Fixes #1161 

This will be backported to 2.x along with the other non-MP3.1 changes. I'll look at doing that over the next few weeks.