### PR TITLE
TCK runner: Update the archive using BeforeDeploy

### DIFF
--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/ArquillianExtension.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/ArquillianExtension.java
@@ -1,12 +1,11 @@
 package io.smallrye.openapi.tck;
 
-import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 
 public class ArquillianExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder extensionBuilder) {
-        extensionBuilder.service(ApplicationArchiveProcessor.class, DeploymentProcessor.class)
+        extensionBuilder.observer(DeploymentProcessor.class)
                 .observer(AfterDeployObserver.class);
     }
 }


### PR DESCRIPTION
Previously an ApplicationArchiveProcessor was used to run the
implementation and generate the OpenAPI document in the archive before
deploying it. However, an ApplicationArchiveProcessor is only called
for _testable_ archives (archives where tests run on the server),
whereas to pass the TCK we need to process all the archives.

Instead, use the BeforeDeploy event to update the archive which is
called for every deployment.