### PR TITLE
Ignore JavaBean method prefixes when method name matches field name

### DIFF
--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -789,4 +789,35 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
 
         assertJsonEquals("components.schemas.exceptional-examples.json", Bean.class);
     }
+
+    @Test
+    void testPropertyWithJavaBeanPrefixes() throws IOException, JSONException {
+        @Schema(name = "Bean")
+        @SuppressWarnings("unused")
+        class Bean {
+            @Schema(name = "getProperty1")
+            public String getProperty1;
+
+            @Schema(name = "propertyTwo")
+            public String getProperty2;
+
+            public String getProperty1() {
+                return getProperty1;
+            }
+
+            public void getProperty1(String getProperty1) {
+                this.getProperty1 = getProperty1;
+            }
+
+            public String getProperty2() {
+                return getProperty2;
+            }
+
+            public void getProperty2(String getProperty2) {
+                this.getProperty2 = getProperty2;
+            }
+        }
+
+        assertJsonEquals("components.schemas.javabean-property-prefix.json", Bean.class);
+    }
 }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.javabean-property-prefix.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.javabean-property-prefix.json
@@ -1,0 +1,18 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "Bean" : {
+        "type" : "object",
+        "properties" : {
+          "getProperty1" : {
+            "type" : "string"
+          },
+          "propertyTwo" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1927 