### PR TITLE
Revert support for scanning resource methods without JAX-RS HTTP methods (2.2.x)

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/JandexUtil.java
@@ -783,13 +783,6 @@ public class JandexUtil {
         return ancestry;
     }
 
-    public static List<MethodInfo> overriddenMethods(MethodInfo method, List<MethodInfo> candidates) {
-        return candidates.stream()
-                .filter(m -> !method.equals(m))
-                .filter(m -> isSameSignature(method, m))
-                .collect(Collectors.toList());
-    }
-
     public static boolean isSameSignature(MethodInfo m1, MethodInfo m2) {
         return Objects.equals(m1.name(), m2.name())
                 && m1.parametersCount() == m2.parametersCount()

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -1,7 +1,5 @@
 package io.smallrye.openapi.jaxrs;
 
-import static io.smallrye.openapi.runtime.util.JandexUtil.overriddenMethods;
-
 import java.lang.reflect.Modifier;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -276,12 +274,7 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
 
             JaxRsConstants.HTTP_METHODS
                     .stream()
-                    .filter(httpMethod -> {
-                        if (methodInfo.hasAnnotation(httpMethod)) {
-                            return true;
-                        }
-                        return overriddenMethods(methodInfo, methods).stream().anyMatch(m -> m.hasAnnotation(httpMethod));
-                    })
+                    .filter(methodInfo::hasAnnotation)
                     .map(DotName::withoutPackagePrefix)
                     .map(PathItem.HttpMethod::valueOf)
                     .forEach(httpMethod -> {

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.inheritance.param-default-values.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.inheritance.param-default-values.json
@@ -35,7 +35,7 @@
             "name": "upsilon",
             "in": "query",
             "schema": {
-              "default": false,
+              "default": true,
               "type": "boolean"
             }
           }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.nonjaxrs-methods-skipped.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.nonjaxrs-methods-skipped.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/trees": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferencesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/trees/tree": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reference"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Reference": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ReferencesResponse": {
+        "type": "object",
+        "properties": {
+          "references": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1234 for 2.2.x
