### PR TITLE
Allow for alternate properties file to determine MP OpenAPI spec level

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/util/VersionUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/api/util/VersionUtil.java
@@ -2,9 +2,13 @@ package io.smallrye.openapi.api.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
+import java.net.URL;
+import java.util.Optional;
 import java.util.Properties;
 
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import io.smallrye.openapi.runtime.OpenApiRuntimeException;
 import io.smallrye.openapi.runtime.util.ModelUtil;
 
 public final class VersionUtil {
@@ -12,16 +16,27 @@ public final class VersionUtil {
     private VersionUtil() {
     }
 
-    static final String MP_VERSION = ModelUtil.supply(() -> {
-        try (InputStream pomProperties = org.eclipse.microprofile.openapi.models.OpenAPI.class.getResourceAsStream(
-                "/META-INF/maven/org.eclipse.microprofile.openapi/microprofile-openapi-api/pom.properties")) {
-            Properties p = new Properties();
-            p.load(pomProperties);
-            return p.getProperty("version");
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+    static final String SR_VERSION_PROPERTIES = VersionUtil.class.getName() + ".properties";
+    static final String MP_POM_PROPERTIES = "/META-INF/maven/org.eclipse.microprofile.openapi/microprofile-openapi-api/pom.properties"; // NOSONAR
+
+    static final String MP_VERSION = ModelUtil.supply(() -> loadProperty(
+            VersionUtil.class.getResource(SR_VERSION_PROPERTIES), "microprofile.openapi.version")
+            .orElseGet(() -> loadProperty(OpenAPI.class.getResource(MP_POM_PROPERTIES), "version")
+                    .orElseThrow(() -> new OpenApiRuntimeException("Unable to determine MicroProfile OpenAPI version"))));
+
+    static Optional<String> loadProperty(URL source, String key) {
+        if (source != null) {
+            try (InputStream properties = source.openStream()) {
+                Properties p = new Properties();
+                p.load(properties);
+                return Optional.ofNullable(p.getProperty(key));
+            } catch (IOException e) {
+                // Ignore it
+            }
         }
-    });
+
+        return Optional.empty();
+    }
 
     static final String[] MP_VERSION_COMPONENTS = ModelUtil.supply(() -> {
         int suffix = MP_VERSION.indexOf('-');


### PR DESCRIPTION
Fixes #1333

Allow MP OpenAPI specification version to be given via properties file `io.smallrye.openapi.api.util.VersionUtil.properties` on the classpath.