### PR TITLE
Support summary attribute on Info annotation

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -209,6 +209,10 @@ public interface OpenApiConfig {
         return getConfigValue(SmallRyeOASConfig.INFO_TERMS, String.class, () -> null);
     }
 
+    default String getInfoSummary() {
+        return getConfigValue(SmallRyeOASConfig.INFO_SUMMARY, String.class, () -> null);
+    }
+
     default String getInfoContactEmail() {
         return getConfigValue(SmallRyeOASConfig.INFO_CONTACT_EMAIL, String.class, () -> null);
     }

--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOASConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOASConfig.java
@@ -62,6 +62,7 @@ public final class SmallRyeOASConfig {
     public static final String INFO_TITLE = SMALLRYE_PREFIX + "info.title";
     public static final String INFO_VERSION = SMALLRYE_PREFIX + "info.version";
     public static final String INFO_DESCRIPTION = SMALLRYE_PREFIX + "info.description";
+    public static final String INFO_SUMMARY = SMALLRYE_PREFIX + "info.summary";
     public static final String INFO_TERMS = SMALLRYE_PREFIX + "info.termsOfService";
     public static final String INFO_CONTACT_EMAIL = SMALLRYE_PREFIX + "info.contact.email";
     public static final String INFO_CONTACT_NAME = SMALLRYE_PREFIX + "info.contact.name";

--- a/core/src/main/java/io/smallrye/openapi/api/models/info/InfoImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/info/InfoImpl.java
@@ -18,6 +18,7 @@ public class InfoImpl extends ExtensibleImpl<Info> implements Info, ModelImpl {
     private Contact contact;
     private License license;
     private String version;
+    private String summary;
 
     /**
      * @see org.eclipse.microprofile.openapi.models.info.Info#getTitle()
@@ -113,6 +114,22 @@ public class InfoImpl extends ExtensibleImpl<Info> implements Info, ModelImpl {
     @Override
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    /**
+     * @see org.eclipse.microprofile.openapi.models.info.Info#getSummary()
+     */
+    @Override
+    public String getSummary() {
+        return summary;
+    }
+
+    /**
+     * @see org.eclipse.microprofile.openapi.models.info.Info#setSummary(java.lang.String)
+     */
+    @Override
+    public void setSummary(String summary) {
+        this.summary = summary;
     }
 
 }

--- a/core/src/main/java/io/smallrye/openapi/api/util/ConfigUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/api/util/ConfigUtil.java
@@ -66,6 +66,7 @@ public class ConfigUtil {
         setIfPresent(config.getInfoTitle(), oai.getInfo()::setTitle);
         setIfPresent(config.getInfoVersion(), oai.getInfo()::setVersion);
         setIfPresent(config.getInfoDescription(), oai.getInfo()::setDescription);
+        setIfPresent(config.getInfoSummary(), oai.getInfo()::setSummary);
         setIfPresent(config.getInfoTermsOfService(), oai.getInfo()::setTermsOfService);
 
         // Contact

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/info/InfoIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/info/InfoIO.java
@@ -19,6 +19,7 @@ public class InfoIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Info, V
     private static final String PROP_DESCRIPTION = "description";
     private static final String PROP_LICENSE = "license";
     private static final String PROP_CONTACT = "contact";
+    private static final String PROP_SUMMARY = "summary";
 
     public InfoIO(IOContext<V, A, O, AB, OB> context) {
         super(context, Names.INFO, Names.create(Info.class));
@@ -30,6 +31,7 @@ public class InfoIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Info, V
         Info info = new InfoImpl();
         info.setTitle(value(annotation, PROP_TITLE));
         info.setDescription(value(annotation, PROP_DESCRIPTION));
+        info.setSummary(value(annotation, PROP_SUMMARY));
         info.setTermsOfService(value(annotation, PROP_TERMS_OF_SERVICE));
         info.setContact(contactIO().read(annotation.value(PROP_CONTACT)));
         info.setLicense(licenseIO().read(annotation.value(PROP_LICENSE)));
@@ -50,6 +52,7 @@ public class InfoIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Info, V
         Info info = new InfoImpl();
         info.setTitle(jsonIO().getString(node, PROP_TITLE));
         info.setDescription(jsonIO().getString(node, PROP_DESCRIPTION));
+        info.setSummary(jsonIO().getString(node, PROP_SUMMARY));
         info.setTermsOfService(jsonIO().getString(node, PROP_TERMS_OF_SERVICE));
         info.setContact(contactIO().readValue(jsonIO().getValue(node, PROP_CONTACT)));
         info.setLicense(licenseIO().readValue(jsonIO().getValue(node, PROP_LICENSE)));
@@ -62,6 +65,7 @@ public class InfoIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Info, V
         return optionalJsonObject(model).map(node -> {
             setIfPresent(node, PROP_TITLE, jsonIO().toJson(model.getTitle()));
             setIfPresent(node, PROP_DESCRIPTION, jsonIO().toJson(model.getDescription()));
+            setIfPresent(node, PROP_SUMMARY, jsonIO().toJson(model.getSummary()));
             setIfPresent(node, PROP_TERMS_OF_SERVICE, jsonIO().toJson(model.getTermsOfService()));
             setIfPresent(node, PROP_CONTACT, contactIO().write(model.getContact()));
             setIfPresent(node, PROP_LICENSE, licenseIO().write(model.getLicense()));

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigExtensionsTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigExtensionsTest.java
@@ -25,6 +25,7 @@ class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
     private static final String TITLE = "mp.openapi.extensions.smallrye.info.title";
     private static final String VERSION = "mp.openapi.extensions.smallrye.info.version";
     private static final String DESCRIPTION = "mp.openapi.extensions.smallrye.info.description";
+    private static final String SUMMARY = "mp.openapi.extensions.smallrye.info.summary";
     private static final String TERMS = "mp.openapi.extensions.smallrye.info.termsOfService";
     private static final String CONTACT_EMAIL = "mp.openapi.extensions.smallrye.info.contact.email";
     private static final String CONTACT_NAME = "mp.openapi.extensions.smallrye.info.contact.name";
@@ -85,10 +86,10 @@ class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
 
     @Test
     void testSettingAllInfo() throws IOException, JSONException {
-
         System.setProperty(TITLE, "My own awesome REST service");
         System.setProperty(VERSION, "1.2.3");
         System.setProperty(DESCRIPTION, "This service is awesome");
+        System.setProperty(SUMMARY, "This summary is rather boring");
         System.setProperty(TERMS, "The terms is also awesome");
         System.setProperty(CONTACT_EMAIL, "phillip.kruger@redhat.com");
         System.setProperty(CONTACT_NAME, "Phillip Kruger");
@@ -109,6 +110,7 @@ class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
             System.clearProperty(TITLE);
             System.clearProperty(VERSION);
             System.clearProperty(DESCRIPTION);
+            System.clearProperty(SUMMARY);
             System.clearProperty(TERMS);
             System.clearProperty(CONTACT_EMAIL);
             System.clearProperty(CONTACT_NAME);

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testAllInfoViaConfig.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testAllInfoViaConfig.json
@@ -4,6 +4,7 @@
     "title" : "My own awesome REST service",
     "description" : "This service is awesome",
     "termsOfService" : "The terms is also awesome",
+    "summary" : "This summary is rather boring",
     "contact" : {
       "name" : "Phillip Kruger",
       "url" : "https://www.phillip-kruger.com",

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
@@ -50,6 +50,7 @@ class Configs implements SmallryeOpenApiProperties {
     final Property<String> infoTitle;
     final Property<String> infoVersion;
     final Property<String> infoDescription;
+    final Property<String> infoSummary;
     final Property<String> infoTermsOfService;
     final Property<String> infoContactEmail;
     final Property<String> infoContactName;
@@ -84,6 +85,7 @@ class Configs implements SmallryeOpenApiProperties {
         infoTitle = objects.property(String.class);
         infoVersion = objects.property(String.class);
         infoDescription = objects.property(String.class);
+        infoSummary = objects.property(String.class);
         infoTermsOfService = objects.property(String.class);
         infoContactEmail = objects.property(String.class);
         infoContactName = objects.property(String.class);
@@ -119,6 +121,7 @@ class Configs implements SmallryeOpenApiProperties {
         infoTitle = objects.property(String.class).convention(ext.getInfoTitle());
         infoVersion = objects.property(String.class).convention(ext.getInfoVersion());
         infoDescription = objects.property(String.class).convention(ext.getInfoDescription());
+        infoSummary = objects.property(String.class).convention(ext.getInfoSummary());
         infoTermsOfService = objects.property(String.class).convention(ext.getInfoTermsOfService());
         infoContactEmail = objects.property(String.class).convention(ext.getInfoContactEmail());
         infoContactName = objects.property(String.class).convention(ext.getInfoContactName());
@@ -177,6 +180,7 @@ class Configs implements SmallryeOpenApiProperties {
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_TITLE, infoTitle);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_VERSION, infoVersion);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_DESCRIPTION, infoDescription);
+        addToPropertyMap(cp, SmallRyeOASConfig.INFO_SUMMARY, infoSummary);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_TERMS, infoTermsOfService);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_CONTACT_EMAIL, infoContactEmail);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_CONTACT_NAME, infoContactName);
@@ -287,6 +291,10 @@ class Configs implements SmallryeOpenApiProperties {
 
     public Property<String> getInfoDescription() {
         return infoDescription;
+    }
+
+    public Property<String> getInfoSummary() {
+        return infoSummary;
     }
 
     public Property<String> getInfoTermsOfService() {

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiProperties.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiProperties.java
@@ -103,6 +103,8 @@ public interface SmallryeOpenApiProperties {
 
     Property<String> getInfoDescription();
 
+    Property<String> getInfoSummary();
+
     Property<String> getInfoTermsOfService();
 
     Property<String> getInfoContactEmail();

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
@@ -373,6 +373,13 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
     @Input
     @Optional
     @Override
+    public Property<String> getInfoSummary() {
+        return properties.infoSummary;
+    }
+
+    @Input
+    @Optional
+    @Override
     public Property<String> getInfoContactEmail() {
         return properties.infoContactEmail;
     }

--- a/tools/gradle-plugin/src/test/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPluginTest.java
+++ b/tools/gradle-plugin/src/test/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPluginTest.java
@@ -297,6 +297,7 @@ class SmallryeOpenApiPluginTest {
             assertThat(info).isNotNull();
             assertThat(info.get("title").asText()).isEqualTo("Info Title");
             assertThat(info.get("description").asText()).isEqualTo("Info Description");
+            assertThat(info.get("summary").asText()).isEqualTo("Info Summary");
             assertThat(info.get("termsOfService").asText()).isEqualTo("Info TOS");
             assertThat(info.get("version").asText()).isEqualTo("Info Version");
             assertThat(info.get("contact").get("email").asText()).isEqualTo("Info Email");

--- a/tools/gradle-plugin/src/test/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPluginTest.java
+++ b/tools/gradle-plugin/src/test/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPluginTest.java
@@ -82,6 +82,7 @@ class SmallryeOpenApiPluginTest {
         ext.infoLicenseUrl.set("info-license-url");
         ext.infoTermsOfService.set("info-tos");
         ext.infoTitle.set("info-title");
+        ext.infoSummary.set("info-summary");
         ext.infoVersion.set("info-version");
         ext.modelReader.set("model-reader");
         ext.operationIdStrategy.set(OperationIdStrategy.CLASS_METHOD);
@@ -112,6 +113,7 @@ class SmallryeOpenApiPluginTest {
                 SmallryeOpenApiProperties::getInfoDescription,
                 SmallryeOpenApiProperties::getInfoLicenseName,
                 SmallryeOpenApiProperties::getInfoLicenseUrl,
+                SmallryeOpenApiProperties::getInfoSummary,
                 SmallryeOpenApiProperties::getInfoTermsOfService,
                 SmallryeOpenApiProperties::getInfoTitle,
                 SmallryeOpenApiProperties::getInfoVersion,
@@ -199,6 +201,7 @@ class SmallryeOpenApiPluginTest {
                         "  infoVersion.set(\"Info Version\")",
                         "  infoDescription.set(\"Info Description\")",
                         "  infoTermsOfService.set(\"Info TOS\")",
+                        "  infoSummary.set(\"Info Summary\")",
                         "  infoContactEmail.set(\"Info Email\")",
                         "  infoContactName.set(\"Info Contact\")",
                         "  infoContactUrl.set(\"https://github.com/smallrye/smallrye-open-api/issues/1231\")",

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
@@ -190,6 +190,9 @@ public class GenerateSchemaMojo extends AbstractMojo {
     @Parameter(property = "infoDescription")
     private String infoDescription;
 
+    @Parameter(property = "infoSummary")
+    private String infoSummary;
+
     @Parameter(property = "infoTermsOfService")
     private String infoTermsOfService;
 
@@ -357,6 +360,7 @@ public class GenerateSchemaMojo extends AbstractMojo {
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_TITLE, infoTitle);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_VERSION, infoVersion);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_DESCRIPTION, infoDescription);
+        addToPropertyMap(cp, SmallRyeOASConfig.INFO_SUMMARY, infoSummary);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_TERMS, infoTermsOfService);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_CONTACT_EMAIL, infoContactEmail);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_CONTACT_NAME, infoContactName);

--- a/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/BasicIT.java
+++ b/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/BasicIT.java
@@ -39,6 +39,7 @@ public class BasicIT extends SchemaTestBase {
             assertEquals(properties.get("infoTitle"), schema.getInfo().getTitle());
             assertEquals(properties.get("infoDescription"), schema.getInfo().getDescription());
             assertEquals(properties.get("infoTermsOfService"), schema.getInfo().getTermsOfService());
+            assertEquals(properties.get("infoSummary"), schema.getInfo().getSummary());
             assertEquals(properties.get("infoContactName"), schema.getInfo().getContact().getName());
             assertEquals(properties.get("infoContactUrl"), schema.getInfo().getContact().getUrl());
             assertEquals(properties.get("infoContactEmail"), schema.getInfo().getContact().getEmail());


### PR DESCRIPTION
This is part of the schema changes under https://github.com/eclipse/microprofile-open-api/issues/584

Specifically it adds the attribute `summary` to the annotation `Info`, as per this issue https://github.com/eclipse/microprofile-open-api/issues/435

I built these changes on a branch including the commits in this PR: https://github.com/smallrye/smallrye-open-api/pull/1801 - I don't think this PR depends on it, but I plan to wait for those commits to be delivered and main-4.0 to be in a compilable state for testing.