### PR TITLE
Support for readers and filters to access the Jandex index

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,14 +86,14 @@ jobs:
           java-version: 11
 
       - name: maven cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
       - name: generate javadocs
-        run: mvn -B package javadoc:javadoc -DskipTests
+        run: mvn -B install javadoc:javadoc -DskipTests
 
   tck-reporting:
     runs-on: ubuntu-latest

--- a/core/src/test/java/io/smallrye/openapi/runtime/OpenApiProcessorTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/OpenApiProcessorTest.java
@@ -1,0 +1,86 @@
+package io.smallrye.openapi.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.jboss.jandex.IndexView;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OpenApiProcessorTest {
+
+    ClassLoader loader;
+
+    @BeforeEach
+    void setup() {
+        this.loader = Thread.currentThread().getContextClassLoader();
+    }
+
+    @Test
+    void testNewInstanceWithNullClassName() {
+        Object instance = OpenApiProcessor.newInstance(null, loader, OpenApiProcessor.EMPTY_INDEX);
+        assertNull(instance);
+    }
+
+    @Test
+    void testNewInstanceWithNotFoundClassName() {
+        String invalidClassName = UUID.randomUUID().toString();
+
+        Throwable thrown = assertThrows(OpenApiRuntimeException.class,
+                () -> OpenApiProcessor.newInstance(invalidClassName, loader, OpenApiProcessor.EMPTY_INDEX));
+        assertEquals(ClassNotFoundException.class, thrown.getCause().getClass());
+    }
+
+    @Test
+    void testNewInstanceWithEmptyIndex() {
+        IndexAwareObject instance = OpenApiProcessor.newInstance(IndexAwareObject.class.getName(), loader,
+                OpenApiProcessor.EMPTY_INDEX);
+        assertNotNull(instance);
+        assertFalse(instance.defaultConstructorUsed);
+        assertEquals(0, instance.index.getKnownClasses().size());
+    }
+
+    @Test
+    void testNewInstanceWithIndexUnsupported() {
+        IndexUnawareObject instance = OpenApiProcessor.newInstance(IndexUnawareObject.class.getName(), loader,
+                OpenApiProcessor.EMPTY_INDEX);
+        assertNotNull(instance);
+        assertTrue(instance.defaultConstructorUsed);
+    }
+
+    static class IndexAwareObject {
+        IndexView index;
+        boolean defaultConstructorUsed;
+
+        IndexAwareObject() {
+            defaultConstructorUsed = true;
+        }
+
+        IndexAwareObject(IndexView index) {
+            this.index = index;
+            defaultConstructorUsed = false;
+        }
+
+        IndexAwareObject(Object other) {
+            defaultConstructorUsed = false;
+        }
+    }
+
+    static class IndexUnawareObject {
+        boolean defaultConstructorUsed;
+
+        IndexUnawareObject() {
+            defaultConstructorUsed = true;
+        }
+
+        IndexUnawareObject(Object other) {
+            defaultConstructorUsed = false;
+        }
+    }
+}

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
@@ -127,7 +127,7 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
 
         OpenAPI staticModel = generateStaticModel(openApiConfig, resourcesSrcDirs);
         OpenAPI annotationModel = generateAnnotationModel(index, openApiConfig, SmallryeOpenApiTask.class.getClassLoader());
-        OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig, classLoader);
+        OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig, classLoader, index);
 
         OpenApiDocument document = OpenApiDocument.INSTANCE;
 
@@ -146,7 +146,7 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
             addingModelDebug("static", staticModel);
             document.modelFromStaticFile(staticModel);
         }
-        document.filter(OpenApiProcessor.getFilter(openApiConfig, classLoader));
+        document.filter(OpenApiProcessor.getFilter(openApiConfig, classLoader, index));
         document.initialize();
 
         return document;

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
@@ -288,7 +288,7 @@ public class GenerateSchemaMojo extends AbstractMojo {
 
         OpenAPI staticModel = generateStaticModel(openApiConfig);
         OpenAPI annotationModel = generateAnnotationModel(index, openApiConfig, classLoader);
-        OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig, classLoader);
+        OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig, classLoader, index);
 
         OpenApiDocument document = OpenApiDocument.newInstance();
 
@@ -304,7 +304,7 @@ public class GenerateSchemaMojo extends AbstractMojo {
         if (staticModel != null) {
             document.modelFromStaticFile(staticModel);
         }
-        document.filter(OpenApiProcessor.getFilter(openApiConfig, classLoader));
+        document.filter(OpenApiProcessor.getFilter(openApiConfig, classLoader, index));
         document.initialize();
 
         return document;


### PR DESCRIPTION
Allows implementations of `OASModelReader` and `OASFilter` to optionally provide a single-argument constructor accepting a Jandex `IndexView` to be used internally.

Relates to #1255 and #1370