### PR TITLE
Handle kotlin.Deprecated tag in OpenAPI generation

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/constants/KotlinConstants.java
+++ b/core/src/main/java/io/smallrye/openapi/api/constants/KotlinConstants.java
@@ -12,6 +12,9 @@ public class KotlinConstants {
     public static final DotName CONTINUATION = DotName
             .createSimple("kotlin.coroutines.Continuation");
 
+    public static final DotName DEPRECATED = DotName
+            .createSimple("kotlin.Deprecated");
+
     public static final DotName JETBRAINS_NULLABLE = DotName
             .createSimple("org.jetbrains.annotations.Nullable");
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -1,20 +1,10 @@
 package io.smallrye.openapi.runtime.util;
 
-import static io.smallrye.openapi.api.constants.JDKConstants.DOTNAME_DEPRECATED;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -36,6 +26,7 @@ import org.jboss.jandex.WildcardType;
 
 import io.smallrye.openapi.api.constants.JDKConstants;
 import io.smallrye.openapi.api.constants.JaxbConstants;
+import io.smallrye.openapi.api.constants.KotlinConstants;
 import io.smallrye.openapi.api.constants.MutinyConstants;
 import io.smallrye.openapi.api.models.ExternalDocumentationImpl;
 import io.smallrye.openapi.runtime.io.externaldocs.ExternalDocsConstant;
@@ -786,7 +777,9 @@ public class TypeUtil {
             return;
         }
 
-        AnnotationInstance deprecated = Annotations.getAnnotation(target, DOTNAME_DEPRECATED);
+        AnnotationInstance deprecated = Annotations.getAnnotation(
+                target,
+                Arrays.asList(JDKConstants.DOTNAME_DEPRECATED, KotlinConstants.DEPRECATED));
 
         if (deprecated != null && JandexUtil.equals(deprecated.target(), target)) {
             setDeprecated.accept(Boolean.TRUE);

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -32,6 +32,8 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
@@ -708,6 +710,21 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
 
         printToConsole(result);
         assertJsonEquals("components.schemas.kotlin-value-class-propname.json", result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            io.smallrye.openapi.testdata.kotlin.JavaDeprecatedKotlinBean.class,
+            io.smallrye.openapi.testdata.kotlin.DeprecatedKotlinBean.class
+    })
+    void testDeprecatedAnnotation(Class clazz) throws IOException, JSONException {
+        Index index = indexOf(clazz);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(emptyConfig(), index);
+
+        OpenAPI result = scanner.scan();
+
+        printToConsole(result);
+        assertJsonEquals("components.schemas.kotlin-deprecated-annotation.json", result);
     }
 
     /*

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.kotlin-deprecated-annotation.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.kotlin-deprecated-annotation.json
@@ -1,0 +1,17 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "DeprecatedKotlinBean" : {
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        },
+        "deprecated" : true
+      }
+    }
+  }
+}

--- a/testsuite/data/src/main/kotlin/io/smallrye/openapi/testdata/kotlin/KotlinBean.kt
+++ b/testsuite/data/src/main/kotlin/io/smallrye/openapi/testdata/kotlin/KotlinBean.kt
@@ -8,5 +8,17 @@ data class KotlinBean (
     @field:Schema(type = SchemaType.INTEGER, implementation = Long::class, name = "id")
     val id: KotlinLongValue? = null,
     val name: String? = null,
-    val description: String = ""
+    val description: String = "",
+)
+
+@Deprecated("1.0.0")
+@Schema(name = "DeprecatedKotlinBean")
+data class DeprecatedKotlinBean(
+    val id: String
+)
+
+@java.lang.Deprecated(since = "1.0.0")
+@Schema(name = "DeprecatedKotlinBean")
+data class JavaDeprecatedKotlinBean(
+    val id: String
 )


### PR DESCRIPTION
fixes #1661 