### PR TITLE
Release 3.0.0-RC2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye OpenAPI
 release:
-  current-version: 2.1.23
-  next-version: 2.1.24-SNAPSHOT
+  current-version: 3.0.0-RC2
+  next-version: 3.0.0-SNAPSHOT


### PR DESCRIPTION
Release of 3.0.0-RC2 after resetting the `3.0.x` branch to `2.1.x` and applying the `to-jakarta.sh` migration script: https://github.com/smallrye/smallrye-open-api/commit/929e6408eedef3e47e11f1e1786a57f40002edc7