### PR TITLE
Gradle plugin: Fix circular task dependency with Quarkus plugin

### DIFF
--- a/tools/gradle-plugin/build.gradle.kts
+++ b/tools/gradle-plugin/build.gradle.kts
@@ -46,4 +46,8 @@ tasks.named<Test>("test") {
     useJUnitPlatform()
 }
 
+tasks.named("pluginUnderTestMetadata") {
+    dependsOn("processJandexIndex")
+}
+
 group = "io.smallrye"

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPlugin.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPlugin.java
@@ -10,7 +10,7 @@ import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.language.jvm.tasks.ProcessResources;
+import org.gradle.jvm.tasks.Jar;
 
 /**
  * Gradle schema generator plugin.
@@ -69,11 +69,9 @@ public class SmallryeOpenApiPlugin implements Plugin<Project> {
                     t.getInputs().files(configProvider).withPathSensitivity(PathSensitivity.RELATIVE);
                 });
 
-        project.getTasks().named(sourceSet.getProcessResourcesTaskName(), ProcessResources.class)
-                .configure(t -> {
-                    t.dependsOn(genTaskName);
-                    t.from(project.getTasks().getByName(genTaskName).getOutputs().getFiles());
-                });
+        project.getTasks().named(sourceSet.getJarTaskName(), Jar.class)
+                // Adds the generated YAML + JSON files
+                .configure(t -> t.from(project.getTasks().getByName(genTaskName)));
 
         project.getConfigurations().create(CONFIG_NAME, c -> {
             c.setCanBeConsumed(true);


### PR DESCRIPTION
The Smallrye Gradle plugin adds the generated OpenAPI schema files (YAML + JSON) to the generated jar file. This was achieved using via the `processResources` task, which unfortunately is not "compatible" with the Quarkus plugin (see below output). The fix is to add the generated schema files directly to the `jar` task.

Tests have been added to verify interopability with the Quarkus plugin, also reproducers for #1335 (without the production code changes of course):
```
Circular dependency between the following tasks:
:compileJava
+--- :quarkusGenerateCode
|    \--- :processResources
|         \--- :generateOpenApiSpec
|              +--- :compileJava (*)
|              +--- :quarkusGenerateCode (*)
|              \--- :quarkusGenerateCodeDev
|                   \--- :processResources (*)
\--- :quarkusGenerateCodeDev (*)
```

Fixes #1335