### PR TITLE
Support identifier field in licence objects

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -229,6 +229,10 @@ public interface OpenApiConfig {
         return getConfigValue(SmallRyeOASConfig.INFO_LICENSE_NAME, String.class, () -> null);
     }
 
+    default String getInfoLicenseIdentifier() {
+        return getConfigValue(SmallRyeOASConfig.INFO_LICENSE_IDENTIFIER, String.class, () -> null);
+    }
+
     default String getInfoLicenseUrl() {
         return getConfigValue(SmallRyeOASConfig.INFO_LICENSE_URL, String.class, () -> null);
     }

--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOASConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOASConfig.java
@@ -68,6 +68,7 @@ public final class SmallRyeOASConfig {
     public static final String INFO_CONTACT_NAME = SMALLRYE_PREFIX + "info.contact.name";
     public static final String INFO_CONTACT_URL = SMALLRYE_PREFIX + "info.contact.url";
     public static final String INFO_LICENSE_NAME = SMALLRYE_PREFIX + "info.license.name";
+    public static final String INFO_LICENSE_IDENTIFIER = SMALLRYE_PREFIX + "info.license.identifier";
     public static final String INFO_LICENSE_URL = SMALLRYE_PREFIX + "info.license.url";
     public static final String OPERATION_ID_STRAGEGY = SMALLRYE_PREFIX + "operationIdStrategy";
     public static final String DUPLICATE_OPERATION_ID_BEHAVIOR = SMALLRYE_PREFIX + "duplicateOperationIdBehavior";

--- a/core/src/main/java/io/smallrye/openapi/api/models/info/LicenseImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/info/LicenseImpl.java
@@ -12,6 +12,7 @@ public class LicenseImpl extends ExtensibleImpl<License> implements License, Mod
 
     private String name;
     private String url;
+    private String identifier;
 
     /**
      * @see org.eclipse.microprofile.openapi.models.info.License#getName()
@@ -43,6 +44,22 @@ public class LicenseImpl extends ExtensibleImpl<License> implements License, Mod
     @Override
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    /**
+     * @see org.eclipse.microprofile.openapi.models.info.License#getIdentifier()
+     */
+    @Override
+    public String getIdentifier() {
+        return this.identifier;
+    }
+
+    /**
+     * @see org.eclipse.microprofile.openapi.models.info.License#setIdentifier(java.lang.String)
+     */
+    @Override
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
     }
 
 }

--- a/core/src/main/java/io/smallrye/openapi/api/util/ConfigUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/api/util/ConfigUtil.java
@@ -84,6 +84,7 @@ public class ConfigUtil {
                 config.getInfoLicenseName(),
                 config.getInfoLicenseUrl())) {
             setIfPresent(config.getInfoLicenseName(), oai.getInfo().getLicense()::setName);
+            setIfPresent(config.getInfoLicenseIdentifier(), oai.getInfo().getLicense()::setIdentifier);
             setIfPresent(config.getInfoLicenseUrl(), oai.getInfo().getLicense()::setUrl);
         }
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/info/LicenseIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/info/LicenseIO.java
@@ -15,6 +15,7 @@ public class LicenseIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Lice
 
     private static final String PROP_NAME = "name";
     private static final String PROP_URL = "url";
+    private static final String PROP_IDENTIFIER = "identifier";
 
     public LicenseIO(IOContext<V, A, O, AB, OB> context) {
         super(context, Names.LICENSE, Names.create(License.class));
@@ -26,6 +27,7 @@ public class LicenseIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Lice
         License license = new LicenseImpl();
         license.setName(value(annotation, PROP_NAME));
         license.setUrl(value(annotation, PROP_URL));
+        license.setIdentifier(value(annotation, PROP_IDENTIFIER));
         license.setExtensions(extensionIO().readExtensible(annotation));
         return license;
     }
@@ -36,6 +38,7 @@ public class LicenseIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Lice
         License license = new LicenseImpl();
         license.setName(jsonIO().getString(node, PROP_NAME));
         license.setUrl(jsonIO().getString(node, PROP_URL));
+        license.setIdentifier(jsonIO().getString(node, PROP_IDENTIFIER));
         license.setExtensions(extensionIO().readMap(node));
         return license;
     }
@@ -44,6 +47,7 @@ public class LicenseIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Lice
         return optionalJsonObject(model).map(node -> {
             setIfPresent(node, PROP_NAME, jsonIO().toJson(model.getName()));
             setIfPresent(node, PROP_URL, jsonIO().toJson(model.getUrl()));
+            setIfPresent(node, PROP_IDENTIFIER, jsonIO().toJson(model.getIdentifier()));
             setAllIfPresent(node, extensionIO().write(model));
             return node;
         }).map(jsonIO()::buildObject);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigExtensionsTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ConfigExtensionsTest.java
@@ -31,6 +31,7 @@ class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
     private static final String CONTACT_NAME = "mp.openapi.extensions.smallrye.info.contact.name";
     private static final String CONTACT_URL = "mp.openapi.extensions.smallrye.info.contact.url";
     private static final String LICENSE_NAME = "mp.openapi.extensions.smallrye.info.license.name";
+    private static final String LICENSE_IDENTIFIER = "mp.openapi.extensions.smallrye.info.license.identifier";
     private static final String LICENSE_URL = "mp.openapi.extensions.smallrye.info.license.url";
 
     @Test
@@ -68,8 +69,9 @@ class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
     }
 
     @Test
-    void testSettingJustLicenseName() throws IOException, JSONException {
+    void testSettingJustLicenseNameAndIdentifier() throws IOException, JSONException {
         System.setProperty(LICENSE_NAME, "Apache License 2.0");
+        System.setProperty(LICENSE_IDENTIFIER, "Apache-2.0");
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfig.fromConfig(config);
         try {
@@ -81,6 +83,7 @@ class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
 
         } finally {
             System.clearProperty(LICENSE_NAME);
+            System.clearProperty(LICENSE_IDENTIFIER);
         }
     }
 
@@ -96,6 +99,7 @@ class ConfigExtensionsTest extends JaxRsDataObjectScannerTestBase {
         System.setProperty(CONTACT_URL, "https://www.phillip-kruger.com");
         System.setProperty(LICENSE_NAME, "Apache License 2.0");
         System.setProperty(LICENSE_URL, "https://choosealicense.com/licenses/apache-2.0/");
+        //Licence Identifier excluded for being exclusive with URL
 
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = OpenApiConfig.fromConfig(config);

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testLicenseNameViaConfig.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testLicenseNameViaConfig.json
@@ -4,7 +4,8 @@
     "title" : "Generated API",
     "version" : "1.0",
     "license" : {
-            "name" : "Apache License 2.0"
+            "name" : "Apache License 2.0",
+            "identifier" : "Apache-2.0"
     }    
   },
   "paths" : {

--- a/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/BasicIT.java
+++ b/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/BasicIT.java
@@ -44,8 +44,9 @@ public class BasicIT extends SchemaTestBase {
             assertEquals(properties.get("infoContactUrl"), schema.getInfo().getContact().getUrl());
             assertEquals(properties.get("infoContactEmail"), schema.getInfo().getContact().getEmail());
             assertEquals(properties.get("infoLicenseName"), schema.getInfo().getLicense().getName());
-            assertEquals(properties.get("infoLicenseUrl"),
-                    schema.getInfo().getLicense().getUrl());
+            assertEquals(properties.get("infoLicenseIdentifier"),
+                    schema.getInfo().getLicense().getIdentifier());
+            //The URL is not tested here due to being exclusive with Identifier
             assertEquals(properties.get("infoVersion"), schema.getInfo().getVersion());
 
             List<String> servers = schema.getServers().stream().map(Server::getUrl).collect(Collectors.toList());


### PR DESCRIPTION
This keeps smallrye up to date with the spec change implemented here: https://github.com/eclipse/microprofile-open-api/issues/436

And this PR depends on https://github.com/eclipse/microprofile-open-api/pull/611

I investigated to see if [PathItem](https://spec.openapis.org/oas/v3.1.0.html#path-item-object] parameters had any code to emit a warning or exception if the constraint is violated and could not find one so I did not add anything to enforce the exclusivity of URL and Identifier. Let me know if I missed something.

For the test I used the maven plugin test to ensure one plugin tests each of the URL and identifier without violating the constraint, let me know if you'd prefer both test both