### PR TITLE
Exclude build of modules not necessary for running TCK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: build with maven
-        run: mvn -B -pl 'core,extension-jaxrs,testsuite/data,testsuite/tck' install -DskipTests
+        run: mvn -B -pl '!testsuite/extra,!tools,!tools/gradle-plugin,!tools/maven-plugin,!ui,!ui/open-api-ui,!ui/open-api-ui-forms' install -DskipTests
 
       - name: execute specific tck
         if: ${{ matrix.default-properties == false }}


### PR DESCRIPTION
Needed for initial build following a release. Allows local installation of parent modules into local Maven repo.