### PR TITLE
Gradle-plugin: CI smoke-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: build with maven
-        run: mvn -B formatter:validate impsort:check install -Pcoverage
+        run: mvn -B formatter:validate impsort:check install -Pcoverage -Pgradle-smoke-test
 
       ## Store information about the build context for Sonar scan in separate job
       - name: Save Build Context

--- a/tools/gradle-plugin/pom.xml
+++ b/tools/gradle-plugin/pom.xml
@@ -202,5 +202,94 @@
                 <gradle.task>assemble</gradle.task>
             </properties>
         </profile>
+        <profile>
+            <id>gradle-smoke-test</id>
+            <build>
+                <plugins>
+                    <!--
+                    Set up the Gradle plugin smoke test, reflecting the order of artifact install /
+                    publish as the release process does:
+                    1. Call Gradle to publish to the local Meven repo
+                    2. Maven "install"
+                    Then call the "smoke test Gradle build", so it has the "same" artifacts as a release.
+                    -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>gradle-smoketest-publish</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${gradle.executable}</executable>
+                                    <arguments>
+                                        <argument>publishToMavenLocal</argument>
+                                        <argument>-Dsmallrye-openapi-version=${project.version}</argument>
+                                        <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                                        <argument>--stacktrace</argument>
+                                        <argument>--no-daemon</argument>
+                                    </arguments>
+                                    <environmentVariables>
+                                        <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
+                                        <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
+                                    </environmentVariables>
+                                    <skip>${skip.gradle.build}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <!-- Need the artifacts installed for the Gradle plugin smoke test -->
+                        <!-- Downside: install happens twice :( -->
+                        <executions>
+                            <execution>
+                                <id>gradle-smoketest-install</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>gradle-smoketest</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${gradle.executable}</executable>
+                                    <arguments>
+                                        <argument>--project-dir</argument>
+                                        <argument>smoke-test/</argument>
+                                        <argument>clean</argument>
+                                        <argument>assemble</argument>
+                                        <argument>-Dsmallrye-openapi-version=${project.version}</argument>
+                                        <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                                        <argument>--stacktrace</argument>
+                                        <argument>--no-daemon</argument>
+                                        <argument>--info</argument>
+                                    </arguments>
+                                    <environmentVariables>
+                                        <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
+                                        <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
+                                    </environmentVariables>
+                                    <skip>${skip.gradle.build}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/tools/gradle-plugin/smoke-test/build.gradle
+++ b/tools/gradle-plugin/smoke-test/build.gradle
@@ -1,0 +1,20 @@
+import io.smallrye.openapi.api.OpenApiConfig.OperationIdStrategy
+
+plugins {
+    id('java-library')
+    id('io.smallrye.openapi')
+}
+
+smallryeOpenApi {
+    scanDependenciesDisable.set(false)
+    infoTitle.set("Smoke Test")
+    schemaFilename.set("META-INF/openapi/openapi")
+    operationIdStrategy.set(OperationIdStrategy.METHOD)
+}
+
+// Just pull in the Gradle plugin to check whether all dependencies match between the pom.xml
+// and build.gradle. This is currently enough.
+//
+// Let this Gradle build happen by activating the Maven profile 'gradle-smoke-test' or manually
+// using this command (replace the version if necessary).
+//   ./gradlew -p smoke-test/ assemble -Dsmallrye-openapi-version=3.3.2-SNAPSHOT

--- a/tools/gradle-plugin/smoke-test/settings.gradle
+++ b/tools/gradle-plugin/smoke-test/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        // Need the local Maven repo for the smoke test, intentionally no other plugin repos
+        mavenLocal()
+    }
+
+    plugins {
+        id('io.smallrye.openapi') version("${System.getProperty('smallrye-openapi-version')}")
+    }
+}
+
+rootProject.name = "gradle-plugin-smoke-test"


### PR DESCRIPTION
Adds a smoke test to validate that the Gradle plugin does initialize.
    
Motivation is to detect mismatches between the `pom.xml` and the dependencies in `build.gradle`.

Reproducer for #1426 - shall be applied/merged after #1425 
