### PR TITLE
Set YAMLFactory loader options to allow for larger files than the current SnakeYaml constraint (3MB)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,3 +42,5 @@ mvn clean install
 ** A fully-qualified class name of an implementation of a Jackson property naming strategy base class (`com.fasterxml.jackson.databind.PropertyNamingStrategies.NamingBase`). Only the `translate` method is utilized.
 * `mp.openapi.extensions.smallrye.remove-unused-schemas.enable` - Set to `true` enable automatic removal of unused schemas from `components/schemas` in the OpenAPI model. Unused schemas will be removed following annotation scanning but prior to running any `OASFilter` that may be configured. Default value is `false`.
 * `mp.openapi.extensions.smallrye.duplicateOperationIdBehavior` - Set to `FAIL` to abort in case of duplicate operationIds, set to `WARN` to log warnings when the build encounters duplicate operationIds. Default value is `WARN`.
+* `mp.openapi.extensions.smallrye.maximumStaticFileSize` - Set this value in order to change the maximum threshold for
+processed static files, when generating model from them. If not set, it will default to 3 MB.

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -24,6 +24,7 @@ import io.smallrye.openapi.api.constants.OpenApiConstants;
 public interface OpenApiConfig {
 
     DuplicateOperationIdBehavior DUPLICATE_OPERATION_ID_BEHAVIOR_DEFAULT = DuplicateOperationIdBehavior.WARN;
+    Integer MAXIMUM_STATIC_FILE_SIZE_DEFAULT = 3 * 1024 * 1024;
 
     default String modelReader() {
         return null;
@@ -179,6 +180,10 @@ public interface OpenApiConfig {
     }
 
     default void doAllowNakedPathParameter() {
+    }
+
+    default Integer getMaximumStaticFileSize() {
+        return MAXIMUM_STATIC_FILE_SIZE_DEFAULT;
     }
 
     enum OperationIdStrategy {

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfigImpl.java
@@ -61,6 +61,7 @@ public class OpenApiConfigImpl implements OpenApiConfig {
     private Optional<String[]> defaultProduces = UNSET;
     private Optional<String[]> defaultConsumes = UNSET;
     private Optional<Boolean> allowNakedPathParameter = Optional.empty();
+    private Integer maximumStaticFileSize;
 
     public static OpenApiConfig fromConfig(Config config) {
         return new OpenApiConfigImpl(config);
@@ -481,6 +482,16 @@ public class OpenApiConfigImpl implements OpenApiConfig {
                     .orElse(OpenApiConfig.super.removeUnusedSchemas());
         }
         return removeUnusedSchemas;
+    }
+
+    @Override
+    public Integer getMaximumStaticFileSize() {
+        if (maximumStaticFileSize == null) {
+            maximumStaticFileSize = getConfig()
+                    .getOptionalValue(OpenApiConstants.MAXIMUM_STATIC_FILE_SIZE, Integer.class)
+                    .orElse(OpenApiConfig.super.getMaximumStaticFileSize());
+        }
+        return maximumStaticFileSize;
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/OpenApiConstants.java
@@ -61,6 +61,7 @@ public final class OpenApiConstants {
     public static final String DUPLICATE_OPERATION_ID_BEHAVIOR = SMALLRYE_PREFIX + "duplicateOperationIdBehavior";
     public static final String DEFAULT_PRODUCES = SMALLRYE_PREFIX + "defaultProduces";
     public static final String DEFAULT_CONSUMES = SMALLRYE_PREFIX + "defaultConsumes";
+    public static final String MAXIMUM_STATIC_FILE_SIZE = SMALLRYE_PREFIX + "maximumStaticFileSize";
 
     /**
      * Set of classes which should never be scanned, regardless of user configuration.

--- a/core/src/main/java/io/smallrye/openapi/runtime/OpenApiProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/OpenApiProcessor.java
@@ -63,7 +63,7 @@ public class OpenApiProcessor {
         // Load all static files
         if (staticFiles != null && staticFiles.length > 0) {
             for (OpenApiStaticFile staticFile : staticFiles) {
-                OpenApiDocument.INSTANCE.modelFromStaticFile(modelFromStaticFile(staticFile));
+                OpenApiDocument.INSTANCE.modelFromStaticFile(modelFromStaticFile(config, staticFile));
             }
         }
         // Scan annotations
@@ -93,12 +93,12 @@ public class OpenApiProcessor {
      * @param staticFile OpenApiStaticFile to be parsed
      * @return OpenApiImpl
      */
-    public static OpenAPI modelFromStaticFile(OpenApiStaticFile staticFile) {
+    public static OpenAPI modelFromStaticFile(OpenApiConfig config, OpenApiStaticFile staticFile) {
         if (staticFile == null) {
             return null;
         }
         try {
-            return OpenApiParser.parse(staticFile.getContent(), staticFile.getFormat());
+            return OpenApiParser.parse(staticFile.getContent(), staticFile.getFormat(), config.getMaximumStaticFileSize());
         } catch (IOException e) {
             throw new OpenApiRuntimeException(e);
         }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java
@@ -65,22 +65,30 @@ public class OpenApiParser {
      * 
      * @param stream InputStream containing an OpenAPI document
      * @param format Format of the stream
+     * @param maximumStaticFileSize Integer to change (usually to increase) the maximum static file size
      * @return OpenAPIImpl parsed from the stream
      * @throws IOException Errors in reading the stream
      */
-    public static final OpenAPI parse(InputStream stream, Format format) throws IOException {
+    public static final OpenAPI parse(InputStream stream, Format format, final Integer maximumStaticFileSize)
+            throws IOException {
         ObjectMapper mapper;
         if (format == Format.JSON) {
             mapper = new ObjectMapper();
         } else {
             LoaderOptions loaderOptions = new LoaderOptions();
-            loaderOptions.setCodePointLimit(64 * 1024 * 1024);
+            if (maximumStaticFileSize != null) {
+                loaderOptions.setCodePointLimit(maximumStaticFileSize);
+            }
             mapper = new ObjectMapper(new YAMLFactoryBuilder(new YAMLFactory()).loaderOptions(loaderOptions).build());
         }
         JsonNode tree = mapper.readTree(stream);
 
         OpenApiParser parser = new OpenApiParser(tree);
         return parser.parse();
+    }
+
+    public static final OpenAPI parse(InputStream stream, Format format) throws IOException {
+        return parse(stream, format, null);
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java
@@ -7,10 +7,12 @@ import java.net.URL;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.yaml.snakeyaml.LoaderOptions;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 
 import io.smallrye.openapi.api.models.OpenAPIImpl;
 import io.smallrye.openapi.runtime.io.definition.DefinitionReader;
@@ -71,7 +73,9 @@ public class OpenApiParser {
         if (format == Format.JSON) {
             mapper = new ObjectMapper();
         } else {
-            mapper = new ObjectMapper(new YAMLFactory());
+            LoaderOptions loaderOptions = new LoaderOptions();
+            loaderOptions.setCodePointLimit(64 * 1024 * 1024);
+            mapper = new ObjectMapper(new YAMLFactoryBuilder(new YAMLFactory()).loaderOptions(loaderOptions).build());
         }
         JsonNode tree = mapper.readTree(stream);
 

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/StaticFileConfigTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/StaticFileConfigTest.java
@@ -2,11 +2,8 @@ package io.smallrye.openapi.runtime.io;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.openapi.api.OpenApiConfig;
@@ -16,11 +13,16 @@ import io.smallrye.openapi.api.constants.OpenApiConstants;
 class StaticFileConfigTest {
 
     @Test
-    void testSettingMaximumFileSize() throws IOException, JSONException {
+    void testSettingMaximumFileSize() {
         final Integer maximumFileSize = 8 * 1024 * 1024;
         System.setProperty(OpenApiConstants.MAXIMUM_STATIC_FILE_SIZE, maximumFileSize.toString());
-        Config config = ConfigProvider.getConfig();
-        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
-        assertEquals(maximumFileSize, openApiConfig.getMaximumStaticFileSize());
+
+        try {
+            Config config = ConfigProvider.getConfig();
+            OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+            assertEquals(maximumFileSize, openApiConfig.getMaximumStaticFileSize());
+        } finally {
+            System.clearProperty(OpenApiConstants.MAXIMUM_STATIC_FILE_SIZE);
+        }
     }
 }

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/StaticFileConfigTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/StaticFileConfigTest.java
@@ -1,0 +1,26 @@
+package io.smallrye.openapi.runtime.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConfigImpl;
+import io.smallrye.openapi.api.constants.OpenApiConstants;
+
+class StaticFileConfigTest {
+
+    @Test
+    void testSettingMaximumFileSize() throws IOException, JSONException {
+        final Integer maximumFileSize = 8 * 1024 * 1024;
+        System.setProperty(OpenApiConstants.MAXIMUM_STATIC_FILE_SIZE, maximumFileSize.toString());
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = OpenApiConfigImpl.fromConfig(config);
+        assertEquals(maximumFileSize, openApiConfig.getMaximumStaticFileSize());
+    }
+}

--- a/core/src/test/resources/io/smallrye/openapi/runtime/io/openapi-fragment-body.yaml
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/io/openapi-fragment-body.yaml
@@ -1,0 +1,99 @@
+  /proxys@@ID@@/all:
+    get:
+      summary: Get all @@ID@@ type proxies
+      description: Retrieves and returns the available proxies
+      operationId: getAllProxies
+      responses:
+        "200":
+          description: All available proxies
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProxyEntity'
+      x-routing-fqdn: provider.acme.unknown
+      x-string-property: string-value
+      x-boolean-property: true
+      x-number-property: 42
+      x-object-property:
+        property-1: value-1
+        property-2: value-2
+        property-3:
+          prop-3-1: 42
+          prop-3-2: true
+      x-string-array-property:
+      - one
+      - two
+      - three
+      x-object-array-property:
+      - name: item-1
+      - name: item-2
+  /proxy@@ID@@/{code}:
+    get:
+      summary: Get @@ID@@ type proxy by code
+      description: Retrieves and returns the requested @@ID@@ type proxy
+      operationId: getProxyByCode
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: excludeObsolete
+        in: query
+        schema:
+          type: boolean
+      responses:
+        "204":
+          description: Requested @@ID@@ type proxy was not found
+        "200":
+          description: Requested @@ID@@ type proxy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyEntity'
+      x-routing-fqdn: provider.acme.unknown
+    patch:
+      summary: Updates a @@ID@@ type proxy data
+      description: "Retrieves, updates and returns the requested @@ID@@ type proxy data"
+      operationId: updateProxy
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProxyEntity'
+      responses:
+        "404":
+          description: Requested @@ID@@ type proxy was not found
+        "200":
+          description: Updated @@ID@@ type proxy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyEntity'
+              example: "{\"code\": \"@@ID@@\", \"name\": \"@@ID@@ type proxy\", \"obsolete\"\
+                : false}"
+      x-routing-fqdn: provider.acme.unknown
+      x-string-property: string-value
+      x-boolean-property: true
+      x-number-property: 42
+      x-object-property:
+        property-1: value-1
+        property-2: value-2
+        property-3:
+          prop-3-1: 42
+          prop-3-2: true
+      x-string-array-property:
+      - one
+      - two
+      - three
+      x-object-array-property:
+      - name: item-1
+      - name: item-2

--- a/core/src/test/resources/io/smallrye/openapi/runtime/io/openapi-fragment-footer.yaml
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/io/openapi-fragment-footer.yaml
@@ -1,0 +1,11 @@
+components:
+  schemas:
+    ProxyEntity:
+      type: object
+      properties:
+        code:
+          type: string
+        name:
+          type: string
+        obsolete:
+          type: boolean

--- a/core/src/test/resources/io/smallrye/openapi/runtime/io/openapi-fragment-header.yaml
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/io/openapi-fragment-header.yaml
@@ -1,0 +1,6 @@
+---
+openapi: 3.0.0
+info:
+  title: Proxy App
+  version: "1.0"
+paths:

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/DeploymentProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/DeploymentProcessor.java
@@ -116,9 +116,9 @@ public class DeploymentProcessor {
 
         Optional<OpenAPI> annotationModel = ofNullable(modelFromAnnotations(openApiConfig, contextClassLoader, index));
         Optional<OpenAPI> readerModel = ofNullable(modelFromReader(openApiConfig, contextClassLoader));
-        Optional<OpenAPI> staticFileModel = Stream.of(modelFromFile(war, "/META-INF/openapi.json", JSON),
-                modelFromFile(war, "/META-INF/openapi.yaml", YAML),
-                modelFromFile(war, "/META-INF/openapi.yml", YAML))
+        Optional<OpenAPI> staticFileModel = Stream.of(modelFromFile(openApiConfig, war, "/META-INF/openapi.json", JSON),
+                modelFromFile(openApiConfig, war, "/META-INF/openapi.yaml", YAML),
+                modelFromFile(openApiConfig, war, "/META-INF/openapi.yml", YAML))
                 .filter(Optional::isPresent)
                 .findFirst()
                 .flatMap(openAPI -> openAPI);
@@ -200,11 +200,11 @@ public class DeploymentProcessor {
         return new OpenApiConfigImpl(config);
     }
 
-    private static Optional<OpenAPI> modelFromFile(final WebArchive war, final String location,
+    private static Optional<OpenAPI> modelFromFile(OpenApiConfig openApiConfig, final WebArchive war, final String location,
             final Format format) {
         return ofNullable(war.get(location))
                 .map(Node::getAsset)
                 .map(asset -> new OpenApiStaticFile(asset.openStream(), format))
-                .map(OpenApiProcessor::modelFromStaticFile);
+                .map(f -> OpenApiProcessor.modelFromStaticFile(openApiConfig, f));
     }
 }

--- a/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiRegistration.java
+++ b/testsuite/tck/src/test/java/io/smallrye/openapi/tck/OpenApiRegistration.java
@@ -80,7 +80,8 @@ public class OpenApiRegistration extends HttpServlet {
             document.reset();
             document.config(openApiConfig);
             document.filter(OpenApiProcessor.getFilter(openApiConfig, Thread.currentThread().getContextClassLoader()));
-            document.modelFromStaticFile(io.smallrye.openapi.runtime.OpenApiProcessor.modelFromStaticFile(staticFile));
+            document.modelFromStaticFile(
+                    io.smallrye.openapi.runtime.OpenApiProcessor.modelFromStaticFile(openApiConfig, staticFile));
             document.initialize();
             return Optional.of(document.get());
         } finally {

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
@@ -134,7 +134,7 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
         OpenApiConfig openApiConfig = properties.asOpenApiConfig();
         ClassLoader classLoader = getClassLoader(config);
 
-        OpenAPI staticModel = generateStaticModel(resourcesSrcDirs);
+        OpenAPI staticModel = generateStaticModel(openApiConfig, resourcesSrcDirs);
         OpenAPI annotationModel = generateAnnotationModel(index, openApiConfig, SmallryeOpenApiTask.class.getClassLoader());
         OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig, classLoader);
 
@@ -214,13 +214,13 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
         return openApiAnnotationScanner.scan();
     }
 
-    private OpenAPI generateStaticModel(FileCollection resourcesSrcDirs) throws IOException {
+    private OpenAPI generateStaticModel(OpenApiConfig openApiConfig, FileCollection resourcesSrcDirs) throws IOException {
         Path staticFile = getStaticFile(resourcesSrcDirs);
         if (staticFile != null) {
             try (InputStream is = Files.newInputStream(staticFile)) {
                 try (OpenApiStaticFile openApiStaticFile = new OpenApiStaticFile(is,
                         getFormat(staticFile))) {
-                    return OpenApiProcessor.modelFromStaticFile(openApiStaticFile);
+                    return OpenApiProcessor.modelFromStaticFile(openApiConfig, openApiStaticFile);
                 }
             }
         }

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
@@ -271,7 +271,7 @@ public class GenerateSchemaMojo extends AbstractMojo {
         OpenApiConfig openApiConfig = new MavenConfig(getProperties());
         ClassLoader classLoader = getClassLoader();
 
-        OpenAPI staticModel = generateStaticModel();
+        OpenAPI staticModel = generateStaticModel(openApiConfig);
         OpenAPI annotationModel = generateAnnotationModel(index, openApiConfig, classLoader);
         OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig, classLoader);
 
@@ -314,12 +314,12 @@ public class GenerateSchemaMojo extends AbstractMojo {
         return openApiAnnotationScanner.scan();
     }
 
-    private OpenAPI generateStaticModel() throws IOException {
+    private OpenAPI generateStaticModel(OpenApiConfig openApiConfig) throws IOException {
         Path staticFile = getStaticFile();
         if (staticFile != null) {
             try (InputStream is = Files.newInputStream(staticFile);
                     OpenApiStaticFile openApiStaticFile = new OpenApiStaticFile(is, getFormat(staticFile))) {
-                return OpenApiProcessor.modelFromStaticFile(openApiStaticFile);
+                return OpenApiProcessor.modelFromStaticFile(openApiConfig, openApiStaticFile);
             }
         }
         return null;

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenConfig.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/MavenConfig.java
@@ -166,4 +166,11 @@ public class MavenConfig implements OpenApiConfig {
     public Set<String> getScanExcludeProfiles() {
         return asCsvSet(properties.getOrDefault(OpenApiConstants.SCAN_EXCLUDE_PROFILES, null));
     }
+
+    @Override
+    public Integer getMaximumStaticFileSize() {
+        return Integer.parseInt(
+                properties.getOrDefault(OpenApiConstants.MAXIMUM_STATIC_FILE_SIZE,
+                        String.valueOf(OpenApiConfig.MAXIMUM_STATIC_FILE_SIZE_DEFAULT)));
+    }
 }


### PR DESCRIPTION
Fixes #1351

This is to pass a `LoaderOptions`, that carries a hardcoded value for the limit of loaded files, to a [jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text) YAMLFactory instance [when OpenAPIProcessor creates it](https://github.com/smallrye/smallrye-open-api/blob/5d7ae7ce8c90ea454bf22f98ef13d30aa635d838/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java#L74).

Without this change the YAMLParser instance would use now the [SnakeYaml `ParserImpl` default (3 MB)](https://bitbucket.org/snakeyaml/snakeyaml/src/d9b0f480b1a63aca4678da7ab1915fcfc7d2a856/src/main/java/org/yaml/snakeyaml/LoaderOptions.java#lines-39) and fail when for instance loading static files that are larger than 3 MB:

```
at io.smallrye.openapi//io.smallrye.openapi.runtime.OpenApiProcessor.modelFromStaticFile(OpenApiProcessor.java:103)
	at org.wildfly.extension.microprofile.openapi-smallrye@28.0.0.Beta1-202301072046-b985cc92//org.wildfly.extension.microprofile.openapi.deployment.OpenAPIModelServiceConfigurator.get(OpenAPIModelServiceConfigurator.java:161)
	at org.wildfly.extension.microprofile.openapi-smallrye@28.0.0.Beta1-202301072046-b985cc92//org.wildfly.extension.microprofile.openapi.deployment.OpenAPIModelServiceConfigurator.get(OpenAPIModelServiceConfigurator.java:90)
	at org.wildfly.clustering.service@28.0.0.Beta1-202301072046-b985cc92//org.wildfly.clustering.service.FunctionalService.start(FunctionalService.java:63)
	... 8 more
Caused by: com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException: The incoming YAML document exceeds the limit: 3145728 code points.
 at [Source: (FileInputStream); line: 109594, column: 25]
	at com.fasterxml.jackson.dataformat.jackson-dataformat-yaml@2.13.4//com.fasterxml.jackson.dataformat.yaml.YAMLParser.nextToken(YAMLParser.java:409)
	at com.fasterxml.jackson.core.jackson-core@2.13.4//com.fasterxml.jackson.core.JsonParser.nextFieldName(JsonParser.java:1038)
	at com.fasterxml.jackson.core.jackson-databind@2.13.4.2//com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer._deserializeContainerNoRecursion(JsonNodeDeserializer.java:440)
	at com.fasterxml.jackson.core.jackson-databind@2.13.4.2//com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:84)
	at com.fasterxml.jackson.core.jackson-databind@2.13.4.2//com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:20)
	at com.fasterxml.jackson.core.jackson-databind@2.13.4.2//com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
	at com.fasterxml.jackson.core.jackson-databind@2.13.4.2//com.fasterxml.jackson.databind.ObjectMapper._readTreeAndClose(ObjectMapper.java:4716)
	at com.fasterxml.jackson.core.jackson-databind@2.13.4.2//com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:3056)
	at io.smallrye.openapi//io.smallrye.openapi.runtime.io.OpenApiParser.parse(OpenApiParser.java:76)
	at io.smallrye.openapi//io.smallrye.openapi.runtime.OpenApiProcessor.modelFromStaticFile(OpenApiProcessor.java:101)
	... 11 more
Caused by: org.yaml.snakeyaml.error.YAMLException: The incoming YAML document exceeds the limit: 3145728 code points.
```

The PR can be improved by externalizing the limit value, instead than uising a 64 MB hardcoded value.
