### PR TITLE
Add support for `@JsonView`

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/constants/JacksonConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/JacksonConstants.java
@@ -22,10 +22,12 @@ public class JacksonConstants {
             .createSimple("com.fasterxml.jackson.annotation.JsonPropertyOrder");
     public static final DotName JSON_UNWRAPPED = DotName
             .createSimple("com.fasterxml.jackson.annotation.JsonUnwrapped");
-    public static final DotName JSON_NAMING = DotName
-            .createSimple("com.fasterxml.jackson.databind.annotation.JsonNaming");
     public static final DotName JSON_VALUE = DotName
             .createSimple("com.fasterxml.jackson.annotation.JsonValue");
+    public static final DotName JSON_VIEW = DotName
+            .createSimple("com.fasterxml.jackson.annotation.JsonView");
+    public static final DotName JSON_NAMING = DotName
+            .createSimple("com.fasterxml.jackson.databind.annotation.JsonNaming");
 
     public static final String PROP_VALUE = "value";
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -595,16 +595,16 @@ public class SchemaFactory {
         }
         SchemaRegistry schemaRegistry = SchemaRegistry.currentInstance();
 
-        if (schemaRegistry != null && schemaRegistry.hasSchema(ctype)) {
+        if (schemaRegistry != null && schemaRegistry.hasSchema(ctype, context.getJsonViews())) {
             if (schemaReferenceSupported) {
-                return schemaRegistry.lookupRef(ctype);
+                return schemaRegistry.lookupRef(ctype, context.getJsonViews());
             } else {
                 // Clone the schema from the registry using mergeObjects
-                return MergeUtil.mergeObjects(new SchemaImpl(), schemaRegistry.lookupSchema(ctype));
+                return MergeUtil.mergeObjects(new SchemaImpl(), schemaRegistry.lookupSchema(ctype, context.getJsonViews()));
             }
         } else if (context.getScanStack().contains(ctype)) {
             // Protect against stack overflow when the type is in the process of being scanned.
-            return SchemaRegistry.registerReference(ctype, null, new SchemaImpl());
+            return SchemaRegistry.registerReference(ctype, context.getJsonViews(), null, new SchemaImpl());
         } else {
             Schema schema = OpenApiDataObjectScanner.process(context, ctype);
 
@@ -628,9 +628,9 @@ public class SchemaFactory {
         SchemaRegistry schemaRegistry = SchemaRegistry.currentInstance();
 
         if (allowRegistration(context, schemaRegistry, type, schema)) {
-            schema = schemaRegistry.register(type, schema);
-        } else if (schemaRegistry != null && schemaRegistry.hasRef(type)) {
-            schema = schemaRegistry.lookupRef(type);
+            schema = schemaRegistry.register(type, context.getJsonViews(), schema);
+        } else if (schemaRegistry != null && schemaRegistry.hasRef(type, context.getJsonViews())) {
+            schema = schemaRegistry.lookupRef(type, context.getJsonViews());
         }
 
         return schema;
@@ -657,7 +657,7 @@ public class SchemaFactory {
         /*
          * Only register if the type is not already registered
          */
-        return !registry.hasSchema(type);
+        return !registry.hasSchema(type, context.getJsonViews());
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -221,7 +221,7 @@ public class OpenApiDataObjectScanner {
 
             Type currentType = currentPathEntry.getClazzType();
 
-            if (SchemaRegistry.hasSchema(currentType, null)) {
+            if (SchemaRegistry.hasSchema(currentType, context.getJsonViews(), null)) {
                 // This type has already been scanned and registered, don't do it again!
                 continue;
             }
@@ -292,9 +292,9 @@ public class OpenApiDataObjectScanner {
                 this.rootSchema = enclosingSchema;
             }
 
-            if (SchemaRegistry.hasSchema(currentType, null)) {
+            if (SchemaRegistry.hasSchema(currentType, context.getJsonViews(), null)) {
                 // Replace the registered schema if one is present
-                SchemaRegistry.currentInstance().register(currentType, enclosingSchema);
+                SchemaRegistry.currentInstance().register(currentType, context.getJsonViews(), enclosingSchema);
             }
         }
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -149,10 +149,17 @@ public class AnnotationTargetProcessor implements RequirementHandler {
             if (typeSchema.getType() != SchemaType.ARRAY) {
                 // Only register a reference to the type schema. The full schema will be added by subsequent
                 // items on the stack (if not already present in the registry).
-                registeredTypeSchema = SchemaRegistry.registerReference(registrationType, typeResolver, typeSchema);
+                if (JandexUtil.isRef(schemaAnnotation)) {
+                    registeredTypeSchema = null;
+                } else {
+                    registeredTypeSchema = SchemaRegistry.registerReference(registrationType, context.getJsonViews(),
+                            typeResolver,
+                            typeSchema);
+                }
             } else {
                 // Allow registration of arrays since we may not encounter a List<CurrentType> again.
-                registeredTypeSchema = SchemaRegistry.checkRegistration(registrationType, typeResolver, typeSchema);
+                registeredTypeSchema = SchemaRegistry.checkRegistration(registrationType, context.getJsonViews(), typeResolver,
+                        typeSchema);
             }
         }
 
@@ -212,8 +219,11 @@ public class AnnotationTargetProcessor implements RequirementHandler {
             } else {
                 fieldSchema = registeredTypeSchema; // Reference to the type schema
             }
-        } else {
-            // Registration did not occur, overlay anything defined by the field on the type's schema
+        } else if (!JandexUtil.isRef(schemaAnnotation)) {
+            /*
+             * Registration did not occur and the user did not indicate this schema is a simple reference,
+             * overlay anything defined by the field on the type's schema
+             */
             fieldSchema = MergeUtil.mergeObjects(typeSchema, fieldSchema);
         }
 
@@ -313,7 +323,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
      * @return true if the schemas are not the same (i.e. registration occurred), otherwise false
      */
     private boolean registrationSuccessful(Schema typeSchema, Schema registeredTypeSchema) {
-        return (typeSchema != registeredTypeSchema);
+        return (registeredTypeSchema != null && typeSchema != registeredTypeSchema);
     }
 
     private Schema readSchemaAnnotatedField(String propertyKey, AnnotationInstance annotation, Type postProcessedField) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
@@ -68,7 +68,7 @@ public class TypeProcessor {
     public Type processType() {
         // If it's a terminal type.
         if (isTerminalType(type)) {
-            SchemaRegistry.checkRegistration(type, typeResolver, schema);
+            SchemaRegistry.checkRegistration(type, context.getJsonViews(), typeResolver, schema);
             return type;
         }
 
@@ -151,7 +151,7 @@ public class TypeProcessor {
             pushToStack(componentType, itemSchema);
         }
 
-        itemSchema = SchemaRegistry.registerReference(componentType, typeResolver, itemSchema);
+        itemSchema = SchemaRegistry.registerReference(componentType, context.getJsonViews(), typeResolver, itemSchema);
 
         while (arrayType.dimensions() > 1) {
             Schema parentArrSchema = new SchemaImpl();
@@ -250,7 +250,7 @@ public class TypeProcessor {
             Type resolved = resolveTypeVariable(propsSchema, valueType, true);
             if (index.containsClass(resolved)) {
                 propsSchema.type(Schema.SchemaType.OBJECT);
-                propsSchema = SchemaRegistry.registerReference(valueType, typeResolver, propsSchema);
+                propsSchema = SchemaRegistry.registerReference(valueType, context.getJsonViews(), typeResolver, propsSchema);
             }
         } else if (index.containsClass(valueType)) {
             if (isA(valueType, ENUM_TYPE)) {
@@ -262,7 +262,7 @@ public class TypeProcessor {
                 pushToStack(valueType, propsSchema);
             }
 
-            propsSchema = SchemaRegistry.registerReference(valueType, typeResolver, propsSchema);
+            propsSchema = SchemaRegistry.registerReference(valueType, context.getJsonViews(), typeResolver, propsSchema);
         }
 
         return propsSchema;

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -41,6 +41,7 @@ import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 
 import io.smallrye.openapi.api.OpenApiConfig.OperationIdStrategy;
+import io.smallrye.openapi.api.constants.JacksonConstants;
 import io.smallrye.openapi.api.constants.KotlinConstants;
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 import io.smallrye.openapi.api.constants.SecurityConstants;
@@ -66,6 +67,7 @@ import io.smallrye.openapi.runtime.io.tag.TagConstant;
 import io.smallrye.openapi.runtime.io.tag.TagReader;
 import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
 import io.smallrye.openapi.runtime.scanner.ResourceParameters;
+import io.smallrye.openapi.runtime.scanner.dataobject.AugmentedIndexView;
 import io.smallrye.openapi.runtime.scanner.processor.JavaSecurityProcessor;
 import io.smallrye.openapi.runtime.util.JandexUtil;
 import io.smallrye.openapi.runtime.util.ModelUtil;
@@ -338,9 +340,33 @@ public interface AnnotationScanner {
         return Optional.of(operation);
     }
 
+    default void setJsonViewContext(AnnotationScannerContext context, Type[] views) {
+        clearJsonViewContext(context);
+
+        if (views != null && views.length > 0) {
+            AugmentedIndexView index = context.getAugmentedIndex();
+
+            Arrays.stream(views)
+                    .map(viewType -> {
+                        if (index.containsClass(viewType)) {
+                            return JandexUtil.inheritanceChain(index, index.getClass(viewType), viewType).values();
+                        }
+                        return Collections.singleton(viewType);
+                    })
+                    .flatMap(Collection::stream)
+                    .forEach(context.getJsonViews()::add);
+        }
+    }
+
+    default void clearJsonViewContext(AnnotationScannerContext context) {
+        context.getJsonViews().clear();
+    }
+
     default void processResponse(final AnnotationScannerContext context, final ClassInfo resourceClass, final MethodInfo method,
             Operation operation,
             Map<DotName, List<AnnotationInstance>> exceptionAnnotationMap) {
+
+        setJsonViewContext(context, TypeUtil.getDeclaredAnnotationValue(method, JacksonConstants.JSON_VIEW));
 
         List<AnnotationInstance> classApiResponseAnnotations = ResponseReader.getResponseAnnotations(resourceClass);
         for (AnnotationInstance annotation : classApiResponseAnnotations) {
@@ -386,6 +412,8 @@ public interface AnnotationScanner {
                 }
             }
         }
+
+        clearJsonViewContext(context);
     }
 
     /**
@@ -872,6 +900,9 @@ public interface AnnotationScanner {
 
             // Only generate the request body schema if the @RequestBody is not a reference and no schema is yet specified
             if (requestBodyType != null && requestBody.getRef() == null) {
+                Type[] views = JandexUtil
+                        .value(JandexUtil.getMethodParameterAnnotation(method, requestBodyType, JacksonConstants.JSON_VIEW));
+                setJsonViewContext(context, views);
                 if (!ModelUtil.requestBodyHasSchema(requestBody)) {
                     requestBodyType = context.getResourceTypeResolver().resolve(requestBodyType);
                     Schema schema = SchemaFactory.typeToSchema(context, requestBodyType, context.getExtensions());
@@ -906,6 +937,9 @@ public interface AnnotationScanner {
                 requestBodyType = context.getResourceTypeResolver().resolve(requestBodyType);
 
                 if (requestBodyType != null && !isScannerInternalParameter(requestBodyType)) {
+                    Type[] views = JandexUtil.value(
+                            JandexUtil.getMethodParameterAnnotation(method, requestBodyType, JacksonConstants.JSON_VIEW));
+                    setJsonViewContext(context, views);
                     Schema schema = null;
 
                     if (isMultipartInput(requestBodyType)) {
@@ -929,6 +963,9 @@ public interface AnnotationScanner {
                 }
             }
         }
+
+        clearJsonViewContext(context);
+
         return requestBody;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
@@ -3,8 +3,10 @@ package io.smallrye.openapi.runtime.scanner.spi;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -38,6 +40,7 @@ public class AnnotationScannerContext {
     private final Deque<Type> scanStack = new ArrayDeque<>();
     private Deque<TypeResolver> resolverStack = new ArrayDeque<>();
     private final Optional<BeanValidationScanner> beanValidationScanner;
+    private final Set<Type> jsonViews = new LinkedHashSet<>();
 
     public AnnotationScannerContext(FilteredIndexView index, ClassLoader classLoader,
             List<AnnotationScannerExtension> extensions,
@@ -108,4 +111,7 @@ public class AnnotationScannerContext {
         return beanValidationScanner;
     }
 
+    public Set<Type> getJsonViews() {
+        return jsonViews;
+    }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -137,6 +137,10 @@ public class JandexUtil {
         return ref;
     }
 
+    public static <T> T value(AnnotationInstance annotation) {
+        return annotation != null ? value(annotation, OpenApiConstants.VALUE) : null;
+    }
+
     /**
      * Convenience method to retrieve the named parameter from an annotation.
      * The value will be unwrapped from its containing {@link AnnotationValue}.
@@ -340,7 +344,7 @@ public class JandexUtil {
      * @return Whether it's a "ref"
      */
     public static boolean isRef(AnnotationInstance annotation) {
-        return annotation.value(OpenApiConstants.REF) != null;
+        return annotation != null && annotation.value(OpenApiConstants.REF) != null;
     }
 
     /**
@@ -567,14 +571,28 @@ public class JandexUtil {
      */
     public static AnnotationInstance getMethodParameterAnnotation(MethodInfo method, int parameterIndex,
             DotName annotationName) {
-        for (AnnotationInstance annotation : method.annotations()) {
-            if (annotation.target().kind() == Kind.METHOD_PARAMETER &&
-                    annotation.target().asMethodParameter().position() == parameterIndex &&
-                    annotation.name().equals(annotationName)) {
-                return annotation;
-            }
-        }
-        return null;
+        return method.annotations(annotationName)
+                .stream()
+                .filter(annotation -> annotation.target().kind() == Kind.METHOD_PARAMETER)
+                .filter(annotation -> annotation.target().asMethodParameter().position() == parameterIndex)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Finds an annotation (if present) with the given name, on a particular parameter of a
+     * method based on the identity of the parameterType. Returns null if not found.
+     * 
+     * @param method the method
+     * @param parameterType the parameter type
+     * @param annotationName name of annotation we are looking for
+     * @return the Annotation instance
+     */
+    public static AnnotationInstance getMethodParameterAnnotation(MethodInfo method, Type parameterType,
+            DotName annotationName) {
+        // parameterType must be the same object as in the method's parameter type array
+        int parameterIndex = method.parameterTypes().indexOf(parameterType);
+        return getMethodParameterAnnotation(method, parameterIndex, annotationName);
     }
 
     public static List<AnnotationValue> schemaDisplayValues(AnnotationInstance annotation) {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
@@ -1,6 +1,7 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassType;
@@ -37,7 +38,7 @@ class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, type);
 
         Schema result = scanner.process();
-        registry.register(type, result);
+        registry.register(type, Collections.emptySet(), result);
 
         printToConsole(oai);
         assertJsonEquals(expectedResourceName, oai);
@@ -53,7 +54,7 @@ class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, parentType);
 
         Schema result = scanner.process();
-        registry.register(parentType, result);
+        registry.register(parentType, Collections.emptySet(), result);
 
         printToConsole(oai);
         assertJsonEquals(expectedResourceName, oai);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
@@ -3,6 +3,7 @@ package io.smallrye.openapi.runtime.scanner;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.zip.GZIPInputStream;
@@ -397,7 +398,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
             schema.setTitle("UUID");
             schema.setDescription("Universally Unique Identifier");
             schema.setExample("de8681db-b4d6-4c47-a428-4b959c1c8e9a");
-            schemaRegistry.register(uuidType, schema);
+            schemaRegistry.register(uuidType, Collections.emptySet(), schema);
         }
 
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JsonViewTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JsonViewTests.java
@@ -1,0 +1,97 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiDocument;
+import io.smallrye.openapi.api.constants.OpenApiConstants;
+
+class JsonViewTests extends IndexScannerTestBase {
+
+    @Test
+    void testJsonViewSchemasPresent() throws Exception {
+        class Views {
+            class Public {
+            }
+
+            class Internal extends Public {
+            }
+
+            class WriteOnly extends Public {
+            }
+        }
+
+        @Schema(name = "Inner2")
+        class InnerBean2 {
+            @Schema
+            String value;
+        }
+
+        @Schema(name = "Inner1")
+        class InnerBean1 {
+            @Schema
+            String value;
+            @Schema(ref = "Inner2")
+            InnerBean2 inner2;
+        }
+
+        @Schema(name = "BeanName")
+        class Bean {
+            @com.fasterxml.jackson.annotation.JsonView(Views.Internal.class)
+            String id;
+            @com.fasterxml.jackson.annotation.JsonView(Views.Public.class)
+            String name;
+            @com.fasterxml.jackson.annotation.JsonView(Views.WriteOnly.class)
+            String secret;
+            @Schema
+            InnerBean1 inner1;
+        }
+
+        @jakarta.ws.rs.Path("/item/{id}")
+        class TestResource {
+            @jakarta.ws.rs.GET
+            @jakarta.ws.rs.Path("internal")
+            @jakarta.ws.rs.Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+            @com.fasterxml.jackson.annotation.JsonView(Views.Internal.class)
+            public Bean getInternal() {
+                return null;
+            }
+
+            @jakarta.ws.rs.GET
+            @jakarta.ws.rs.Path("public")
+            @jakarta.ws.rs.Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+            @com.fasterxml.jackson.annotation.JsonView(Views.Public.class)
+            public java.util.concurrent.CompletionStage<Bean> getPublic() {
+                return null;
+            }
+
+            @jakarta.ws.rs.POST
+            @jakarta.ws.rs.Path("public")
+            @jakarta.ws.rs.Consumes(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+            @jakarta.ws.rs.Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+            @com.fasterxml.jackson.annotation.JsonView(Views.Public.class)
+            public java.util.concurrent.CompletionStage<Bean> updatePublic(
+                    @com.fasterxml.jackson.annotation.JsonView(Views.WriteOnly.class) Bean modified) {
+                return null;
+            }
+        }
+
+        Index index = Index.of(Views.Public.class, Views.WriteOnly.class, Views.Internal.class, Bean.class, InnerBean1.class,
+                InnerBean2.class, TestResource.class);
+        OpenApiConfig config = dynamicConfig(OpenApiConstants.SMALLRYE_REMOVE_UNUSED_SCHEMAS, Boolean.TRUE);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, index);
+
+        OpenApiDocument document = OpenApiDocument.newInstance();
+        document.reset();
+        document.config(config);
+        document.modelFromAnnotations(scanner.scan());
+        document.initialize();
+
+        OpenAPI result = document.get();
+        printToConsole(result);
+        assertJsonEquals("special.jsonview-schemas-basic.json", result);
+    }
+}

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
@@ -3,6 +3,7 @@ package io.smallrye.openapi.runtime.scanner;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema;
@@ -66,7 +67,7 @@ class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
         SchemaRegistry registry = SchemaRegistry.newInstance(context);
 
         Schema result = scanner.process();
-        registry.register(type, result);
+        registry.register(type, Collections.emptySet(), result);
 
         printToConsole(oai);
         assertJsonEquals("refsEnabled.kitchenSink.expected.json", oai);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
@@ -1,6 +1,7 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -29,7 +30,7 @@ class NestedSchemaReferenceTests extends JaxRsDataObjectScannerTestBase {
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, parentType);
 
         Schema result = scanner.process();
-        registry.register(parentType, result);
+        registry.register(parentType, Collections.emptySet(), result);
 
         printToConsole(oai);
         assertJsonEquals("refsEnabled.nested.schema.family.expected.json", oai);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
@@ -3,6 +3,7 @@ package io.smallrye.openapi.runtime.scanner;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jboss.jandex.ClassInfo;
@@ -42,9 +43,9 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         FieldInfo n2 = cInfo.field("n2");
         FieldInfo n3 = cInfo.field("n3");
 
-        Schema s1 = registry.register(n1.type(), new SchemaImpl());
-        Schema s2 = registry.register(n2.type(), new SchemaImpl());
-        Schema s3 = registry.register(n3.type(), new SchemaImpl());
+        Schema s1 = registry.register(n1.type(), Collections.emptySet(), new SchemaImpl());
+        Schema s2 = registry.register(n2.type(), Collections.emptySet(), new SchemaImpl());
+        Schema s3 = registry.register(n3.type(), Collections.emptySet(), new SchemaImpl());
 
         assertEquals("#/components/schemas/NestableStringNestableStringString", s1.getRef());
         assertEquals("#/components/schemas/NestableStringNestableStringObject", s2.getRef());
@@ -66,7 +67,7 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         ClassInfo cInfo = index.getClassByName(cName);
 
         FieldInfo n4 = cInfo.field("n4");
-        Schema s4 = registry.register(n4.type(), new SchemaImpl());
+        Schema s4 = registry.register(n4.type(), Collections.emptySet(), new SchemaImpl());
         assertEquals("#/components/schemas/NestableStringSuperInteger", s4.getRef());
     }
 
@@ -85,7 +86,7 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         ClassInfo cInfo = index.getClassByName(cName);
 
         FieldInfo n5 = cInfo.field("n5");
-        Schema s5 = registry.register(n5.type(), new SchemaImpl());
+        Schema s5 = registry.register(n5.type(), Collections.emptySet(), new SchemaImpl());
         assertEquals("#/components/schemas/NestableExtendsCharSequenceExtendsNumber", s5.getRef());
     }
 
@@ -105,7 +106,7 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         ClassInfo cInfo = index.getClassByName(cName);
 
         FieldInfo n6 = cInfo.field("n6");
-        Schema s6 = registry.register(n6.type(), new SchemaImpl());
+        Schema s6 = registry.register(n6.type(), Collections.emptySet(), new SchemaImpl());
         assertEquals("#/components/schemas/n6", s6.getRef());
     }
 
@@ -128,7 +129,7 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, n6Type);
 
         Schema result = scanner.process();
-        registry.register(n6Type, result);
+        registry.register(n6Type, Collections.emptySet(), result);
         printToConsole(context.getOpenApi());
 
         String field3SchemaName = ModelUtil.nameFromRef(result.getProperties().get("field3").getRef());

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-schemas-basic.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-schemas-basic.json
@@ -1,0 +1,148 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/item/{id}/internal": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeanName_Internal_Public"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/item/{id}/public": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeanName_Public"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeanName_WriteOnly_Public"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeanName_Public"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BeanName_Internal_Public": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "inner1": {
+            "$ref": "#/components/schemas/Inner1_Internal_Public"
+          }
+        }
+      },
+      "BeanName_Public": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "inner1": {
+            "$ref": "#/components/schemas/Inner1_Public"
+          }
+        }
+      },
+      "BeanName_WriteOnly_Public": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "secret": {
+            "type": "string"
+          },
+          "inner1": {
+            "$ref": "#/components/schemas/Inner1_WriteOnly_Public"
+          }
+        }
+      },
+      "Inner1_Internal_Public": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "inner2": {
+            "$ref": "#/components/schemas/Inner2"
+          }
+        }
+      },
+      "Inner1_Public": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "inner2": {
+            "$ref": "#/components/schemas/Inner2"
+          }
+        }
+      },
+      "Inner1_WriteOnly_Public": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "inner2": {
+            "$ref": "#/components/schemas/Inner2"
+          }
+        }
+      },
+      "Inner2": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #1008

When endpoints responses and request bodies are found with `@JsonView`, the schema tree generated from the scan will include the name(s) of the views that were applied to the request/response. For cases where a nested bean should not be different between the views, the user may annotate a field with `@Schema(ref = "<NameOfCommonSchema>")`.

Users will likely want to set `mp.openapi.extensions.smallrye.remove-unused-schemas.enable` to `true`.