### PR TITLE
Bump MicroProfile OpenAPI spec to 4.0-RC1, disable older TCKs jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,10 +88,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - tck-version: "2.0.1"
-        - tck-version: "3.0"
-        - tck-version: "3.1.1"
-        - tck-version: "4.0-SNAPSHOT"
+        # Disable older TCK jobs prior to 4.0 GA release 
+        #- tck-version: "2.0.1"
+        #- tck-version: "3.0"
+        #- tck-version: "3.1.1"
+        - tck-version: "4.0-RC1"
 
     name: MicroProfile OpenAPI TCK ${{ matrix.tck-version }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - tck-version: "2.0.1"
-        - tck-version: "3.0"
-        - tck-version: "3.1.1"
+        # Disable older TCK jobs prior to 4.0 GA release
+        #- tck-version: "2.0.1"
+        #- tck-version: "3.0"
+        #- tck-version: "3.1.1"
+        - tck-version: "4.0-RC1"
 
     name: MicroProfile OpenAPI TCK ${{ matrix.tck-version }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <version.eclipse.microprofile.config>3.0.3</version.eclipse.microprofile.config>
         <version.io.smallrye.jandex>3.2.0</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-config>3.8.2</version.io.smallrye.smallrye-config>
-        <version.eclipse.microprofile.openapi>4.0-SNAPSHOT</version.eclipse.microprofile.openapi>
+        <version.eclipse.microprofile.openapi>4.0-RC1</version.eclipse.microprofile.openapi>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.1</version.org.skyscreamer>

--- a/testsuite/data/pom.xml
+++ b/testsuite/data/pom.xml
@@ -13,7 +13,7 @@
     <name>SmallRye: OpenAPI Test Data</name>
 
     <properties>
-        <eclipse.microprofile.openapi.version>4.0-SNAPSHOT</eclipse.microprofile.openapi.version>
+        <eclipse.microprofile.openapi.version>4.0-RC1</eclipse.microprofile.openapi.version>
         <kotlin.version>2.0.0</kotlin.version>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
Targets `main-4.0` branch