### PR TITLE
Save build context for Sonar, ignore `node` directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: build with maven
-        run: mvn -B formatter:validate impsort:check javadoc:javadoc verify
+        run: mvn -B formatter:validate impsort:check javadoc:javadoc verify -Pcoverage
 
       - uses: actions/upload-artifact@v2
         name: tck-report
@@ -74,3 +74,4 @@ jobs:
             **/target/
             !**/target/node/**/*
             !**/target/**/*.jar
+            !**/target/**/*.war

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,12 @@ jobs:
           name: tck-report
           path: testsuite/tck/target/surefire-reports
 
+      ## Store information about the build context for Sonar scan in separate job
+      - name: Save Build Context
+        run: echo "$GITHUB_CONTEXT" > target/build-context.json
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
       ## Attach target directories for safe Sonar scan in separate job
       - name: Attach Build Output
         if: matrix.java == '11'
@@ -66,4 +72,5 @@ jobs:
           name: target
           path: |
             **/target/
+            !**/target/node/**/*
             !**/target/**/*.jar


### PR DESCRIPTION
Follows up on #1221 