### PR TITLE
Clone schema references on lookup from schema registry

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/OpenApiProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/OpenApiProcessor.java
@@ -89,15 +89,41 @@ public class OpenApiProcessor {
      * method does NOT close the resources in the static file. The caller is
      * responsible for that.
      *
+     * @param config configuration used while reading the static file
      * @param staticFile OpenApiStaticFile to be parsed
      * @return OpenApiImpl
      */
     public static OpenAPI modelFromStaticFile(OpenApiConfig config, OpenApiStaticFile staticFile) {
+        return modelFromStaticFile(staticFile, config != null ? config.getMaximumStaticFileSize() : null);
+    }
+
+    /**
+     * Parse the static file content and return the resulting model. Note that this
+     * method does NOT close the resources in the static file. The caller is
+     * responsible for that.
+     *
+     * @param staticFile OpenApiStaticFile to be parsed
+     * @return OpenAPI model from the file
+     */
+    public static OpenAPI modelFromStaticFile(OpenApiStaticFile staticFile) {
+        return modelFromStaticFile(staticFile, null);
+    }
+
+    /**
+     * Parse the static file content and return the resulting model. Note that this
+     * method does NOT close the resources in the static file. The caller is
+     * responsible for that.
+     *
+     * @param staticFile OpenApiStaticFile to be parsed
+     * @param maxStaticFileSize maximum file size when the format is YAML
+     * @return OpenAPI model from the file
+     */
+    private static OpenAPI modelFromStaticFile(OpenApiStaticFile staticFile, Integer maxStaticFileSize) {
         if (staticFile == null) {
             return null;
         }
         try {
-            return OpenApiParser.parse(staticFile.getContent(), staticFile.getFormat(), config.getMaximumStaticFileSize());
+            return OpenApiParser.parse(staticFile.getContent(), staticFile.getFormat(), maxStaticFileSize);
         } catch (IOException e) {
             throw new OpenApiRuntimeException(e);
         }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/SchemaRegistry.java
@@ -385,7 +385,7 @@ public class SchemaRegistry {
             throw ScannerMessages.msg.notRegistered(key.type.name());
         }
 
-        return info.schemaRef;
+        return new SchemaImpl().ref(info.schemaRef.getRef());
     }
 
     private Schema lookupSchema(TypeKey key) {


### PR DESCRIPTION
Effectively makes references in the registry immutable and avoids modifications after retrieval in merge processing, etc.

Fixes #1444

Also make `OpenApiProcessor`'s `modelFromStaticFile` method backward compatible e.g. Quarkus 2.x.