### PR TITLE
Lower severity for missing framework parameter logging to DEBUG

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/ScannerSPILogging.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/ScannerSPILogging.java
@@ -17,8 +17,8 @@ interface ScannerSPILogging { // NOSONAR (use of constants in an interface)
     @Message(id = 7901, value = "Matrix parameter references missing path segment: %s")
     void missingPathSegment(String segment);
 
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 7902, value = "@Parameter annotation missing %s parameter. Class: %s, Method: %s, Parameter.name: %s, Parameter.in: %s")
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 7902, value = "@Parameter annotation found without %s parameter. Class: %s, Method: %s, Parameter.name: %s, Parameter.in: %s")
     void missingFrameworkParam(String frameworkName, String className, String method, String paramName, String paramIn);
 
     @LogMessage(level = Logger.Level.WARN)


### PR DESCRIPTION
Closes #1264 

Log a slightly modified message at DEBUG when a `@Parameter` is found without an equivalent framework parameter, e.g. `@PathParam`. Using `@Parameter` as a standalone annotation has valid use cases (see #1264) and should not be logged as a warning.