### PR TITLE
Implement webhooks model

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/models/OpenAPIImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/OpenAPIImpl.java
@@ -1,11 +1,14 @@
 package io.smallrye.openapi.api.models;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.Paths;
 import org.eclipse.microprofile.openapi.models.info.Info;
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
@@ -26,6 +29,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Mod
     private List<SecurityRequirement> security;
     private List<Tag> tags;
     private Paths paths;
+    private Map<String, PathItem> webhooks;
     private Components components;
 
     /**
@@ -225,5 +229,26 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Mod
     @Override
     public void setComponents(Components components) {
         this.components = components;
+    }
+
+    @Override
+    public Map<String, PathItem> getWebhooks() {
+        return ModelUtil.unmodifiableMap(this.webhooks);
+    }
+
+    @Override
+    public void setWebhooks(Map<String, PathItem> webhooks) {
+        this.webhooks = ModelUtil.replace(webhooks, LinkedHashMap<String, PathItem>::new);
+    }
+
+    @Override
+    public OpenAPI addWebhook(String name, PathItem webhook) {
+        this.webhooks = ModelUtil.add(name, webhook, this.webhooks, LinkedHashMap<String, PathItem>::new);
+        return this;
+    }
+
+    @Override
+    public void removeWebhook(String name) {
+        ModelUtil.remove(this.webhooks, name);
     }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/OpenAPIDefinitionIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/OpenAPIDefinitionIO.java
@@ -19,6 +19,7 @@ public class OpenAPIDefinitionIO<V, A extends V, O extends V, AB, OB> extends Mo
     public static final String PROP_SECURITY_SETS = "securitySets";
     public static final String PROP_SERVERS = "servers";
     public static final String PROP_TAGS = "tags";
+    public static final String PROP_WEBHOOKS = "webhooks";
 
     public OpenAPIDefinitionIO(IOContext<V, A, O, AB, OB> context) {
         super(context, Names.OPENAPI_DEFINITION, Names.create(OpenAPI.class));
@@ -60,6 +61,7 @@ public class OpenAPIDefinitionIO<V, A extends V, O extends V, AB, OB> extends Mo
         openApi.setExternalDocs(extDocIO().readValue(jsonIO().getValue(node, PROP_EXTERNAL_DOCS)));
         openApi.setComponents(componentsIO().readValue(jsonIO().getValue(node, PROP_COMPONENTS)));
         openApi.setPaths(pathsIO().readValue(jsonIO().getValue(node, PROP_PATHS)));
+        openApi.setWebhooks(pathItemIO().readMap(jsonIO().getValue(node, PROP_WEBHOOKS)));
         openApi.setExtensions(extensionIO().readMap(node));
         return openApi;
     }
@@ -74,6 +76,7 @@ public class OpenAPIDefinitionIO<V, A extends V, O extends V, AB, OB> extends Mo
             setIfPresent(node, PROP_SECURITY, securityIO().write(model.getSecurity()));
             setIfPresent(node, PROP_TAGS, tagIO().write(model.getTags()));
             setIfPresent(node, PROP_PATHS, pathsIO().write(model.getPaths()));
+            setIfPresent(node, PROP_WEBHOOKS, pathItemIO().write(model.getWebhooks()));
             setIfPresent(node, PROP_COMPONENTS, componentsIO().write(model.getComponents()));
             setAllIfPresent(node, extensionIO().write(model));
             return node;

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/PathItemIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/PathItemIO.java
@@ -14,7 +14,7 @@ import org.jboss.jandex.AnnotationInstance;
 
 import io.smallrye.openapi.api.models.PathItemImpl;
 
-public class PathItemIO<V, A extends V, O extends V, AB, OB> extends ModelIO<PathItem, V, A, O, AB, OB>
+public class PathItemIO<V, A extends V, O extends V, AB, OB> extends MapModelIO<PathItem, V, A, O, AB, OB>
         implements ReferenceIO<V, A, O, AB, OB> {
 
     private static final String PROP_DESCRIPTION = "description";


### PR DESCRIPTION
- Note that I haven't made a `WebhookIO` class.
  - For the model, the new `webhooks` property just holds a `Map<String, PathItem>`
  - For the annotation, a `@Webhook` annotation represents one entry in that map. Since the value is a `PathItem`, I added it to `PathItemIO`. I could make a new IO class for it instead, though there's no model object to read and write to JSON.
- I haven't added any tests here because I think the TCK tests are sufficient.

Implements eclipse/microprofile-open-api#612

~In order to pass the TCK locally, I also have to merge in #1818 because that implements eclipse/microprofile-open-api#604 which has already been merged.~