### PR TITLE
Find `@RequestBody` annotations by argument index instead of type

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/parameters/RequestBodyIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/parameters/RequestBodyIO.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.eclipse.microprofile.openapi.models.media.Content;
@@ -43,9 +44,8 @@ public class RequestBodyIO<V, A extends V, O extends V, AB, OB> extends MapModel
 
     Stream<AnnotationInstance> getAnnotations(MethodInfo method, DotName annotation) {
         Stream<AnnotationInstance> methodAnnos = Stream.of(scannerContext().annotations().getAnnotation(method, annotation));
-        Stream<AnnotationInstance> paramAnnos = method.parameterTypes()
-                .stream()
-                .map(p -> scannerContext().annotations().getMethodParameterAnnotation(method, p, annotation));
+        Stream<AnnotationInstance> paramAnnos = IntStream.range(0, method.parametersCount())
+                .mapToObj(p -> scannerContext().annotations().getMethodParameterAnnotation(method, p, annotation));
 
         return Stream.concat(methodAnnos, paramAnnos)
                 .filter(Objects::nonNull);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/RequestBodyScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/RequestBodyScanTests.java
@@ -3,6 +3,7 @@ package io.smallrye.openapi.runtime.scanner;
 import java.io.IOException;
 import java.util.HashMap;
 
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
@@ -103,5 +104,23 @@ class RequestBodyScanTests extends IndexScannerTestBase {
             }
         }
         test("params.request-body-constraints.json", Resource.class);
+    }
+
+    @Test
+    void testResponseAnnotationUsed() throws IOException, JSONException {
+        @jakarta.ws.rs.Path("foo")
+        class FooApi {
+            @jakarta.ws.rs.PUT
+            @jakarta.ws.rs.Path("{name}/bar")
+            @jakarta.ws.rs.Consumes("text/plain")
+            @jakarta.ws.rs.Produces("application/json")
+            public jakarta.ws.rs.core.Response putDescription(
+                    @Parameter(description = "The name", required = true) @jakarta.ws.rs.PathParam("name") String name,
+                    @RequestBody(description = "The description", required = true) String description) {
+                return null;
+            }
+        }
+
+        assertJsonEquals("params.request-body-annotation-on-arg.json", FooApi.class);
     }
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.request-body-annotation-on-arg.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.request-body-annotation-on-arg.json
@@ -1,0 +1,34 @@
+{
+  "openapi" : "3.1.0",
+  "paths" : {
+    "/foo/{name}/bar" : {
+      "put" : {
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "description" : "The name",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The description",
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
For quarkusio/quarkus#43338