### PR TITLE
Expose Swagger configuration "tryItOutEnabled" property

### DIFF
--- a/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/IndexHtmlCreator.java
+++ b/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/IndexHtmlCreator.java
@@ -317,6 +317,7 @@ public class IndexHtmlCreator {
         DEFAULT_OPTIONS.put(Option.onComplete, null);
         DEFAULT_OPTIONS.put(Option.syntaxHighlight, null);
         DEFAULT_OPTIONS.put(Option.queryConfigEnabled, null);
+        DEFAULT_OPTIONS.put(Option.tryItOutEnabled, null);
 
         // Network section
         DEFAULT_OPTIONS.put(Option.oauth2RedirectUrl, null);

--- a/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/Option.java
+++ b/ui/open-api-ui/src/main/java/io/smallrye/openapi/ui/Option.java
@@ -45,6 +45,7 @@ public enum Option {
     layout,
     plugins,
     presets,
+    tryItOutEnabled,
     // OAuth related
     initOAuthSection,
     oauthClientId,

--- a/ui/open-api-ui/src/main/resources/template/index.html
+++ b/ui/open-api-ui/src/main/resources/template/index.html
@@ -47,6 +47,7 @@
                             tagsSorter: ${tagsSorter},
                             onComplete: ${onComplete},
                             syntaxHighlight: ${syntaxHighlight},
+                            tryItOutEnabled: ${tryItOutEnabled},
                             requestInterceptor: ${requestInterceptor},
                             request.curlOptions: ${requestCurlOptions},
                             responseInterceptor: ${responseInterceptor},

--- a/ui/open-api-ui/src/test/java/io/smallrye/openapi/ui/IndexCreatorTest.java
+++ b/ui/open-api-ui/src/test/java/io/smallrye/openapi/ui/IndexCreatorTest.java
@@ -32,7 +32,7 @@ class IndexCreatorTest {
         assertTrue(s.contains("dom_id: '#swagger-ui',"));
         assertTrue(s.contains("deepLinking: true,"));
         assertFalse(s.contains("queryConfigEnabled"));
-
+        assertFalse(s.contains("tryItOutEnabled"));
     }
 
     @Test
@@ -239,5 +239,18 @@ class IndexCreatorTest {
         String s = new String(indexHtml);
 
         assertTrue(s.contains("syntaxHighlight: { activated: true, theme: \"monokai\" },"));
+    }
+
+    @Test
+    void testCreateWithTryItOutEnabledBoolean() throws IOException {
+        Map<Option, String> options = new HashMap<>();
+        options.put(Option.tryItOutEnabled, "true");
+
+        byte[] indexHtml = IndexHtmlCreator.createIndexHtml(options);
+        assertNotNull(indexHtml);
+
+        String s = new String(indexHtml);
+
+        assertTrue(s.contains("tryItOutEnabled: true,"));
     }
 }


### PR DESCRIPTION
This feature exposes Swagger `tryItOutEnabled` configuration property ([doc](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/))