### PR TITLE
Support YAML long keys

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiSerializer.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiSerializer.java
@@ -30,7 +30,7 @@ public class OpenApiSerializer {
      * @return OpenAPI object as a String
      * @throws IOException Errors in processing the JSON
      */
-    public static final String serialize(OpenAPI openApi, Format format) throws IOException {
+    public static String serialize(OpenAPI openApi, Format format) throws IOException {
 
         try {
             ObjectNode tree = JsonUtil.objectNode();
@@ -42,6 +42,7 @@ public class OpenApiSerializer {
                 return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tree);
             } else {
                 YAMLFactory factory = new YAMLFactory();
+                factory.enable(YAMLGenerator.Feature.ALLOW_LONG_KEYS);
                 factory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
                 factory.enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS);
                 mapper = new ObjectMapper(factory);

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/OpenApiParserAndSerializerTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/OpenApiParserAndSerializerTest.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException;
 
 import io.smallrye.openapi.api.constants.OpenApiConstants;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /**
  * @author eric.wittmann@gmail.com
  */
@@ -552,5 +554,17 @@ class OpenApiParserAndSerializerTest {
         } finally {
             System.clearProperty(OpenApiConstants.MAXIMUM_STATIC_FILE_SIZE);
         }
+    }
+
+    /**
+     *
+     * Support long paths (until 1024)
+     */
+    @Test
+    void testAllowLongKeys() throws Exception {
+        URL resource = OpenApiParserAndSerializerTest.class.getResource("long-path.yaml");
+        assertNotNull(resource, "resource not found: long-path.yaml");
+        OpenAPI model = OpenApiParser.parse(resource.openStream(), Format.YAML);
+        doTest(resource, Format.YAML, model);
     }
 }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/io/long-path.yaml
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/io/long-path.yaml
@@ -1,0 +1,23 @@
+---
+openapi: 3.0.3
+info:
+  title: code-with-quarkus API
+  version: 1.0.0-SNAPSHOT
+paths:
+  /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    get:
+      tags:
+      - Greeting Resource
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  securitySchemes:
+    SecurityScheme:
+      type: http
+      description: Authentication
+      scheme: basic


### PR DESCRIPTION
The limit is 1024 characters. See https://yaml.org/spec/1.1/#id934537

- Fixes #1456
