### PR TITLE
fix: avoid rescanning type parameter when schema previously registered

### DIFF
--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/EnumNamingTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/EnumNamingTest.java
@@ -1,5 +1,7 @@
 package io.smallrye.openapi.runtime.scanner.dataobject;
 
+import java.util.Set;
+
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
@@ -24,7 +26,7 @@ class EnumNamingTest extends IndexScannerTestBase {
         @Schema(name = "Bean")
         class Bean {
             @SuppressWarnings("unused")
-            DaysOfWeekDefault days;
+            Set<DaysOfWeekDefault> days;
         }
 
         test(Bean.class, DaysOfWeekDefault.class);
@@ -35,7 +37,7 @@ class EnumNamingTest extends IndexScannerTestBase {
         @Schema(name = "Bean")
         class Bean {
             @SuppressWarnings("unused")
-            DaysOfWeekValue days;
+            Set<DaysOfWeekValue> days;
         }
 
         test(Bean.class, DaysOfWeekValue.class);
@@ -46,7 +48,7 @@ class EnumNamingTest extends IndexScannerTestBase {
         @Schema(name = "Bean")
         class Bean {
             @SuppressWarnings("unused")
-            DaysOfWeekStrategy days;
+            Set<DaysOfWeekStrategy> days;
         }
 
         test(Bean.class, DaysOfWeekStrategy.class);
@@ -57,7 +59,7 @@ class EnumNamingTest extends IndexScannerTestBase {
         @Schema(name = "Bean")
         class Bean {
             @SuppressWarnings("unused")
-            DaysOfWeekProperty days;
+            Set<DaysOfWeekProperty> days;
         }
 
         test(Bean.class, DaysOfWeekProperty.class);

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.enum-naming.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.enum-naming.json
@@ -6,7 +6,11 @@
         "type" : "object",
         "properties" : {
           "days" : {
-            "$ref" : "#/components/schemas/DaysOfWeek"
+            "uniqueItems" : true,
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/DaysOfWeek"
+            }
           }
         }
       },


### PR DESCRIPTION
Fixes #1624 

For https://github.com/quarkusio/quarkus/issues/36677