### PR TITLE
Fix special-case handling of oauth2Redirect token

### DIFF
--- a/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/IndexHtmlCreator.java
+++ b/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/IndexHtmlCreator.java
@@ -68,38 +68,38 @@ public class IndexHtmlCreator {
                     String replacement = options.get(variableOption);
                     if (replacement == null) {
                         // Special case for oauth2RedirectUrl
-                        if (variableOption.equals("oauth2RedirectUrl")) {
-                            return "-";
+                        if (!variableOption.equals(Option.oauth2RedirectUrl)) {
+                            // You want to remove this line
+                            return null;
                         }
-                        // You want to remove this line
-                        return null;
-                    } else {
-                        // Some properties can be boolean or String, if String we need to add '
-                        replacement = replacement.trim();
-                        if (BOOLEAN_OR_STRING_KEYS.contains(variableOption)) {
-                            if (!replacement.equals("true") && !replacement.equals("false")) {
-                                replacement = "'" + replacement + "'";
-                            }
-                        }
-                        // Some properties can be a String or a function, if String we need to add '
-                        replacement = replacement.trim();
-                        if (STRING_OR_FUNCTION_KEYS.contains(variableOption)) {
-                            if (!replacement.startsWith("function")) {
-                                replacement = "'" + replacement + "'";
-                            }
-                        }
-                        // Some properties are string arrays, and we need to add the ' per element
-                        if (STRING_ARRAY_KEYS.contains(variableOption)) {
-                            List<String> newArray = new ArrayList<>();
-                            String[] parts = replacement.replace("[", "").replace("]", "").split(",");
-                            for (String part : parts) {
-                                newArray.add("'" + part.trim() + "'");
-                            }
-                            replacement = Arrays.toString(newArray.toArray(new String[] {}));
-                        }
-
-                        line = line.replace(VAR_BEGIN + variableOption + VAR_END, replacement);
+                        // Use a harmless default value for oauth2RedirectUrl.
+                        replacement = "-";
                     }
+                    // Some properties can be boolean or String, if String we need to add '
+                    replacement = replacement.trim();
+                    if (BOOLEAN_OR_STRING_KEYS.contains(variableOption)) {
+                        if (!replacement.equals("true") && !replacement.equals("false")) {
+                            replacement = "'" + replacement + "'";
+                        }
+                    }
+                    // Some properties can be a String or a function, if String we need to add '
+                    replacement = replacement.trim();
+                    if (STRING_OR_FUNCTION_KEYS.contains(variableOption)) {
+                        if (!replacement.startsWith("function")) {
+                            replacement = "'" + replacement + "'";
+                        }
+                    }
+                    // Some properties are string arrays, and we need to add the ' per element
+                    if (STRING_ARRAY_KEYS.contains(variableOption)) {
+                        List<String> newArray = new ArrayList<>();
+                        String[] parts = replacement.replace("[", "").replace("]", "").split(",");
+                        for (String part : parts) {
+                            newArray.add("'" + part.trim() + "'");
+                        }
+                        replacement = Arrays.toString(newArray.toArray(new String[] {}));
+                    }
+
+                    line = line.replace(VAR_BEGIN + variableOption + VAR_END, replacement);
                 }
                 // Check if there is more varibles
                 return replace(line, urls, urlsPrimaryName, options);

--- a/ui/open-api-ui/src/test/java/io/smallrye/openapi/ui/IndexCreatorTest.java
+++ b/ui/open-api-ui/src/test/java/io/smallrye/openapi/ui/IndexCreatorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/ui/open-api-ui/src/test/java/io/smallrye/openapi/ui/IndexCreatorTest.java
+++ b/ui/open-api-ui/src/test/java/io/smallrye/openapi/ui/IndexCreatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -198,5 +199,17 @@ class IndexCreatorTest {
         assertTrue(s.contains("ui.preauthorizeApiKey('api_key', 'abcde12345');"));
         assertTrue(s.contains("<title>SmallRye OpenAPI UI</title>"));
         assertTrue(s.contains("ui.preauthorizeBasic('basicAuth', 'username', 'password');"));
+    }
+
+    @Test
+    void testOauth2RedirectReplacement() throws IOException {
+        String title = "Test Title";
+        Map<Option, String> options = new HashMap<>();
+        options.put(Option.title, title);
+        byte[] indexHtml = IndexHtmlCreator.createIndexHtml(options);
+
+        String html = new String(indexHtml);
+
+        assertTrue(html.contains("var oar"), "Missing declaration of 'oar'");
     }
 }


### PR DESCRIPTION
Resolves #1304 

This PR changes the special handling of the `oauth2Redirect` token replacement to:

1. Fix the comparison.
2. Instead of returning right away with the token's default value, continue processing to use the replacement value to substitute for the token in the line being processed.

Also adds a test.