### PR TITLE
Index Java runtime classes in Maven and Gradle plugins

### DIFF
--- a/tools/gradle-plugin/build.gradle
+++ b/tools/gradle-plugin/build.gradle
@@ -6,14 +6,10 @@ plugins {
 
 group = "io.smallrye"
 
-if (JavaVersion.current().isJava9Compatible()) {
-    compileJava.options.compilerArgs.addAll(['--release', '8'])
-}
-
 compileJava {
     options.encoding = 'UTF-8'
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+    sourceCompatibility = '11'
+    targetCompatibility = '11'
 }
 
 compileTestJava {

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
@@ -64,6 +64,7 @@ class Configs implements SmallryeOpenApiProperties {
     final MapProperty<String, String> scanResourceClasses;
     final Property<String> outputFileTypeFilter;
     final Property<String> encoding;
+    final ListProperty<String> includeStandardJavaModules;
 
     Configs(ObjectFactory objects) {
         configProperties = objects.fileProperty();
@@ -99,6 +100,7 @@ class Configs implements SmallryeOpenApiProperties {
         scanResourceClasses = objects.mapProperty(String.class, String.class);
         outputFileTypeFilter = objects.property(String.class).convention("ALL");
         encoding = objects.property(String.class).convention(StandardCharsets.UTF_8.name());
+        includeStandardJavaModules = objects.listProperty(String.class);
     }
 
     Configs(ObjectFactory objects, SmallryeOpenApiExtension ext) {
@@ -137,6 +139,7 @@ class Configs implements SmallryeOpenApiProperties {
         scanResourceClasses = objects.mapProperty(String.class, String.class).convention(ext.getScanResourceClasses());
         outputFileTypeFilter = objects.property(String.class).convention(ext.getOutputFileTypeFilter());
         encoding = objects.property(String.class).convention(ext.getEncoding());
+        includeStandardJavaModules = objects.listProperty(String.class).convention(ext.getIncludeStandardJavaModules());
     }
 
     Config asMicroprofileConfig() {
@@ -349,4 +352,7 @@ class Configs implements SmallryeOpenApiProperties {
         return encoding;
     }
 
+    public ListProperty<String> getIncludeStandardJavaModules() {
+        return includeStandardJavaModules;
+    }
 }

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiProperties.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiProperties.java
@@ -151,4 +151,9 @@ public interface SmallryeOpenApiProperties {
      * Output encoding for openapi document.
      */
     Property<String> getEncoding();
+
+    /**
+     * List of standard Java modules that should be made available to annotation scanning for introspection.
+     */
+    ListProperty<String> getIncludeStandardJavaModules();
 }

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
@@ -14,8 +14,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -33,6 +31,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
@@ -93,19 +92,23 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
     public void generate() {
         try {
             clearOutput();
-
-            Set<File> dependencies = properties.scanDependenciesDisable.get().booleanValue()
-                    ? Collections.emptySet()
-                    : classpath.getFiles();
-
-            IndexView index = new GradleDependencyIndexCreator(getLogger()).createIndex(dependencies,
-                    classesDirs);
+            IndexView index = new GradleDependencyIndexCreator(getLogger()).createIndex(this);
             SmallRyeOpenAPI openAPI = generateOpenAPI(index, resourcesSrcDirs);
             write(openAPI);
         } catch (Exception ex) {
             // allow failOnError = false ?
             throw new GradleException("Could not generate OpenAPI Schema", ex);
         }
+    }
+
+    @Internal
+    FileCollection getClasspath() {
+        return this.classpath;
+    }
+
+    @Internal
+    FileCollection getClassesDirs() {
+        return this.classesDirs;
     }
 
     private SmallRyeOpenAPI generateOpenAPI(IndexView index, FileCollection resourcesSrcDirs) {
@@ -459,5 +462,12 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
     @Override
     public Property<String> getEncoding() {
         return properties.encoding;
+    }
+
+    @Input
+    @Optional
+    @Override
+    public ListProperty<String> getIncludeStandardJavaModules() {
+        return properties.includeStandardJavaModules;
     }
 }

--- a/tools/gradle-plugin/src/test/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPluginTest.java
+++ b/tools/gradle-plugin/src/test/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiPluginTest.java
@@ -21,10 +21,13 @@ import org.gradle.api.provider.Provider;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 import io.smallrye.openapi.api.OpenApiConfig.OperationIdStrategy;
 
@@ -138,7 +141,7 @@ class SmallryeOpenApiPluginTest {
     }
 
     @Test
-    void simpleProject(@TempDir Path buildDir) throws Exception {
+    void simpleProject(@TempDir(cleanup = CleanupMode.ON_SUCCESS) Path buildDir) throws Exception {
         // "Simple" Gradle project
         smokeProject(buildDir, false, SmallryeOpenApiPlugin.TASK_NAME);
     }
@@ -156,13 +159,13 @@ class SmallryeOpenApiPluginTest {
     }
 
     @Test
-    void quarkusProjectGenApiOnly(@TempDir Path buildDir) throws Exception {
+    void quarkusProjectGenApiOnly(@TempDir(cleanup = CleanupMode.ON_SUCCESS) Path buildDir) throws Exception {
         // Quarkus Gradle project, just call the generateOpenApiSpec task
         smokeProject(buildDir, true, SmallryeOpenApiPlugin.TASK_NAME);
     }
 
     @Test
-    void quarkusProject(@TempDir Path buildDir) throws Exception {
+    void quarkusProject(@TempDir(cleanup = CleanupMode.ON_SUCCESS) Path buildDir) throws Exception {
         // Quarkus Gradle project, perform a "full Quarkus build"
         smokeProject(buildDir, true, "quarkusBuild");
     }
@@ -190,8 +193,8 @@ class SmallryeOpenApiPluginTest {
                         "}",
                         "",
                         "dependencies {",
-                        "  implementation(\"javax.ws.rs:javax.ws.rs-api:2.1.1\")",
-                        "  implementation(\"org.eclipse.microprofile.openapi:microprofile-openapi-api:3.0\")",
+                        "  implementation(\"jakarta.ws.rs:jakarta.ws.rs-api:3.1.0\")",
+                        "  implementation(\"org.eclipse.microprofile.openapi:microprofile-openapi-api:4.0.1\")",
                         "}",
                         "",
                         "smallryeOpenApi {",
@@ -210,6 +213,7 @@ class SmallryeOpenApiPluginTest {
                         "  operationIdStrategy.set(OperationIdStrategy.METHOD)",
                         "  filter.set(\"testcases.CustomOASFilter\")",
                         "  outputFileTypeFilter.set(\"" + outputFileTypeFilter + "\")",
+                        "  includeStandardJavaModules.set([ \"java.base\" ])",
                         "}"));
 
         Path javaDir = Paths.get("src/main/java/testcases");
@@ -218,12 +222,13 @@ class SmallryeOpenApiPluginTest {
         Files.write(buildDir.resolve(javaDir.resolve("DummyJaxRs.java")),
                 asList("package testcases;",
                         "",
-                        "import javax.ws.rs.GET;",
-                        "import javax.ws.rs.Path;",
-                        "import javax.ws.rs.Produces;",
-                        "import javax.ws.rs.core.MediaType;",
+                        "import jakarta.ws.rs.GET;",
+                        "import jakarta.ws.rs.Path;",
+                        "import jakarta.ws.rs.Produces;",
+                        "import jakarta.ws.rs.core.MediaType;",
                         "import org.eclipse.microprofile.openapi.annotations.Operation;",
                         "import org.eclipse.microprofile.openapi.annotations.media.Content;",
+                        "import org.eclipse.microprofile.openapi.annotations.media.Schema;",
                         "import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;",
                         "import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;",
                         "",
@@ -235,10 +240,11 @@ class SmallryeOpenApiPluginTest {
                         "    @APIResponses({",
                         "      @APIResponse(",
                         "          description = \"Dummy get thing.\",",
-                        "          content = @Content(mediaType = \"application/text\")",
+                        "          content = @Content(mediaType = \"application/text\",",
+                        "                             schema = @Schema(implementation = java.util.concurrent.TimeUnit.class))",
                         "      )})",
-                        "    public String dummyThing() {",
-                        "        return \"foo\";",
+                        "    public java.util.concurrent.TimeUnit dummyThing() {",
+                        "        return java.util.concurrent.TimeUnit.HOURS;",
                         "    }",
                         "}"));
 
@@ -309,6 +315,9 @@ class SmallryeOpenApiPluginTest {
 
             JsonNode paths = root.get("paths");
             assertThat(paths.get("/mypath").get("get").get("operationId").asText()).isEqualTo("dummyThing");
+
+            JsonNode schemas = root.get("components").get("schemas");
+            assertThat(((ArrayNode) schemas.get("TimeUnit").get("enum"))).contains(new TextNode("HOURS"));
         }
 
         if ("YAML".equals(expectedOutputFileType)) {

--- a/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/openapi/mavenplugin/GenerateSchemaMojo.java
@@ -76,6 +76,13 @@ public class GenerateSchemaMojo extends AbstractMojo {
     private List<String> includeDependenciesTypes;
 
     /**
+     * List of standard Java modules that should be made available to annotation
+     * scanning for introspection.
+     */
+    @Parameter(property = "includeStandardJavaModules")
+    private List<String> includeStandardJavaModules;
+
+    /**
      * Skip execution of the plugin.
      */
     @Parameter(defaultValue = "false", property = "skip")
@@ -279,7 +286,7 @@ public class GenerateSchemaMojo extends AbstractMojo {
         if (!skip) {
             try {
                 IndexView index = mavenDependencyIndexCreator.createIndex(mavenProject, scanDependenciesDisable,
-                        includeDependenciesScopes, includeDependenciesTypes);
+                        includeDependenciesScopes, includeDependenciesTypes, includeStandardJavaModules);
                 SmallRyeOpenAPI openAPI = generateOpenAPI(index);
                 write(openAPI);
             } catch (Exception ex) {

--- a/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/BasicIT.java
+++ b/tools/maven-plugin/src/test/java/io/smallrye/openapi/mavenplugin/BasicIT.java
@@ -55,6 +55,7 @@ public class BasicIT extends SchemaTestBase {
             assertTrue(servers.contains(properties.get("server2").toString()));
 
             assertTrue(schema.getPaths().hasPathItem("/hello"));
+            assertTrue(schema.getComponents().getSchemas().get("TimeUnit").getEnumeration().contains("HOURS"));
         };
 
         testSchema(result, schemaConsumer);

--- a/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/basic_info/pom.xml
+++ b/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/basic_info/pom.xml
@@ -68,6 +68,9 @@
                         </server>
                     </servers>
                     <encoding>UTF-8</encoding>
+                    <includeStandardJavaModules>
+                        <includeStandardJavaModule>java.base</includeStandardJavaModule>
+                    </includeStandardJavaModules>
                 </configuration>
             </plugin>
         </plugins>

--- a/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/basic_info/src/main/java/io/smallrye/example/ExampleResource.java
+++ b/tools/maven-plugin/src/test/resources-its/io/smallrye/openapi/mavenplugin/BasicIT/basic_info/src/main/java/io/smallrye/example/ExampleResource.java
@@ -1,5 +1,7 @@
 package io.smallrye.example;
 
+import java.util.concurrent.TimeUnit;
+
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
@@ -13,4 +15,9 @@ public class ExampleResource {
         return greeting + " world!";
     }
 
+    @GET
+    @Path("/timeunit")
+    public TimeUnit getTimeUnit() {
+        return TimeUnit.HOURS;
+    }
 }


### PR DESCRIPTION
Add options to the Maven and Gradle plugins to index named JDK modules for the annotation scanner.

Closes #1999 