### PR TITLE
Release 2.3.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye OpenAPI
 release:
-  current-version: 2.2.1
-  next-version: 2.2.2-SNAPSHOT
+  current-version: 2.3.0
+  next-version: 2.3.1-SNAPSHOT


### PR DESCRIPTION
Same as 2.2.1, with Jandex 3

Signed-off-by: Michael Edgar <michael@xlate.io>