### PR TITLE
Do not set `nullable: false` due to Bean Validation annotations

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java
@@ -370,9 +370,6 @@ public class BeanValidationScanner {
         AnnotationInstance constraint = getConstraint(target, BV_NOT_BLANK);
 
         if (constraint != null) {
-            if (schema.getNullable() == null) {
-                schema.setNullable(Boolean.FALSE);
-            }
             if (schema.getPattern() == null) {
                 schema.setPattern("\\S");
             }
@@ -413,10 +410,6 @@ public class BeanValidationScanner {
         AnnotationInstance constraint = getConstraint(target, BV_NOT_EMPTY);
 
         if (constraint != null) {
-            if (schema.getNullable() == null) {
-                schema.setNullable(Boolean.FALSE);
-            }
-
             if (schema.getMinLength() == null) {
                 schema.setMinLength(1);
             }
@@ -429,10 +422,6 @@ public class BeanValidationScanner {
         AnnotationInstance constraint = getConstraint(target, BV_NOT_NULL);
 
         if (constraint != null) {
-            if (schema.getNullable() == null) {
-                schema.setNullable(Boolean.FALSE);
-            }
-
             handler.setRequired(target, propertyKey);
         }
     }

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScannerTest.java
@@ -155,7 +155,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
         testTarget.sizeArray(targetField, schema);
         testTarget.notEmptyArray(targetField, schema, propertyKey, requirementHandler(parentSchema));
 
-        assertEquals(Boolean.FALSE, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(Integer.valueOf(1), schema.getMinItems());
         assertEquals(Integer.valueOf(20), schema.getMaxItems());
         assertEquals(Arrays.asList(propertyKey), parentSchema.getRequired());
@@ -181,7 +181,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
         testTarget.sizeArray(targetField, schema);
         testTarget.notEmptyArray(targetField, schema, propertyKey, requirementHandler(parentSchema));
 
-        assertEquals(null, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(Integer.valueOf(5), schema.getMinItems());
         assertEquals(Integer.valueOf(20), schema.getMaxItems());
         assertEquals(Arrays.asList(propertyKey), parentSchema.getRequired());
@@ -211,7 +211,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
         testTarget.sizeObject(targetField, schema);
         testTarget.notEmptyObject(targetField, schema, propertyKey, requirementHandler(parentSchema));
 
-        assertEquals(Boolean.FALSE, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(Integer.valueOf(1), schema.getMinProperties());
         assertEquals(Integer.valueOf(20), schema.getMaxProperties());
         assertEquals(Arrays.asList(propertyKey), parentSchema.getRequired());
@@ -239,7 +239,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
         testTarget.sizeObject(targetField, schema);
         testTarget.notEmptyObject(targetField, schema, propertyKey, requirementHandler(parentSchema));
 
-        assertEquals(null, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(Integer.valueOf(5), schema.getMinProperties());
         assertEquals(Integer.valueOf(20), schema.getMaxProperties());
         assertEquals(Arrays.asList(propertyKey), parentSchema.getRequired());
@@ -265,7 +265,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
         testTarget.sizeObject(targetField, schema);
         testTarget.notEmptyObject(targetField, schema, propertyKey, requirementHandlerFail());
 
-        assertEquals(null, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(null, schema.getMinProperties());
         assertEquals(null, schema.getMaxProperties());
         assertNull(parentSchema.getRequired());
@@ -649,7 +649,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
         testTarget.notNull(targetField, schema, propertyKey, requirementHandler(parentSchema));
 
         assertEquals("\\S", schema.getPattern());
-        assertEquals(Boolean.FALSE, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(Arrays.asList(propertyKey), parentSchema.getRequired());
     }
 
@@ -673,7 +673,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
         testTarget.notBlank(targetField, schema, propertyKey, requirementHandler(parentSchema));
 
         assertEquals("^\\d{1,8}([.]\\d{1,10})?$", schema.getPattern());
-        assertEquals(Boolean.FALSE, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(Arrays.asList(propertyKey), parentSchema.getRequired());
     }
 
@@ -698,7 +698,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
 
         assertEquals(Integer.valueOf(1), schema.getMinLength());
         assertEquals(Integer.valueOf(2000), schema.getMaxLength());
-        assertEquals(Boolean.FALSE, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(Arrays.asList(propertyKey), parentSchema.getRequired());
     }
 
@@ -723,7 +723,7 @@ class BeanValidationScannerTest extends IndexScannerTestBase {
 
         assertEquals(Integer.valueOf(100), schema.getMinLength());
         assertEquals(Integer.valueOf(2000), schema.getMaxLength());
-        assertEquals(Boolean.FALSE, schema.getNullable());
+        assertNull(schema.getNullable());
         assertEquals(Arrays.asList(propertyKey), parentSchema.getRequired());
     }
 

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/resource.testBeanValidationDocument.json
@@ -83,14 +83,7 @@
             }
           },
           "enumValue": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TestEnum"
-              },
-              {
-                "nullable": false
-              }
-            ]
+            "$ref": "#/components/schemas/TestEnum"
           }
         }
       },
@@ -111,7 +104,6 @@
         "properties": {
           "arrayListNotNullAndNotEmptyAndMaxItems": {
             "type": "array",
-            "nullable": false,
             "minItems": 1,
             "maxItems": 20,
             "items": {
@@ -127,8 +119,7 @@
             }
           },
           "booleanNotNull": {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           "decimalMaxBigDecimalExclusiveDigits": {
             "type": "number",
@@ -199,7 +190,6 @@
           },
           "mapObjectNotNullAndNotEmptyAndMaxProperties": {
             "type": "object",
-            "nullable": false,
             "minProperties": 1,
             "maxProperties": 20,
             "additionalProperties": {
@@ -216,23 +206,19 @@
           },
           "stringNotBlankDigits": {
             "type": "string",
-            "nullable": false,
             "pattern": "^\\d{1,8}([.]\\d{1,10})?$"
           },
           "stringNotBlankNotNull": {
             "type": "string",
-            "nullable": false,
             "pattern": "\\S"
           },
           "stringNotEmptyMaxSize": {
             "type": "string",
-            "nullable": false,
             "minLength": 1,
             "maxLength": 2000
           },
           "stringNotEmptySizeRange": {
             "type": "string",
-            "nullable": false,
             "minLength": 100,
             "maxLength": 2000
           },

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/schema.inherited-bv-constraints.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/dataobject/schema.inherited-bv-constraints.json
@@ -13,8 +13,7 @@
             "description": "The user identifier",
             "maximum": 9999,
             "minimum": 15,
-            "type": "integer",
-            "nullable": false
+            "type": "integer"
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.all-the-params.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.all-the-params.json
@@ -116,8 +116,7 @@
                   },
                   "f2": {
                     "type": "string",
-                    "default": "f2-default",
-                    "nullable": false
+                    "default": "f2-default"
                   }
                 }
               },

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.matrix-params-on-resource-method-args.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.matrix-params-on-resource-method-args.json
@@ -9,8 +9,7 @@
           "required": true,
           "schema": {
             "type": "string",
-            "maxLength": 10,
-            "nullable": false
+            "maxLength": 10
           }
         }
       ],

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.multipart-form.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.multipart-form.json
@@ -46,8 +46,7 @@
                     "default": 3
                   },
                   "formField4": {
-                    "type": "string",
-                    "nullable": false
+                    "type": "string"
                   },
                   "data": {
                     "type": "object"

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.optional-types.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.optional-types.json
@@ -246,8 +246,7 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string",
-              "nullable": false
+              "type": "string"
             }
           }
         ],
@@ -274,7 +273,7 @@
         "properties": {
           "title": {
             "type": "string",
-            "nullable": false
+            "nullable": true
           }
         }
       },

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.parameters-in-constructor.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.parameters-in-constructor.json
@@ -42,8 +42,7 @@
           "in": "cookie",
           "required": true,
           "schema": {
-            "type": "string",
-            "nullable": false
+            "type": "string"
           }
         }
       ],

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.path-param-with-form-params.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.path-param-with-form-params.json
@@ -10,7 +10,6 @@
           "schema": {
             "type": "string",
             "default": "12345",
-            "nullable": false,
             "minLength": 1,
             "maxLength": 12
           }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.interface-inheritance.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.interface-inheritance.json
@@ -86,8 +86,7 @@
             "format": "date-time",
             "description": "When the entity was created as a Unix timestamp. For create operations, this will not need to be defined.",
             "type": "string",
-            "example": "0",
-            "nullable": false
+            "example": "0"
           },
           "creator": {
             "format": "uuid",
@@ -95,8 +94,7 @@
             "maxLength": 37,
             "minLength": 37,
             "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
-            "type": "string",
-            "nullable": false
+            "type": "string"
           },
           "id": {
             "format": "uuid",
@@ -104,14 +102,12 @@
             "maxLength": 37,
             "minLength": 37,
             "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
-            "type": "string",
-            "nullable": false
+            "type": "string"
           },
           "name": {
             "description": "Display name of this entity.",
             "minLength": 0,
-            "type": "string",
-            "nullable": false
+            "type": "string"
           },
           "schema": {
             "format": "uuid",
@@ -119,8 +115,7 @@
             "maxLength": 37,
             "minLength": 37,
             "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
-            "type": "string",
-            "nullable": false
+            "type": "string"
           },
           "data": {
             "description": "The textual data of the note.",

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.hidden-setter-readonly-props.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.hidden-setter-readonly-props.json
@@ -35,8 +35,7 @@
             "description": "Condition string.",
             "minLength": 1,
             "type": "string",
-            "example": "arch = \"x86_64\"",
-            "nullable": false
+            "example": "arch = \"x86_64\""
           },
           "ctime": {
             "format": "yyyy-MM-dd hh:mm:ss.ddd",
@@ -71,8 +70,7 @@
             "description": "Name of the rule. Must be unique per customer account.",
             "maxLength": 150,
             "minLength": 1,
-            "type": "string",
-            "nullable": false
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
Fixes #1180 

Nullable of `false` is the default assumed value in OpenAPI 3