### PR TITLE
Upgrade to Jandex 3.0.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/FilteredIndexView.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/FilteredIndexView.java
@@ -1,6 +1,7 @@
 package io.smallrye.openapi.runtime.scanner;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -258,6 +259,22 @@ public class FilteredIndexView implements IndexView {
     }
 
     /**
+     * @see org.jboss.jandex.IndexView#getKnownDirectSubinterfaces(org.jboss.jandex.DotName)
+     */
+    @Override
+    public Collection<ClassInfo> getKnownDirectSubinterfaces(DotName interfaceName) {
+        return filterClasses(this.delegate.getKnownDirectSubinterfaces(interfaceName));
+    }
+
+    /**
+     * @see org.jboss.jandex.IndexView#getAllKnownSubinterfaces(org.jboss.jandex.DotName)
+     */
+    @Override
+    public Collection<ClassInfo> getAllKnownSubinterfaces(DotName interfaceName) {
+        return filterClasses(this.delegate.getAllKnownSubinterfaces(interfaceName));
+    }
+
+    /**
      * @see org.jboss.jandex.IndexView#getKnownDirectImplementors(org.jboss.jandex.DotName)
      */
     @Override
@@ -302,6 +319,16 @@ public class FilteredIndexView implements IndexView {
     @Override
     public Collection<ClassInfo> getKnownUsers(DotName className) {
         return filterClasses(this.delegate.getKnownUsers(className));
+    }
+
+    @Override
+    public Collection<ClassInfo> getClassesInPackage(DotName packageName) {
+        return filterClasses(this.delegate.getClassesInPackage(packageName));
+    }
+
+    @Override
+    public Set<DotName> getSubpackages(DotName packageName) {
+        return delegate.getSubpackages(packageName);
     }
 
     private Collection<AnnotationInstance> filterInstances(Collection<AnnotationInstance> annotations) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
@@ -1,6 +1,7 @@
 package io.smallrye.openapi.runtime.scanner.dataobject;
 
 import java.util.Collection;
+import java.util.Set;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
@@ -72,6 +73,18 @@ public class AugmentedIndexView implements IndexView {
     }
 
     @Override
+    public Collection<ClassInfo> getKnownDirectSubinterfaces(DotName interfaceName) {
+        validateInput(interfaceName);
+        return index.getKnownDirectSubinterfaces(interfaceName);
+    }
+
+    @Override
+    public Collection<ClassInfo> getAllKnownSubinterfaces(DotName interfaceName) {
+        validateInput(interfaceName);
+        return index.getAllKnownSubinterfaces(interfaceName);
+    }
+
+    @Override
     public Collection<ClassInfo> getKnownDirectImplementors(DotName className) {
         validateInput(className);
         return index.getKnownDirectImplementors(className);
@@ -110,6 +123,18 @@ public class AugmentedIndexView implements IndexView {
     public Collection<ClassInfo> getKnownUsers(DotName className) {
         validateInput(className);
         return index.getKnownUsers(className);
+    }
+
+    @Override
+    public Collection<ClassInfo> getClassesInPackage(DotName packageName) {
+        validateInput(packageName);
+        return index.getClassesInPackage(packageName);
+    }
+
+    @Override
+    public Set<DotName> getSubpackages(DotName packageName) {
+        validateInput(packageName);
+        return index.getSubpackages(packageName);
     }
 
     private void validateInput(Object... inputs) {

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
         <version.buildhelper.plugin>3.3.0</version.buildhelper.plugin>
         <jackson-bom.version>2.13.3</jackson-bom.version>
         <version.eclipse.microprofile.config>2.0.1</version.eclipse.microprofile.config>
+        <version.io.smallrye.jandex>3.0.0</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-config>2.10.1</version.io.smallrye.smallrye-config>
         <version.eclipse.microprofile.openapi>2.0.1</version.eclipse.microprofile.openapi>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.jboss.jandex>2.4.3.Final</version.org.jboss.jandex> <!-- won't be needed with SmallRye Parent v36 -->
         <version.org.skyscreamer>1.5.1</version.org.skyscreamer>
         <version.maven-resources-plugin>3.3.0</version.maven-resources-plugin>
         <version.com.github.eirslett.frontend-maven-plugin>1.12.1</version.com.github.eirslett.frontend-maven-plugin>
@@ -129,6 +129,11 @@
             </dependency>
 
             <!-- SmallRye Projects -->
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex</artifactId>
+                <version>${version.io.smallrye.jandex}</version>
+            </dependency>
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>

--- a/tools/maven-plugin/pom.xml
+++ b/tools/maven-plugin/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
 


### PR DESCRIPTION
I noticed someone created the 2.3.x branch, but it was branched off of the 2.2.0 tag, which I believe is not right. So this PR, targeting the 2.3.x branch:

1. fast-forwards the 2.3.x branch one commit after the 2.2.0 tag in the 2.2.x branch (`[maven-release-plugin] prepare for next development iteration`);
2. fixes the `<tag>` element in the POM, as that should read `HEAD` outside of release commits;
3. changes the `<version>` elements to say `2.3.0-SNAPSHOT`;
4. upgrades to Jandex 3.0.0.

With this PR merged to current 2.3.x (which points to a6d1ad538e), I believe the 2.3.x branch would be in the correct state. Next, we would close #1227 (as we want to keep 2.2.x on Jandex 2.x). We could also close #1228, if 3.0.x is really automatically created from 2.2.x -- I believe we would actually also move 3.0.x to be based on 2.3.x.

Makes sense, or do I completely misunderstand how SmallRye OpenAPI is managed? Thank you!