### PR TITLE
maven-plugin: Document JDK 1.8 compatibility hack

### DIFF
--- a/tools/maven-plugin/README.adoc
+++ b/tools/maven-plugin/README.adoc
@@ -18,6 +18,21 @@ Add this to your pom.xml:
             </goals>
         </execution>
     </executions>
+    <!-- Uncomment the dependency overrides for JDK 1.8 compatibility: -->
+    <!--
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.4.3.Final</version>
+        </dependency>
+    </dependencies>
+    -->
 </plugin>
 ----
 


### PR DESCRIPTION
As discussed in #1604, JDK 1.8 is supported when a couple of dependency versions are overridden.