### PR TITLE
Remove management of maven-surefire-plugin from JAX-RS module

### DIFF
--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -109,16 +109,6 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <!-- Overriding version from smallrye-jakarta-parent. JUnit 5 Tests not executed otherwise. -->
-                    <version>3.0.0-M8</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
smallrye-parent is now updated to the 3.0.0 surefire series, making management locally superfluous.