### PR TITLE
Ignore class members having illegal Java identifiers in name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,15 +19,16 @@ mvn clean install
 
 === Project structure
 
-* link:core[] - The core OpenAPI code, independent of entry point dependencies.
-* link:extension-jaxrs[] - The JAX-RS entry point. This module depends on JAX-RS and core.
-* link:extension-spring[] - The Spring entry point. This module depends on Spring and core.
-* link:extension-vertx[] - The Vert.x entry point. This module depends on Vert.x and core.
-* link:implementation[] - Implementation of the Eclipse MicroProfile OpenAPI specification. This just pulls in Core and the JAX-RS extension .
-* link:testsuite[] - Test suites.
-* link:testsuite/tck[] - Test suite to run the implementation against the Eclipse MicroProfile OpenAPI TCK.
-* link:testsuite/extra[] - Extra integration tests not related to the TCK.
-* link:tools/maven-plugin[] - Maven plugin that creates the OpenAPI Schema on build.
+* link:core[core] - The core OpenAPI code, independent of entry point dependencies.
+* link:extension-jaxrs[extension-jaxrs] - The JAX-RS entry point. This module depends on JAX-RS and core.
+* link:extension-spring[extension-spring] - The Spring entry point. This module depends on Spring and core.
+* link:extension-vertx[extension-vertx] - The Vert.x entry point. This module depends on Vert.x and core.
+* link:implementation[implementation] - Implementation of the Eclipse MicroProfile OpenAPI specification. This just pulls in Core and the JAX-RS extension .
+* link:testsuite[testsuite] - Test Suites and Data
+** link:testsuite/tck[tck] - Test suite to run the implementation against the Eclipse MicroProfile OpenAPI TCK.
+** link:testsuite/extra[extra] - Extra integration tests not related to the TCK.
+** link:testsuite/data[data] - Classes for use by unit tests
+* link:tools/maven-plugin[maven-plugin] - Maven plugin that creates the OpenAPI Schema on build.
 
 === Links
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>jsonassert</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-open-api-testsuite-data</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -501,12 +501,14 @@ public class TypeResolver {
                     .stream()
                     .filter(TypeResolver::acceptField)
                     .filter(field -> isViewable(context, field))
+                    .filter(field -> field.name().chars().allMatch(Character::isJavaIdentifierPart))
                     .forEach(field -> scanField(context, properties, field, stack, reference, descendants));
 
             methods(context, currentClass)
                     .stream()
                     .filter(TypeResolver::acceptMethod)
                     .filter(method -> isViewable(context, method))
+                    .filter(method -> method.name().chars().allMatch(Character::isJavaIdentifierPart))
                     .forEach(method -> scanMethod(context, properties, method, stack, reference, descendants));
 
             JandexUtil.interfaces(index, currentClass)
@@ -516,6 +518,7 @@ public class TypeResolver {
                     .filter(Objects::nonNull)
                     .flatMap(clazz -> methods(context, clazz).stream())
                     .filter(method -> isViewable(context, method))
+                    .filter(method -> method.name().chars().allMatch(Character::isJavaIdentifierPart))
                     .forEach(method -> scanMethod(context, properties, method, stack, reference, descendants));
 
             descendants.add(currentClass);

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -625,4 +625,16 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
         printToConsole(result);
         assertJsonEquals("components.schemas.field-overrides-type.json", result);
     }
+
+    @Test
+    void testKotlinPropertyName() throws IOException, JSONException {
+        Index index = indexOf(io.smallrye.openapi.testdata.kotlin.KotlinBean.class,
+                io.smallrye.openapi.testdata.kotlin.KotlinLongValue.class);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.kotlin-value-class-propname.json", result);
+    }
 }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.kotlin-value-class-propname.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.kotlin-value-class-propname.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "KotlinBean": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,11 @@
                 <artifactId>smallrye-open-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>smallrye-open-api-testsuite-data</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/testsuite/data/pom.xml
+++ b/testsuite/data/pom.xml
@@ -1,0 +1,112 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-open-api-testsuite</artifactId>
+        <version>3.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-open-api-testsuite-data</artifactId>
+    <name>SmallRye: OpenAPI Test Data</name>
+
+    <properties>
+        <kotlin.version>1.7.10</kotlin.version>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/src/main/kotlin</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+                See https://kotlinlang.org/docs/maven.html#compile-kotlin-and-java-sources
+             -->
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testsuite/data/src/main/java/io/smallrye/openapi/testdata/java/package-info.java
+++ b/testsuite/data/src/main/java/io/smallrye/openapi/testdata/java/package-info.java
@@ -1,0 +1,1 @@
+package io.smallrye.openapi.testdata.java;

--- a/testsuite/data/src/main/kotlin/io/smallrye/openapi/testdata/kotlin/KotlinBean.kt
+++ b/testsuite/data/src/main/kotlin/io/smallrye/openapi/testdata/kotlin/KotlinBean.kt
@@ -1,0 +1,11 @@
+package io.smallrye.openapi.testdata.kotlin
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
+import org.eclipse.microprofile.openapi.annotations.media.Schema
+
+@Schema
+data class KotlinBean (
+    @field:Schema(type = SchemaType.INTEGER, implementation = Long::class, name = "id")
+    val id: KotlinLongValue? = null,
+    val name: String? = null
+)

--- a/testsuite/data/src/main/kotlin/io/smallrye/openapi/testdata/kotlin/KotlinLongValue.kt
+++ b/testsuite/data/src/main/kotlin/io/smallrye/openapi/testdata/kotlin/KotlinLongValue.kt
@@ -1,0 +1,4 @@
+package io.smallrye.openapi.testdata.kotlin
+
+@JvmInline
+value class KotlinLongValue(val value: Long)

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -26,11 +26,12 @@
   <artifactId>smallrye-open-api-testsuite</artifactId>
   <packaging>pom</packaging>
 
-  <name>SmallRye: MicroProfile OpenAPI Test Suite</name>
+  <name>SmallRye: OpenAPI Test Suites and Data</name>
 
   <modules>
     <module>tck</module>
     <module>extra</module>
+    <module>data</module>
   </modules>
 
   <build>


### PR DESCRIPTION
- Do not include properties where the name is not a valid Java identifier (covers the case of generated methods for Kotlin value class fields)
- Add test data module, initally holding test Kotlin classes

Fixes #1195