### PR TITLE
Release 3.1.0-RC2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye OpenAPI
 release:
-  current-version: 3.1.0-RC1
+  current-version: 3.1.0-RC2
   next-version: 3.1.0-SNAPSHOT


### PR DESCRIPTION
Based on [MicroProfile OpenAPI 3.1-RC2](https://github.com/eclipse/microprofile-open-api/releases/tag/3.1-RC2)