### PR TITLE
Load the pom.properties of org.eclipse.microprofile.openapi:microprofile-openapi-api using the classloader of a class from this artifact.

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/util/VersionUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/api/util/VersionUtil.java
@@ -13,7 +13,7 @@ public final class VersionUtil {
     }
 
     static final String MP_VERSION = ModelUtil.supply(() -> {
-        try (InputStream pomProperties = VersionUtil.class.getResourceAsStream(
+        try (InputStream pomProperties = org.eclipse.microprofile.openapi.models.OpenAPI.class.getResourceAsStream(
                 "/META-INF/maven/org.eclipse.microprofile.openapi/microprofile-openapi-api/pom.properties")) {
             Properties p = new Properties();
             p.load(pomProperties);


### PR DESCRIPTION
Fixes https://github.com/smallrye/smallrye-open-api/issues/1328.

This is otherwise blocking the integration of version 3.1 in WildFly.