### PR TITLE
Enable selection of annotation scanners (#1370) via maven plugin config.

### DIFF
--- a/tools/maven-plugin/README.adoc
+++ b/tools/maven-plugin/README.adoc
@@ -66,6 +66,7 @@ E.g. for includeDependenciesScopes could be configured as:
 - `skip` (boolean, default: false) - Skip execution of the plugin.
 - `encoding` (String) - Encoding of output OpenAPI files.
 - `outputFileTypeFilter` (String, default: ALL) - Set this to `YAML` in order to let the generation process produce just *.yaml output, `JSON` to obtain *.json files only. The default is `ALL`, which will generate both file types.
+- `scanners` (List<String>) - To set the names of the AnnotationScanner implementations that should be executed.
 
 == MicroProfile OpenAPI Properties
 

--- a/tools/maven-plugin/README.adoc
+++ b/tools/maven-plugin/README.adoc
@@ -66,7 +66,7 @@ E.g. for includeDependenciesScopes could be configured as:
 - `skip` (boolean, default: false) - Skip execution of the plugin.
 - `encoding` (String) - Encoding of output OpenAPI files.
 - `outputFileTypeFilter` (String, default: ALL) - Set this to `YAML` in order to let the generation process produce just *.yaml output, `JSON` to obtain *.json files only. The default is `ALL`, which will generate both file types.
-- `scanners` (List<String>) - To set the names of the AnnotationScanner implementations that should be executed.
+- `scanners` (List<String>) - Names of the AnnotationScanner implementations that should be executed. If omitted or an empty list, all scanners will be executed. The names of the scanners available by default are `JAX-RS`, `Spring`, and `Vert.x`.
 
 == MicroProfile OpenAPI Properties
 

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
@@ -100,6 +100,12 @@ public class GenerateSchemaMojo extends AbstractMojo {
     @Parameter(property = "configProperties")
     private File configProperties;
 
+    /**
+     * Configuration property to specify the list of scanners to use. If the list is empty the default scanners are used.
+     */
+    @Parameter(property = "scanners")
+    private List<String> scanners;
+
     // Properies as per OpenAPI Config.
 
     /**
@@ -295,6 +301,7 @@ public class GenerateSchemaMojo extends AbstractMojo {
                 .withConfig(config)
                 .withApplicationClassLoader(getClassLoader())
                 .withIndex(index)
+                .withScannerFilter(scanners != null && !scanners.isEmpty() ? x -> scanners.contains(x) : x -> true)
                 .build();
     }
 


### PR DESCRIPTION
Hi,

this PR adds the capability to configure which annotation scanners should be executed (as noted in #1370).