### PR TITLE
Adding a configuration property for the Maven and Gradle plugin to filter output file types

### DIFF
--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
@@ -61,6 +61,7 @@ class Configs implements SmallryeOpenApiProperties {
     final ListProperty<String> scanProfiles;
     final ListProperty<String> scanExcludeProfiles;
     final MapProperty<String, String> scanResourceClasses;
+    final Property<String> outputFileTypeFilter;
     final Property<String> encoding;
 
     Configs(ObjectFactory objects) {
@@ -94,6 +95,7 @@ class Configs implements SmallryeOpenApiProperties {
         scanProfiles = objects.listProperty(String.class);
         scanExcludeProfiles = objects.listProperty(String.class);
         scanResourceClasses = objects.mapProperty(String.class, String.class);
+        outputFileTypeFilter = objects.property(String.class).convention("ALL");
         encoding = objects.property(String.class).convention(StandardCharsets.UTF_8.name());
     }
 
@@ -130,6 +132,7 @@ class Configs implements SmallryeOpenApiProperties {
         scanProfiles = objects.listProperty(String.class).convention(ext.getScanProfiles());
         scanExcludeProfiles = objects.listProperty(String.class).convention(ext.getScanExcludeProfiles());
         scanResourceClasses = objects.mapProperty(String.class, String.class).convention(ext.getScanResourceClasses());
+        outputFileTypeFilter = objects.property(String.class).convention(ext.getOutputFileTypeFilter());
         encoding = objects.property(String.class).convention(ext.getEncoding());
     }
 
@@ -330,6 +333,10 @@ class Configs implements SmallryeOpenApiProperties {
 
     public MapProperty<String, String> getScanResourceClasses() {
         return scanResourceClasses;
+    }
+
+    public Property<String> getOutputFileTypeFilter() {
+        return outputFileTypeFilter;
     }
 
     public Property<String> getEncoding() {

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiProperties.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiProperties.java
@@ -141,6 +141,11 @@ public interface SmallryeOpenApiProperties {
     MapProperty<String, String> getScanResourceClasses();
 
     /**
+     * Filter the type of files that will be generated, allowed values are {@code ALL}, {@code YAML} and {@code JSON}.
+     */
+    Property<String> getOutputFileTypeFilter();
+
+    /**
      * Output encoding for openapi document.
      */
     Property<String> getEncoding();

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
@@ -79,6 +80,12 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
     private final DirectoryProperty outputDirectory;
 
     private final Configs properties;
+
+    enum OutputFileFilter {
+        ALL,
+        YAML,
+        JSON
+    }
 
     @Inject
     public SmallryeOpenApiTask(
@@ -306,9 +313,17 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
                 throw new GradleException("encoding parameter does not define a supported charset", e);
             }
 
-            writeSchemaFile(directory, "yaml", yaml.getBytes(charset));
+            if (Stream.of(OutputFileFilter.ALL, OutputFileFilter.YAML)
+                    .anyMatch(f -> f
+                            .equals(OutputFileFilter.valueOf(OutputFileFilter.class, properties.outputFileTypeFilter.get())))) {
+                writeSchemaFile(directory, "yaml", json.getBytes(charset));
+            }
 
-            writeSchemaFile(directory, "json", json.getBytes(charset));
+            if (Stream.of(OutputFileFilter.ALL, OutputFileFilter.JSON)
+                    .anyMatch(f -> f
+                            .equals(OutputFileFilter.valueOf(OutputFileFilter.class, properties.outputFileTypeFilter.get())))) {
+                writeSchemaFile(directory, "json", json.getBytes(charset));
+            }
 
             getLogger().info("Wrote the schema files to {}",
                     outputDirectory.get().getAsFile().getAbsolutePath());
@@ -547,6 +562,13 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
     @Override
     public MapProperty<String, String> getScanResourceClasses() {
         return properties.scanResourceClasses;
+    }
+
+    @Input
+    @Optional
+    @Override
+    public Property<String> getOutputFileTypeFilter() {
+        return properties.outputFileTypeFilter;
     }
 
     @Input

--- a/tools/gradle-plugin/src/test/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPluginTest.java
+++ b/tools/gradle-plugin/src/test/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPluginTest.java
@@ -142,6 +142,18 @@ class SmallryeOpenApiPluginTest {
     }
 
     @Test
+    void simpleProjectWithJustYamlOutput(@TempDir Path buildDir) throws Exception {
+        // "Simple" Gradle project
+        smokeProject(buildDir, false, SmallryeOpenApiPlugin.TASK_NAME, "YAML");
+    }
+
+    @Test
+    void simpleProjectWithJustJsonOutput(@TempDir Path buildDir) throws Exception {
+        // "Simple" Gradle project
+        smokeProject(buildDir, false, SmallryeOpenApiPlugin.TASK_NAME, "JSON");
+    }
+
+    @Test
     void quarkusProjectGenApiOnly(@TempDir Path buildDir) throws Exception {
         // Quarkus Gradle project, just call the generateOpenApiSpec task
         smokeProject(buildDir, true, SmallryeOpenApiPlugin.TASK_NAME);
@@ -154,6 +166,10 @@ class SmallryeOpenApiPluginTest {
     }
 
     void smokeProject(Path buildDir, boolean withQuarkus, String taskName) throws Exception {
+        smokeProject(buildDir, withQuarkus, taskName, "ALL");
+    }
+
+    void smokeProject(Path buildDir, boolean withQuarkus, String taskName, String outputFileTypeFilter) throws Exception {
         Files.write(buildDir.resolve("settings.gradle"),
                 singletonList("rootProject.name = 'smoke-test-project'"));
 
@@ -189,6 +205,7 @@ class SmallryeOpenApiPluginTest {
                         "  infoLicenseName.set(\"Apache 2.0\")",
                         "  infoLicenseUrl.set(\"http://www.apache.org/licenses/LICENSE-2.0.html\")",
                         "  operationIdStrategy.set(OperationIdStrategy.METHOD)",
+                        "  outputFileTypeFilter.set(\"" + outputFileTypeFilter + "\")",
                         "}"));
 
         Path javaDir = Paths.get("src/main/java/testcases");
@@ -222,51 +239,68 @@ class SmallryeOpenApiPluginTest {
 
         runGradleTask(buildDir, taskName, withQuarkus);
 
-        checkGeneratedFiles(buildDir);
+        checkGeneratedFiles(buildDir, outputFileTypeFilter);
 
-        checkJarContents(buildDir, withQuarkus);
+        checkJarContents(buildDir, withQuarkus, outputFileTypeFilter);
     }
 
-    private static void checkJarContents(Path buildDir, boolean withQuarkus) throws Exception {
+    private static void checkJarContents(Path buildDir, boolean withQuarkus, String expectedOutputFileType) throws Exception {
         runGradleTask(buildDir, "jar", withQuarkus);
 
         Path jarFile = buildDir.resolve("build/libs/smoke-test-project.jar");
         assertThat(jarFile).isRegularFile();
 
         try (ZipFile zipFile = new ZipFile(jarFile.toFile())) {
-            assertThat(zipFile.getEntry("my-openapi-schema-file.yaml")).isNotNull();
-            assertThat(zipFile.getEntry("my-openapi-schema-file.json")).isNotNull();
+            if ("ALL".equals(expectedOutputFileType) || "YAML".equals(expectedOutputFileType)) {
+                assertThat(zipFile.getEntry("my-openapi-schema-file.yaml")).isNotNull();
+            }
+            if ("ALL".equals(expectedOutputFileType) || "JSON".equals(expectedOutputFileType)) {
+                assertThat(zipFile.getEntry("my-openapi-schema-file.json")).isNotNull();
+            }
             assertThat(zipFile.getEntry("testcases/DummyJaxRs.class")).isNotNull();
             assertThat(zipFile.getEntry("META-INF/MANIFEST.MF")).isNotNull();
         }
     }
 
-    private static void checkGeneratedFiles(Path buildDir) throws IOException {
+    private static void checkGeneratedFiles(Path buildDir, String expectedOutputFileType) throws IOException {
         Path targetOpenapiDir = buildDir.resolve("build/generated/openapi");
         assertThat(targetOpenapiDir).isDirectory();
-        assertThat(targetOpenapiDir.resolve("my-openapi-schema-file.yaml")).isRegularFile();
-        assertThat(targetOpenapiDir.resolve("my-openapi-schema-file.json")).isRegularFile();
 
-        JsonNode root = new ObjectMapper().readValue(
-                targetOpenapiDir.resolve("my-openapi-schema-file.json").toUri().toURL(),
-                JsonNode.class);
-        assertThat(root.get("openapi").asText()).isEqualTo("3.0.2");
+        if ("ALL".equals(expectedOutputFileType)) {
+            assertThat(targetOpenapiDir.resolve("my-openapi-schema-file.yaml")).isRegularFile();
+            assertThat(targetOpenapiDir.resolve("my-openapi-schema-file.json")).isRegularFile();
 
-        JsonNode info = root.get("info");
-        assertThat(info).isNotNull();
-        assertThat(info.get("title").asText()).isEqualTo("Info Title");
-        assertThat(info.get("description").asText()).isEqualTo("Info Description");
-        assertThat(info.get("termsOfService").asText()).isEqualTo("Info TOS");
-        assertThat(info.get("version").asText()).isEqualTo("Info Version");
-        assertThat(info.get("contact").get("email").asText()).isEqualTo("Info Email");
-        assertThat(info.get("contact").get("name").asText()).isEqualTo("Info Contact");
-        assertThat(info.get("contact").get("url").asText())
-                .isEqualTo("https://github.com/smallrye/smallrye-open-api/issues/1231");
-        assertThat(info.get("license").get("name").asText()).isEqualTo("Apache 2.0");
-        assertThat(info.get("license").get("url").asText()).isEqualTo("http://www.apache.org/licenses/LICENSE-2.0.html");
+            JsonNode root = new ObjectMapper().readValue(
+                    targetOpenapiDir.resolve("my-openapi-schema-file.json").toUri().toURL(),
+                    JsonNode.class);
+            assertThat(root.get("openapi").asText()).isEqualTo("3.0.2");
 
-        JsonNode paths = root.get("paths");
-        assertThat(paths.get("/mypath").get("get").get("operationId").asText()).isEqualTo("dummyThing");
+            JsonNode info = root.get("info");
+            assertThat(info).isNotNull();
+            assertThat(info.get("title").asText()).isEqualTo("Info Title");
+            assertThat(info.get("description").asText()).isEqualTo("Info Description");
+            assertThat(info.get("termsOfService").asText()).isEqualTo("Info TOS");
+            assertThat(info.get("version").asText()).isEqualTo("Info Version");
+            assertThat(info.get("contact").get("email").asText()).isEqualTo("Info Email");
+            assertThat(info.get("contact").get("name").asText()).isEqualTo("Info Contact");
+            assertThat(info.get("contact").get("url").asText())
+                    .isEqualTo("https://github.com/smallrye/smallrye-open-api/issues/1231");
+            assertThat(info.get("license").get("name").asText()).isEqualTo("Apache 2.0");
+            assertThat(info.get("license").get("url").asText()).isEqualTo("http://www.apache.org/licenses/LICENSE-2.0.html");
+
+            JsonNode paths = root.get("paths");
+            assertThat(paths.get("/mypath").get("get").get("operationId").asText()).isEqualTo("dummyThing");
+        }
+
+        if ("YAML".equals(expectedOutputFileType)) {
+            assertThat(targetOpenapiDir.resolve("my-openapi-schema-file.yaml")).isRegularFile();
+            assertThat(targetOpenapiDir.resolve("my-openapi-schema-file.json")).doesNotExist();
+        }
+
+        if ("JSON".equals(expectedOutputFileType)) {
+            assertThat(targetOpenapiDir.resolve("my-openapi-schema-file.yaml")).doesNotExist();
+            assertThat(targetOpenapiDir.resolve("my-openapi-schema-file.json")).isRegularFile();
+        }
     }
 
     private static void runGradleTask(Path buildDir, String taskName, boolean withQuarkus) {

--- a/tools/maven-plugin/README.adoc
+++ b/tools/maven-plugin/README.adoc
@@ -50,6 +50,7 @@ E.g. for includeDependenciesScopes could be configured as:
 - `attachArtifacts` (boolean, default: false) - Attach the built OpenAPI schema as build artifact.
 - `skip` (boolean, default: false) - Skip execution of the plugin.
 - `encoding` (String) - Encoding of output OpenAPI files.
+- `outputFileTypeFilter` (String) - Set this to "YAML" in order to let the generation process produce just *.yaml output, "JSON" to obtain *.json files only. The default is "ALL", which will generate both file types.
 
 == MicroProfile OpenAPI Properties
 

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -249,6 +250,18 @@ public class GenerateSchemaMojo extends AbstractMojo {
     @Parameter(property = "scanResourceClasses")
     private Map<String, String> scanResourceClasses;
 
+    enum OutputFileFilter {
+        ALL,
+        YAML,
+        JSON
+    }
+
+    /**
+     * Filter the type of files that will be generated, allowed values are {@code ALL}, {@code YAML} and {@code JSON}.
+     */
+    @Parameter(property = "outputFileTypeFilter", defaultValue = "ALL")
+    private String outputFileTypeFilter;
+
     @Component
     private MavenDependencyIndexCreator mavenDependencyIndexCreator;
 
@@ -472,9 +485,15 @@ public class GenerateSchemaMojo extends AbstractMojo {
                     }
                 }
 
-                writeSchemaFile(directory, "yaml", yaml.getBytes(charset));
+                if (Stream.of(OutputFileFilter.ALL, OutputFileFilter.YAML)
+                        .anyMatch(f -> f.equals(OutputFileFilter.valueOf(this.outputFileTypeFilter)))) {
+                    writeSchemaFile(directory, "yaml", yaml.getBytes(charset));
+                }
 
-                writeSchemaFile(directory, "json", json.getBytes(charset));
+                if (Stream.of(OutputFileFilter.ALL, OutputFileFilter.JSON)
+                        .anyMatch(f -> f.equals(OutputFileFilter.valueOf(this.outputFileTypeFilter)))) {
+                    writeSchemaFile(directory, "json", json.getBytes(charset));
+                }
 
                 getLog().info("Wrote the schema files to " + outputDirectory.getAbsolutePath());
             }

--- a/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/outputFileTypeFilter_All/pom.xml
+++ b/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/outputFileTypeFilter_All/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.smallrye.openapi.mavenplugin</groupId>
+    <artifactId>outputFileTypeFilter_All</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <openApiVersion>custom-openapi-version</openApiVersion>
+        <infoTitle>Smallrye OpenAPI</infoTitle>
+        <infoVersion>2.1.15</infoVersion>
+        <infoDescription>Description of this schema</infoDescription>
+        <infoTermsOfService>custom-tos</infoTermsOfService>
+        <infoContactEmail>custom-info-email</infoContactEmail>
+        <infoContactName>Max Mustermann</infoContactName>
+        <infoContactUrl>https://example.com/contact</infoContactUrl>
+        <infoLicenseName>Apache License V2.0</infoLicenseName>
+        <infoLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</infoLicenseUrl>
+        <outputDirectory>${java.io.tmpdir}/smallrye-openapi/maven-plugin/it</outputDirectory>
+        <outputFileTypeFilter>ALL</outputFileTypeFilter>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <goals>
+                    <goal>generate-schema</goal>
+                </goals>
+                <configuration>
+                    <openApiVersion>${openApiVersion}</openApiVersion>
+                    <infoTitle>${infoTitle}</infoTitle>
+                    <infoVersion>${infoVersion}</infoVersion>
+                    <infoDescription>${infoDescription}</infoDescription>
+                    <infoTermsOfService>${infoTermsOfService}</infoTermsOfService>
+                    <infoContactEmail>${infoContactEmail}</infoContactEmail>
+                    <infoContactName>${infoContactName}</infoContactName>
+                    <infoContactUrl>${infoContactUrl}</infoContactUrl>
+                    <infoLicenseName>${infoLicenseName}</infoLicenseName>
+                    <infoLicenseUrl>${infoLicenseUrl}</infoLicenseUrl>
+                    <outputDirectory>${outputDirectory}</outputDirectory>
+                    <outputFileTypeFilter>${outputFileTypeFilter}</outputFileTypeFilter>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/outputFileTypeFilter_Json/pom.xml
+++ b/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/outputFileTypeFilter_Json/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.smallrye.openapi.mavenplugin</groupId>
+    <artifactId>outputFileTypeFilter_All</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <openApiVersion>custom-openapi-version</openApiVersion>
+        <infoTitle>Smallrye OpenAPI</infoTitle>
+        <infoVersion>2.1.15</infoVersion>
+        <infoDescription>Description of this schema</infoDescription>
+        <infoTermsOfService>custom-tos</infoTermsOfService>
+        <infoContactEmail>custom-info-email</infoContactEmail>
+        <infoContactName>Max Mustermann</infoContactName>
+        <infoContactUrl>https://example.com/contact</infoContactUrl>
+        <infoLicenseName>Apache License V2.0</infoLicenseName>
+        <infoLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</infoLicenseUrl>
+        <outputDirectory>${java.io.tmpdir}/smallrye-openapi/maven-plugin/it</outputDirectory>
+        <outputFileTypeFilter>JSON</outputFileTypeFilter>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <goals>
+                    <goal>generate-schema</goal>
+                </goals>
+                <configuration>
+                    <openApiVersion>${openApiVersion}</openApiVersion>
+                    <infoTitle>${infoTitle}</infoTitle>
+                    <infoVersion>${infoVersion}</infoVersion>
+                    <infoDescription>${infoDescription}</infoDescription>
+                    <infoTermsOfService>${infoTermsOfService}</infoTermsOfService>
+                    <infoContactEmail>${infoContactEmail}</infoContactEmail>
+                    <infoContactName>${infoContactName}</infoContactName>
+                    <infoContactUrl>${infoContactUrl}</infoContactUrl>
+                    <infoLicenseName>${infoLicenseName}</infoLicenseName>
+                    <infoLicenseUrl>${infoLicenseUrl}</infoLicenseUrl>
+                    <outputDirectory>${outputDirectory}</outputDirectory>
+                    <outputFileTypeFilter>${outputFileTypeFilter}</outputFileTypeFilter>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/outputFileTypeFilter_Yaml/pom.xml
+++ b/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/outputFileTypeFilter_Yaml/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.smallrye.openapi.mavenplugin</groupId>
+    <artifactId>outputFileTypeFilter_All</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <openApiVersion>custom-openapi-version</openApiVersion>
+        <infoTitle>Smallrye OpenAPI</infoTitle>
+        <infoVersion>2.1.15</infoVersion>
+        <infoDescription>Description of this schema</infoDescription>
+        <infoTermsOfService>custom-tos</infoTermsOfService>
+        <infoContactEmail>custom-info-email</infoContactEmail>
+        <infoContactName>Max Mustermann</infoContactName>
+        <infoContactUrl>https://example.com/contact</infoContactUrl>
+        <infoLicenseName>Apache License V2.0</infoLicenseName>
+        <infoLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</infoLicenseUrl>
+        <outputDirectory>${java.io.tmpdir}/smallrye-openapi/maven-plugin/it</outputDirectory>
+        <outputFileTypeFilter>YAML</outputFileTypeFilter>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <goals>
+                    <goal>generate-schema</goal>
+                </goals>
+                <configuration>
+                    <openApiVersion>${openApiVersion}</openApiVersion>
+                    <infoTitle>${infoTitle}</infoTitle>
+                    <infoVersion>${infoVersion}</infoVersion>
+                    <infoDescription>${infoDescription}</infoDescription>
+                    <infoTermsOfService>${infoTermsOfService}</infoTermsOfService>
+                    <infoContactEmail>${infoContactEmail}</infoContactEmail>
+                    <infoContactName>${infoContactName}</infoContactName>
+                    <infoContactUrl>${infoContactUrl}</infoContactUrl>
+                    <infoLicenseName>${infoLicenseName}</infoLicenseName>
+                    <infoLicenseUrl>${infoLicenseUrl}</infoLicenseUrl>
+                    <outputDirectory>${outputDirectory}</outputDirectory>
+                    <outputFileTypeFilter>${outputFileTypeFilter}</outputFileTypeFilter>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Adding the "outputFileTypeFilter" property to the Maven and Gradle plugin configuration, so that a user can decide whether to generate `*.yaml` ("YAML"), `*.json` ("JSON") file types, or both ("ALL").

Fix #1511 