### PR TITLE
Prevent duplicate entries in operation and path item arrays

### DIFF
--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/Sub1TestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/Sub1TestResource.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
@@ -34,7 +35,7 @@ public class Sub1TestResource<T> {
     }
 
     @Path(value = "/sub2/{sub2-id}")
-    public Sub2TestResource<T> getSub2() {
+    public Sub2TestResource<T> getSub2(@PathParam("sub2-id") String sub2Id) {
         return new Sub2TestResource<T>();
     }
 

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/javax/Sub1TestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/javax/Sub1TestResource.java
@@ -7,6 +7,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
@@ -34,7 +35,7 @@ public class Sub1TestResource<T> {
     }
 
     @Path(value = "/sub2/{sub2-id}")
-    public Sub2TestResource<T> getSub2() {
+    public Sub2TestResource<T> getSub2(@PathParam("sub2-id") String sub2Id) {
         return new Sub2TestResource<T>();
     }
 


### PR DESCRIPTION
Fixes #1256 

When a parameter is present in both the operator parameters array and the path item parameters array, prefer the operation parameter and exclude the path item parameter.

Signed-off-by: Michael Edgar <michael@xlate.io>