### PR TITLE
Gradle-Plugin: prepare for Gradle configuration cache

### DIFF
--- a/tools/gradle-plugin/build.gradle
+++ b/tools/gradle-plugin/build.gradle
@@ -49,6 +49,9 @@ test {
     // multiple Gradle invocations executed from the same testing JVM cause problems, so fork
     // for each test, and make sure we only run one Gradle execution in each test
     forkEvery 1
+    // For Gradle testing :(
+    jvmArgs("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED")
 }
 
 gradlePlugin {

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPlugin.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPlugin.java
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.jvm.ClassDirectoryBinaryNamingScheme;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.PathSensitivity;
@@ -46,6 +47,9 @@ public class SmallryeOpenApiPlugin implements Plugin<Project> {
         NamedDomainObjectProvider<Configuration> configProvider = project.getConfigurations()
                 .named(sourceSet.getCompileClasspathConfigurationName());
 
+        Configuration configuration = configProvider.get();
+        FileCollection classpath = project.getObjects().fileCollection().from(configuration);
+
         ConfigurableFileCollection resourcesSrcDirs = project.getObjects()
                 .fileCollection();
         resourcesSrcDirs.from(sourceSet.getResources().getSrcDirs());
@@ -55,7 +59,7 @@ public class SmallryeOpenApiPlugin implements Plugin<Project> {
                         genTaskName,
                         SmallryeOpenApiTask.class,
                         ext,
-                        configProvider,
+                        classpath,
                         resourcesSrcDirs,
                         sourceSet.getOutput().getClassesDirs());
         task
@@ -66,7 +70,7 @@ public class SmallryeOpenApiPlugin implements Plugin<Project> {
                     t.getInputs().files(sourceSet.getAllSource().getSourceDirectories());
                     t.getInputs().files(sourceSet.getOutput().getDirs()).withPathSensitivity(
                             PathSensitivity.RELATIVE);
-                    t.getInputs().files(configProvider).withPathSensitivity(PathSensitivity.RELATIVE);
+                    t.getInputs().files(classpath).withPathSensitivity(PathSensitivity.RELATIVE);
                 });
 
         project.getTasks().named(sourceSet.getJarTaskName(), Jar.class)


### PR DESCRIPTION
Gradle's configuration cache aims to prevent running (expensive) code to configure the build (tasks, et al). Preventing configuration can save a (comparatively) huge amount of time, especially on small/tiny CI machines (looking at you, GH standard hosted runner).

But to be able to use the configuration cache, the build itself and all plugins must respect a couple of rules. Gradle types that must not be referenced during task _execution_ are for example: `Project`, `Configuration`, `Task` and some more. Those need to be replaced with either more specialized types or with different mechanisms.

Test note: The Quarkus plugin in all released versions (at least up to 3.0.0.CR1) cannot be used with Gradle's configuration cache. The tests that use the Quarkus plugin do not enable Gradle's configuration cache.

See [Gradle build cache requirements](https://docs.gradle.org/8.0.2/userguide/configuration_cache.html#config_cache:requirements).