### PR TITLE
Fix UI `syntaxHighlight` option not support Object value

### DIFF
--- a/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/IndexHtmlCreator.java
+++ b/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/IndexHtmlCreator.java
@@ -85,7 +85,7 @@ public class IndexHtmlCreator {
                     // Some properties can be boolean or Object, if not, we treat it as String and add '
                     if (BOOLEAN_OR_OBJECT_KEYS.contains(variableOption)) {
                         if (!replacement.equals("true") && !replacement.equals("false") &&
-                        !(replacement.startsWith("{") && replacement.endsWith("}"))) {
+                                !(replacement.startsWith("{") && replacement.endsWith("}"))) {
                             replacement = "'" + replacement + "'";
                         }
                     }
@@ -270,7 +270,7 @@ public class IndexHtmlCreator {
 
     // Some properties can be a boolean or an Object. To render correct we need to handle those specially
     private static final List<Option> BOOLEAN_OR_OBJECT_KEYS = Arrays
-      .asList(new Option[] { Option.syntaxHighlight });
+            .asList(new Option[] { Option.syntaxHighlight });
 
     // Some properties can be a String or a function. To render correct we need to handle those specially
     private static final List<Option> STRING_OR_FUNCTION_KEYS = Arrays

--- a/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/IndexHtmlCreator.java
+++ b/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/IndexHtmlCreator.java
@@ -82,6 +82,13 @@ public class IndexHtmlCreator {
                             replacement = "'" + replacement + "'";
                         }
                     }
+                    // Some properties can be boolean or Object, if not, we treat it as String and add '
+                    if (BOOLEAN_OR_OBJECT_KEYS.contains(variableOption)) {
+                        if (!replacement.equals("true") && !replacement.equals("false") &&
+                        !(replacement.startsWith("{") && replacement.endsWith("}"))) {
+                            replacement = "'" + replacement + "'";
+                        }
+                    }
                     // Some properties can be a String or a function, if String we need to add '
                     replacement = replacement.trim();
                     if (STRING_OR_FUNCTION_KEYS.contains(variableOption)) {
@@ -259,7 +266,11 @@ public class IndexHtmlCreator {
 
     // Some properties can be a boolean or a String. To render correct we need to handle those specially
     private static final List<Option> BOOLEAN_OR_STRING_KEYS = Arrays
-            .asList(new Option[] { Option.filter, Option.syntaxHighlight });
+            .asList(new Option[] { Option.filter });
+
+    // Some properties can be a boolean or an Object. To render correct we need to handle those specially
+    private static final List<Option> BOOLEAN_OR_OBJECT_KEYS = Arrays
+      .asList(new Option[] { Option.syntaxHighlight });
 
     // Some properties can be a String or a function. To render correct we need to handle those specially
     private static final List<Option> STRING_OR_FUNCTION_KEYS = Arrays

--- a/ui/open-api-ui/src/test/java/io/smallrye/openapi/ui/IndexCreatorTest.java
+++ b/ui/open-api-ui/src/test/java/io/smallrye/openapi/ui/IndexCreatorTest.java
@@ -214,4 +214,30 @@ class IndexCreatorTest {
 
         assertTrue(html.contains("var oar"), "Missing declaration of 'oar'");
     }
+
+    @Test
+    void testCreateWithSyntaxHighlightBoolean() throws IOException {
+        Map<Option, String> options = new HashMap<>();
+        options.put(Option.syntaxHighlight, "false");
+
+        byte[] indexHtml = IndexHtmlCreator.createIndexHtml(options);
+        assertNotNull(indexHtml);
+
+        String s = new String(indexHtml);
+
+        assertTrue(s.contains("syntaxHighlight: false,"));
+    }
+
+    @Test
+    void testCreateWithSyntaxHighlightObject() throws IOException {
+        Map<Option, String> options = new HashMap<>();
+        options.put(Option.syntaxHighlight, "{ activated: true, theme: \"monokai\" }");
+
+        byte[] indexHtml = IndexHtmlCreator.createIndexHtml(options);
+        assertNotNull(indexHtml);
+
+        String s = new String(indexHtml);
+
+        assertTrue(s.contains("syntaxHighlight: { activated: true, theme: \"monokai\" },"));
+    }
 }


### PR DESCRIPTION
Fix #1502 using proposed solution.

I add 2 test cases to check the solution is working as expected.