### PR TITLE
Gradle plugin: Add mandatory dependency to smallrye-config

### DIFF
--- a/tools/gradle-plugin/pom.xml
+++ b/tools/gradle-plugin/pom.xml
@@ -36,6 +36,11 @@
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api-vertx</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Using the Gradle plugin (v3.3.1) otherwise leads to
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':nessie-model:generateOpenApiSpec'.
> io/smallrye/config/SmallRyeConfigBuilder
```
which is a `ClassNotFoundException`.

Fixes #1426 
