### PR TITLE
Release 3.0.0-RC3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye OpenAPI
 release:
-  current-version: 2.2.0
-  next-version: 2.2.1-SNAPSHOT
+  current-version: 3.0.0-RC3
+  next-version: 3.0.0-SNAPSHOT


### PR DESCRIPTION
Release 3.0.0-RC3, based on tag `2.2.0` + `to-jakarta.sh`

Signed-off-by: Michael Edgar <michael@xlate.io>