### PR TITLE
Enable Sonar for PRs via triggered job, skip JavaDoc for Kotlin code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,11 @@ name: SmallRye Build
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches:
+      - 'main'
+      - '[1-9].[0-9].x'
+      - '1.x'
+      - '!dependabot/**'
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'
@@ -11,6 +14,10 @@ on:
       - 'NOTICE'
       - 'README*'
   pull_request:
+    branches:
+      - 'main'
+      - '[1-9].[0-9].x'
+      - '1.x'
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'
@@ -23,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17]
+        java: [ 11, 17 ]
     name: build with jdk ${{matrix.java}}
 
     steps:
@@ -43,7 +50,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: build with maven
-        run: mvn -B formatter:validate impsort:check verify --file pom.xml
+        run: mvn -B formatter:validate impsort:check javadoc:javadoc verify
 
       - uses: actions/upload-artifact@v2
         name: tck-report
@@ -51,37 +58,12 @@ jobs:
           name: tck-report
           path: testsuite/tck/target/surefire-reports
 
-  quality:
-    needs: [build]
-    if: github.event_name == 'push' && github.repository == 'smallrye/smallrye-open-api'
-    runs-on: ubuntu-latest
-    name: quality
-
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow --tags --force
-
-      - uses: actions/setup-java@v1.4.3
+      ## Attach target directories for safe Sonar scan in separate job
+      - name: Attach Build Output
+        if: matrix.java == '11'
+        uses: actions/upload-artifact@v2
         with:
-          java-version: 11
-
-      - name: cache sonar
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: maven cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: sonar
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-        run: mvn -B verify --file pom.xml -Pcoverage javadoc:javadoc sonar:sonar -Dsonar.projectKey=smallrye_smallrye-open-api -Dsonar.login=$SONAR_TOKEN
+          name: target
+          path: |
+            **/target/
+            !**/target/**/*.jar

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,131 @@
+name: "SonarCloud"
+
+on:
+  workflow_run:
+    workflows: [ "SmallRye Build" ]
+    types: [ completed ]
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    name: Display Context
+    steps:
+      - name: Display Github Event Context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+  analyze:
+    if: ${{ github.repository == 'smallrye/smallrye-open-api' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    name: Analyze
+    steps:
+      - name: Display Github Event Context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      ## Checkout the source of the event that triggered this workflow,
+      ## PR commit (pull_request event) or commit (push event).
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      ## Retrieve the `target` directory from the build job
+      - name: Fetch Build Result
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "target"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/target.zip', Buffer.from(download.data));
+
+      ## Extract the `target` directories from the build job
+      - name: Extract Build Result
+        run: |
+          unzip target.zip
+
+      ## Load the context from the build job - runs for any trigger to allow templates with `steps.build_context.outputs.content`
+      ## to be accepted by GitHub Actions.
+      - name: Read Build Context
+        id: build_context
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./target/build-context.json
+
+      ## (PRs Only) Check out the base branch (target of the PR)
+      - name: Checkout Base Branch (PR Only)
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          BASE_BRANCH: ${{ fromJson(steps.build_context.outputs.content).base_ref }}
+        run: |
+          git remote add upstream ${{ github.event.repository.clone_url }}
+          git fetch upstream --prune --tags --force
+          git checkout -B $BASE_BRANCH upstream/$BASE_BRANCH
+          git checkout ${{ github.event.workflow_run.head_sha }}
+          git clean -ffdx --exclude=target/ && git reset --hard HEAD
+
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      ## (PRs Only) Run Sonar analysis against the results of the build job, providing PR information
+      - name: SonarCloud Analysis (PR Only)
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn -B --no-transfer-progress org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=smallrye_smallrye-open-api  \
+            -Dsonar.login=${SONAR_TOKEN} \
+            -Dsonar.coverage.jacoco.xmlReportPaths=$(pwd)/testsuite/extra/target/site/jacoco-aggregate/jacoco.xml \
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
+            -Dsonar.pullrequest.key=${{ fromJson(steps.build_context.outputs.content).event.number }} \
+            -Dsonar.pullrequest.branch=${{ fromJson(steps.build_context.outputs.content).head_ref }} \
+            -Dsonar.pullrequest.base=${{ fromJson(steps.build_context.outputs.content).base_ref }}
+
+      ## (Push Only) Run Sonar analysis against the results of the build job
+      - name: SonarCloud Analysis (Push Only)
+        if: github.event.workflow_run.event == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn -B --no-transfer-progress org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=smallrye_smallrye-open-api \
+            -Dsonar.login=${SONAR_TOKEN} \
+            -Dsonar.coverage.jacoco.xmlReportPaths=$(pwd)/testsuite/extra/target/site/jacoco-aggregate/jacoco.xml \
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
+            -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}

--- a/testsuite/data/pom.xml
+++ b/testsuite/data/pom.xml
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
                 <executions>
                     <!-- Replacing default-compile as it is treated specially by maven -->
                     <execution>
@@ -105,6 +104,13 @@
                 <artifactId>maven-install-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This allows the Sonar scan with PRs from forks by scanning the Jacoco build results in a separate job, trigger by the primary build job. The `sonar.yml` job will not run until it is merged.