### PR TITLE
Fix gradle multithread issue

### DIFF
--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
@@ -136,7 +136,7 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
         OpenAPI annotationModel = generateAnnotationModel(index, openApiConfig, SmallryeOpenApiTask.class.getClassLoader());
         OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig, classLoader, index);
 
-        OpenApiDocument document = OpenApiDocument.INSTANCE;
+        OpenApiDocument document = OpenApiDocument.newInstance();
 
         document.reset();
         document.config(openApiConfig);


### PR DESCRIPTION
My team and I have run into a race condition on generating the schema for our composite gradle build. This is due to gradle trying to build multiple projects at the same time and this plugin's use of the OpenApiDocument.INSTANCE singleton. Using the newInstance method instead gives a fresh document to each task, this lets us continue to build with multithreading on and avoid the race condition.