### PR TITLE
Split builder API `build` method to enable downstream optimizations

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
@@ -53,7 +53,7 @@ public class SmallRyeOpenAPI {
     private final BiFunction<? super Object, Format, String> toString;
 
     @SuppressWarnings("unchecked")
-    private SmallRyeOpenAPI(OpenAPI model, Object jsonModel, BiFunction<?, Format, String> toString) {
+    protected SmallRyeOpenAPI(OpenAPI model, Object jsonModel, BiFunction<?, Format, String> toString) {
         this.model = model;
         this.jsonModel = jsonModel;
         this.toString = (BiFunction<? super Object, Format, String>) toString;
@@ -92,6 +92,9 @@ public class SmallRyeOpenAPI {
     public static class Builder {
 
         private static final IndexView EMPTY_INDEX = new Indexer().complete();
+
+        private transient BuildContext<?, ?, ?, ?, ?> buildContext;
+
         private Config config;
         private ClassLoader applicationClassLoader;
         private OpenAPI initialModel;
@@ -118,7 +121,19 @@ public class SmallRyeOpenAPI {
         private boolean enableStandardFilter = true;
         private Map<String, OASFilter> filters = new LinkedHashMap<>();
 
-        private Builder() {
+        protected Builder() {
+        }
+
+        protected void removeContext() {
+            this.buildContext = null;
+        }
+
+        @SuppressWarnings("unchecked")
+        protected <V, A extends V, O extends V, AB, OB> BuildContext<V, A, O, AB, OB> getContext() {
+            if (buildContext == null) {
+                buildContext = new BuildContext<>(this);
+            }
+            return (BuildContext<V, A, O, AB, OB>) buildContext;
         }
 
         /**
@@ -133,6 +148,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withConfig(Config config) {
+            removeContext();
             this.config = Objects.requireNonNull(config);
             return this;
         }
@@ -146,6 +162,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withApplicationClassLoader(ClassLoader classLoader) {
+            removeContext();
             this.applicationClassLoader = Objects.requireNonNull(classLoader);
             return this;
         }
@@ -160,6 +177,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withInitialModel(OpenAPI initialModel) {
+            removeContext();
             this.initialModel = initialModel;
             return this;
         }
@@ -174,6 +192,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder enableModelReader(boolean enableModelReader) {
+            removeContext();
             this.enableModelReader = enableModelReader;
             return this;
         }
@@ -189,6 +208,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder enableStandardStaticFiles(boolean enableStandardStaticFiles) {
+            removeContext();
             this.enableStandardStaticFiles = enableStandardStaticFiles;
             return this;
         }
@@ -203,6 +223,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder enableStandardFilter(boolean enableStandardFilter) {
+            removeContext();
             this.enableStandardFilter = enableStandardFilter;
             return this;
         }
@@ -225,6 +246,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder defaultRequiredProperties(boolean defaultRequiredProperties) {
+            removeContext();
             this.defaultRequiredProperties = defaultRequiredProperties;
             return this;
         }
@@ -240,6 +262,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withResourceLocator(Function<String, URL> resourceLocator) {
+            removeContext();
             this.resourceLocator = resourceLocator;
             return this;
         }
@@ -254,6 +277,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withCustomStaticFile(Supplier<InputStream> customStaticFile) {
+            removeContext();
             this.customStaticFile = Objects.requireNonNull(customStaticFile);
             return this;
         }
@@ -265,6 +289,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withIndex(IndexView index) {
+            removeContext();
             this.index = Objects.requireNonNull(index);
             return this;
         }
@@ -281,6 +306,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withContextRootResolver(Function<Collection<ClassInfo>, String> contextRootResolver) {
+            removeContext();
             this.contextRootResolver = Objects.requireNonNull(contextRootResolver);
             return this;
         }
@@ -295,6 +321,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withTypeConverter(UnaryOperator<Type> typeConverter) {
+            removeContext();
             this.typeConverter = Objects.requireNonNull(typeConverter);
             return this;
         }
@@ -310,6 +337,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withJsonParser(Function<String, Object> jsonParser) {
+            removeContext();
             this.jsonParser = jsonParser;
             return this;
         }
@@ -324,6 +352,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withSchemaParser(Function<String, Schema> schemaParser) {
+            removeContext();
             this.schemaParser = schemaParser;
             return this;
         }
@@ -336,6 +365,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder enableAnnotationScan(boolean enableAnnotationScan) {
+            removeContext();
             this.enableAnnotationScan = enableAnnotationScan;
             return this;
         }
@@ -350,6 +380,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder enableUnannotatedPathParameters(boolean enableUnannotatedPathParameters) {
+            removeContext();
             this.enableUnannotatedPathParameters = enableUnannotatedPathParameters;
             return this;
         }
@@ -369,6 +400,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withScannerClassLoader(ClassLoader scannerClassLoader) {
+            removeContext();
             this.scannerClassLoader = scannerClassLoader;
             return this;
         }
@@ -381,6 +413,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withScannerFilter(Predicate<String> scannerFilter) {
+            removeContext();
             this.scannerFilter = Objects.requireNonNull(scannerFilter);
             return this;
         }
@@ -393,9 +426,10 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withFilters(Collection<OASFilter> filters) {
+            removeContext();
             Objects.requireNonNull(filters);
             this.filters.clear();
-            filters.forEach(filter -> this.filters.put(filter.getClass().getName(), filter));
+            filters.forEach(this::addFilter);
             return this;
         }
 
@@ -413,9 +447,31 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder withFilterNames(Collection<String> filterNames) {
+            removeContext();
             Objects.requireNonNull(filterNames);
-            filters.clear();
-            filterNames.forEach(filter -> this.filters.put(filter, null));
+            this.filters.clear();
+            filterNames.forEach(this::addFilterName);
+            return this;
+        }
+
+        /**
+         * AProvide a collection of OASFilter implementation class names to apply to the final OpenAPI model. New
+         * instances of the named classes will be instantiated immediately using the
+         * {@linkplain ClassLoader} provided. If the given index is null, the filters will be
+         * created with a non-null, empty index.
+         *
+         * The filters will be executed in the same order as given in the collection.
+         *
+         * @param filterNames collection of OASFilter implementation class names
+         * @param classLoader CLassLoader use to load the filter
+         * @param index IndexView passed to the filter, possibly null
+         * @return this builder
+         */
+        public Builder withFilterNames(Collection<String> filterNames, ClassLoader classLoader, IndexView index) {
+            removeContext();
+            Objects.requireNonNull(filterNames);
+            this.filters.clear();
+            filterNames.forEach(name -> this.addFilter(name, classLoader, index));
             return this;
         }
 
@@ -427,6 +483,7 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder addFilter(OASFilter filter) {
+            removeContext();
             Objects.requireNonNull(filter);
             filters.put(filter.getClass().getName(), filter);
             return this;
@@ -446,51 +503,52 @@ public class SmallRyeOpenAPI {
          * @return this builder
          */
         public Builder addFilterName(String filterName) {
+            removeContext();
             Objects.requireNonNull(filterName);
             filters.put(filterName, null);
             return this;
         }
 
         /**
-         * Build a new {@linkplain SmallRyeOpenAPI} instance based on the current state of this builder.
+         * Add an OASFilter implementation class name to apply to the final OpenAPI model. A new
+         * instance of the named class will be instantiated immediately using the
+         * {@linkplain ClassLoader} provided. If the given index is null, the filter will be
+         * created with a non-null, empty index.
          *
-         * @param <V> JSON value type
-         * @param <A> JSON array type
-         * @param <O> JSON object type
-         * @param <AB> JSON array builder type
-         * @param <OB> JSON object builder type
-         * @return a new {@linkplain SmallRyeOpenAPI} instance
+         * Filters will be executed in the order they are added.
+         *
+         * @param filterName OASFilter implementation class name
+         * @param classLoader CLassLoader use to load the filter
+         * @param index IndexView passed to the filter, possibly null
+         * @return this builder
          */
-        public <V, A extends V, O extends V, AB, OB> SmallRyeOpenAPI build() {
-            ClassLoader appClassLoader = applicationClassLoader != null ? applicationClassLoader
-                    : Thread.currentThread().getContextClassLoader();
+        public Builder addFilter(String filterName, ClassLoader classLoader, IndexView index) {
+            removeContext();
+            Objects.requireNonNull(filterName);
+            Objects.requireNonNull(classLoader);
+            OASFilter filter = OpenApiProcessor.getFilter(filterName, classLoader, index != null ? index : EMPTY_INDEX);
+            filters.put(filterName, filter);
+            return this;
+        }
 
-            OpenApiConfig buildConfig = OpenApiConfig.fromConfig(Optional.ofNullable(this.config)
-                    .orElseGet(() -> ConfigProvider.getConfig(appClassLoader)));
-            IOContext<V, A, O, AB, OB> io = IOContext.forJson(JsonIO.newInstance(buildConfig));
-            OpenAPIDefinitionIO<V, A, O, AB, OB> modelIO = new OpenAPIDefinitionIO<>(io);
-            FilteredIndexView filteredIndex = new FilteredIndexView(index, buildConfig);
-
-            OpenAPI readerModel = null;
-            OpenAPI staticModel = null;
-            OpenAPI annotationModel = null;
-            OASFilter standardFilter = null;
-
+        protected void buildReaderModel(BuildContext<?, ?, ?, ?, ?> ctx) {
             if (enableModelReader) {
-                readerModel = OpenApiProcessor.modelFromReader(buildConfig, appClassLoader, filteredIndex);
-                debugModel("reader", readerModel);
+                ctx.readerModel = OpenApiProcessor.modelFromReader(ctx.buildConfig, ctx.appClassLoader, index);
+                debugModel("reader", ctx.readerModel);
             }
+        }
 
+        protected <V, A extends V, O extends V, AB, OB> void buildStaticModel(BuildContext<V, A, O, AB, OB> ctx) {
             if (enableStandardStaticFiles) {
                 Function<String, URL> loadFn = Optional.ofNullable(resourceLocator)
-                        .orElse(appClassLoader::getResource);
+                        .orElse(ctx.appClassLoader::getResource);
 
-                staticModel = OpenApiProcessor.loadOpenApiStaticFiles(loadFn)
+                ctx.staticModel = OpenApiProcessor.loadOpenApiStaticFiles(loadFn)
                         .stream()
                         .map(file -> {
                             try (Reader reader = new InputStreamReader(file.getContent())) {
-                                V dom = io.jsonIO().fromReader(reader, file.getFormat());
-                                OpenAPI fileModel = modelIO.readValue(dom);
+                                V dom = ctx.modelIO.jsonIO().fromReader(reader, file.getFormat());
+                                OpenAPI fileModel = ctx.modelIO.readValue(dom);
                                 debugModel("static file", fileModel);
                                 return fileModel;
                             } catch (IOException e) {
@@ -506,56 +564,123 @@ public class SmallRyeOpenAPI {
 
             if (customFile != null) {
                 try (Reader reader = new InputStreamReader(customFile)) {
-                    V dom = io.jsonIO().fromReader(reader);
-                    OpenAPI customStaticModel = modelIO.readValue(dom);
+                    V dom = ctx.modelIO.jsonIO().fromReader(reader);
+                    OpenAPI customStaticModel = ctx.modelIO.readValue(dom);
                     debugModel("static file", customStaticModel);
-                    staticModel = MergeUtil.merge(customStaticModel, staticModel);
+                    ctx.staticModel = MergeUtil.merge(customStaticModel, ctx.staticModel);
                 } catch (IOException e) {
                     throw new OpenApiRuntimeException("IOException reading custom static file", e);
                 }
             }
+        }
 
-            if (enableAnnotationScan && !buildConfig.scanDisable()) {
-                buildConfig.setAllowNakedPathParameter(enableUnannotatedPathParameters);
-                AnnotationScannerExtension ext = newExtension(modelIO);
-                AnnotationScannerContext scannerContext = new AnnotationScannerContext(filteredIndex, appClassLoader,
-                        Collections.singletonList(ext), false, buildConfig, modelIO, new OpenAPIImpl());
-                io.scannerContext(scannerContext);
+        protected <V, A extends V, O extends V, AB, OB> void buildAnnotationModel(BuildContext<V, A, O, AB, OB> ctx) {
+            if (enableAnnotationScan && !ctx.buildConfig.scanDisable()) {
+                ctx.buildConfig.setAllowNakedPathParameter(enableUnannotatedPathParameters);
+                AnnotationScannerExtension ext = newExtension(ctx.modelIO);
+                AnnotationScannerContext scannerContext = new AnnotationScannerContext(ctx.filteredIndex, ctx.appClassLoader,
+                        Collections.singletonList(ext), false, ctx.buildConfig, ctx.modelIO, new OpenAPIImpl());
+                ctx.modelIO.ioContext().scannerContext(scannerContext);
                 Supplier<Iterable<AnnotationScanner>> supplier = Optional.ofNullable(scannerClassLoader)
                         .map(AnnotationScannerFactory::new)
-                        .orElseGet(() -> new AnnotationScannerFactory(appClassLoader));
+                        .orElseGet(() -> new AnnotationScannerFactory(ctx.appClassLoader));
                 OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(scannerContext, supplier);
-                annotationModel = scanner.scan(scannerFilter);
-                debugModel("annotation", annotationModel);
+                ctx.annotationModel = scanner.scan(scannerFilter);
+                debugModel("annotation", ctx.annotationModel);
             }
+        }
 
+        protected void buildStandardFilter(BuildContext<?, ?, ?, ?, ?> ctx) {
             if (enableStandardFilter) {
-                standardFilter = OpenApiProcessor.getFilter(buildConfig, appClassLoader, filteredIndex);
+                ctx.standardFilter = OpenApiProcessor.getFilter(
+                        ctx.buildConfig,
+                        ctx.appClassLoader,
+                        ctx.filteredIndex);
             }
+        }
 
-            OpenApiDocument doc = OpenApiDocument.newInstance();
-            doc.config(buildConfig);
-            doc.defaultRequiredProperties(defaultRequiredProperties);
-            doc.modelFromReader(MergeUtil.merge(initialModel, readerModel));
-            doc.modelFromStaticFile(staticModel);
-            doc.modelFromAnnotations(annotationModel);
+        protected void buildPrepare(BuildContext<?, ?, ?, ?, ?> ctx) {
+            ctx.doc.set(null);
+        }
+
+        protected <V> SmallRyeOpenAPI buildFinalize(BuildContext<V, ?, ?, ?, ?> ctx) {
+            ctx.doc.config(ctx.buildConfig);
+            ctx.doc.defaultRequiredProperties(ctx.defaultRequiredProperties);
+            ctx.doc.modelFromReader(MergeUtil.merge(ctx.initialModel, ctx.readerModel));
+            ctx.doc.modelFromStaticFile(ctx.staticModel);
+            ctx.doc.modelFromAnnotations(ctx.annotationModel);
 
             filters.entrySet()
                     .stream()
                     .map(e -> Optional.ofNullable(e.getValue())
                             // Create an instance from the key (class name) when the value is null
-                            .orElseGet(() -> OpenApiProcessor.getFilter(e.getKey(), appClassLoader, filteredIndex)))
-                    .forEach(doc::filter);
+                            .orElseGet(() -> OpenApiProcessor.getFilter(
+                                    e.getKey(),
+                                    ctx.appClassLoader,
+                                    ctx.filteredIndex)))
+                    .forEach(ctx.doc::filter);
 
-            if (standardFilter != null && !filters.containsKey(standardFilter.getClass().getName())) {
-                doc.filter(standardFilter);
+            if (ctx.standardFilter != null && !filters.containsKey(ctx.standardFilter.getClass().getName())) {
+                ctx.doc.filter(ctx.standardFilter);
             }
 
-            doc.initialize();
+            ctx.doc.initialize();
+            OpenAPI model = ctx.doc.get();
+            BiFunction<V, Format, String> toString = ctx.modelIO.jsonIO()::toString;
+            return new SmallRyeOpenAPI(model, ctx.modelIO.write(model).orElse(null), toString);
+        }
 
-            OpenAPI model = doc.get();
-            BiFunction<V, Format, String> toString = io.jsonIO()::toString;
-            return new SmallRyeOpenAPI(model, modelIO.write(model).orElse(null), toString);
+        protected static class BuildContext<V, A extends V, O extends V, AB, OB> {
+            ClassLoader appClassLoader;
+            OpenApiConfig buildConfig;
+            OpenAPIDefinitionIO<V, A, O, AB, OB> modelIO;
+            FilteredIndexView filteredIndex;
+            OpenAPI initialModel;
+            OpenAPI readerModel;
+            OpenAPI staticModel;
+            OpenAPI annotationModel;
+            OASFilter standardFilter;
+            boolean defaultRequiredProperties;
+
+            OpenApiDocument doc;
+
+            BuildContext(Builder builder) {
+                this.appClassLoader = builder.applicationClassLoader != null
+                        ? builder.applicationClassLoader
+                        : Thread.currentThread().getContextClassLoader();
+
+                this.buildConfig = OpenApiConfig.fromConfig(Optional.ofNullable(builder.config)
+                        .orElseGet(() -> ConfigProvider.getConfig(this.appClassLoader)));
+                IOContext<V, A, O, AB, OB> io = IOContext.forJson(JsonIO.newInstance(this.buildConfig));
+                this.modelIO = new OpenAPIDefinitionIO<>(io);
+                this.filteredIndex = new FilteredIndexView(builder.index, this.buildConfig);
+                this.initialModel = builder.initialModel;
+                this.defaultRequiredProperties = builder.defaultRequiredProperties;
+
+                this.doc = OpenApiDocument.newInstance();
+            }
+        }
+
+        /**
+         * Build a new {@linkplain SmallRyeOpenAPI} instance based on the current state of this builder.
+         *
+         * @param <V> JSON value type
+         * @param <A> JSON array type
+         * @param <O> JSON object type
+         * @param <AB> JSON array builder type
+         * @param <OB> JSON object builder type
+         * @return a new {@linkplain SmallRyeOpenAPI} instance
+         */
+        public <V, A extends V, O extends V, AB, OB> SmallRyeOpenAPI build() {
+            BuildContext<V, A, O, AB, OB> ctx = getContext();
+
+            buildPrepare(ctx);
+            buildReaderModel(ctx);
+            buildStaticModel(ctx);
+            buildAnnotationModel(ctx);
+            buildStandardFilter(ctx);
+
+            return buildFinalize(ctx);
         }
 
         private <V, A extends V, O extends V, AB, OB> AnnotationScannerExtension newExtension(

--- a/core/src/main/java/io/smallrye/openapi/api/models/ComponentsImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/ComponentsImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.Components;
@@ -46,7 +45,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setSchemas(Map<String, Schema> schemas) {
-        this.schemas = ModelUtil.replace(schemas, LinkedHashMap<String, Schema>::new);
+        this.schemas = ModelUtil.replace(schemas);
     }
 
     /**
@@ -55,7 +54,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addSchema(String key, Schema schema) {
-        this.schemas = ModelUtil.add(key, schema, this.schemas, LinkedHashMap<String, Schema>::new);
+        this.schemas = ModelUtil.add(key, schema, this.schemas);
         return this;
     }
 
@@ -80,7 +79,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setResponses(Map<String, APIResponse> responses) {
-        this.responses = ModelUtil.replace(responses, LinkedHashMap<String, APIResponse>::new);
+        this.responses = ModelUtil.replace(responses);
     }
 
     /**
@@ -89,7 +88,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addResponse(String key, APIResponse response) {
-        this.responses = ModelUtil.add(key, response, this.responses, LinkedHashMap<String, APIResponse>::new);
+        this.responses = ModelUtil.add(key, response, this.responses);
         return this;
     }
 
@@ -114,7 +113,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setParameters(Map<String, Parameter> parameters) {
-        this.parameters = ModelUtil.replace(parameters, LinkedHashMap<String, Parameter>::new);
+        this.parameters = ModelUtil.replace(parameters);
     }
 
     /**
@@ -123,7 +122,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addParameter(String key, Parameter parameter) {
-        this.parameters = ModelUtil.add(key, parameter, this.parameters, LinkedHashMap<String, Parameter>::new);
+        this.parameters = ModelUtil.add(key, parameter, this.parameters);
         return this;
     }
 
@@ -148,7 +147,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setExamples(Map<String, Example> examples) {
-        this.examples = ModelUtil.replace(examples, LinkedHashMap<String, Example>::new);
+        this.examples = ModelUtil.replace(examples);
     }
 
     /**
@@ -157,7 +156,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addExample(String key, Example example) {
-        this.examples = ModelUtil.add(key, example, this.examples, LinkedHashMap<String, Example>::new);
+        this.examples = ModelUtil.add(key, example, this.examples);
         return this;
     }
 
@@ -182,7 +181,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setRequestBodies(Map<String, RequestBody> requestBodies) {
-        this.requestBodies = ModelUtil.replace(requestBodies, LinkedHashMap<String, RequestBody>::new);
+        this.requestBodies = ModelUtil.replace(requestBodies);
     }
 
     /**
@@ -191,7 +190,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addRequestBody(String key, RequestBody requestBody) {
-        this.requestBodies = ModelUtil.add(key, requestBody, this.requestBodies, LinkedHashMap<String, RequestBody>::new);
+        this.requestBodies = ModelUtil.add(key, requestBody, this.requestBodies);
         return this;
     }
 
@@ -216,7 +215,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setHeaders(Map<String, Header> headers) {
-        this.headers = ModelUtil.replace(headers, LinkedHashMap<String, Header>::new);
+        this.headers = ModelUtil.replace(headers);
     }
 
     /**
@@ -225,7 +224,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addHeader(String key, Header header) {
-        this.headers = ModelUtil.add(key, header, this.headers, LinkedHashMap<String, Header>::new);
+        this.headers = ModelUtil.add(key, header, this.headers);
         return this;
     }
 
@@ -250,7 +249,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setSecuritySchemes(Map<String, SecurityScheme> securitySchemes) {
-        this.securitySchemes = ModelUtil.replace(securitySchemes, LinkedHashMap<String, SecurityScheme>::new);
+        this.securitySchemes = ModelUtil.replace(securitySchemes);
     }
 
     /**
@@ -259,8 +258,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addSecurityScheme(String key, SecurityScheme securityScheme) {
-        this.securitySchemes = ModelUtil.add(key, securityScheme, this.securitySchemes,
-                LinkedHashMap<String, SecurityScheme>::new);
+        this.securitySchemes = ModelUtil.add(key, securityScheme, this.securitySchemes);
         return this;
     }
 
@@ -285,7 +283,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setLinks(Map<String, Link> links) {
-        this.links = ModelUtil.replace(links, LinkedHashMap<String, Link>::new);
+        this.links = ModelUtil.replace(links);
     }
 
     /**
@@ -294,7 +292,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addLink(String key, Link link) {
-        this.links = ModelUtil.add(key, link, this.links, LinkedHashMap<String, Link>::new);
+        this.links = ModelUtil.add(key, link, this.links);
         return this;
     }
 
@@ -319,7 +317,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public void setCallbacks(Map<String, Callback> callbacks) {
-        this.callbacks = ModelUtil.replace(callbacks, LinkedHashMap<String, Callback>::new);
+        this.callbacks = ModelUtil.replace(callbacks);
     }
 
     /**
@@ -328,7 +326,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
      */
     @Override
     public Components addCallback(String key, Callback callback) {
-        this.callbacks = ModelUtil.add(key, callback, this.callbacks, LinkedHashMap<String, Callback>::new);
+        this.callbacks = ModelUtil.add(key, callback, this.callbacks);
         return this;
     }
 
@@ -347,12 +345,12 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public void setPathItems(Map<String, PathItem> pathItems) {
-        this.pathItems = ModelUtil.replace(pathItems, LinkedHashMap<String, PathItem>::new);
+        this.pathItems = ModelUtil.replace(pathItems);
     }
 
     @Override
     public Components addPathItem(String name, PathItem pathItem) {
-        this.pathItems = ModelUtil.add(name, pathItem, this.pathItems, LinkedHashMap<String, PathItem>::new);
+        this.pathItems = ModelUtil.add(name, pathItem, this.pathItems);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/ExtensibleImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/ExtensibleImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.Extensible;
@@ -31,7 +30,7 @@ public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensi
     @SuppressWarnings("unchecked")
     @Override
     public T addExtension(String name, Object value) {
-        this.extensions = ModelUtil.add(name, value, this.extensions, LinkedHashMap<String, Object>::new);
+        this.extensions = ModelUtil.add(name, value, this.extensions);
         return (T) this;
     }
 
@@ -48,7 +47,7 @@ public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensi
      */
     @Override
     public void setExtensions(Map<String, Object> extensions) {
-        this.extensions = ModelUtil.replace(extensions, LinkedHashMap<String, Object>::new);
+        this.extensions = ModelUtil.replace(extensions);
     }
 
 }

--- a/core/src/main/java/io/smallrye/openapi/api/models/OpenAPIImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/OpenAPIImpl.java
@@ -1,7 +1,6 @@
 package io.smallrye.openapi.api.models;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -93,7 +92,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Mod
      */
     @Override
     public void setServers(List<Server> servers) {
-        this.servers = ModelUtil.replace(servers, ArrayList<Server>::new);
+        this.servers = ModelUtil.replace(servers);
     }
 
     /**
@@ -101,7 +100,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Mod
      */
     @Override
     public OpenAPI addServer(Server server) {
-        this.servers = ModelUtil.add(server, this.servers, ArrayList<Server>::new);
+        this.servers = ModelUtil.add(server, this.servers);
         return this;
     }
 
@@ -126,7 +125,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Mod
      */
     @Override
     public void setSecurity(List<SecurityRequirement> security) {
-        this.security = ModelUtil.replace(security, ArrayList<SecurityRequirement>::new);
+        this.security = ModelUtil.replace(security);
     }
 
     /**
@@ -134,7 +133,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Mod
      */
     @Override
     public OpenAPI addSecurityRequirement(SecurityRequirement securityRequirement) {
-        this.security = ModelUtil.add(securityRequirement, this.security, ArrayList<SecurityRequirement>::new);
+        this.security = ModelUtil.add(securityRequirement, this.security);
         return this;
     }
 
@@ -159,7 +158,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Mod
      */
     @Override
     public void setTags(List<Tag> tags) {
-        this.tags = ModelUtil.replace(tags, ArrayList<Tag>::new);
+        this.tags = ModelUtil.replace(tags);
     }
 
     /**
@@ -238,12 +237,12 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Mod
 
     @Override
     public void setWebhooks(Map<String, PathItem> webhooks) {
-        this.webhooks = ModelUtil.replace(webhooks, LinkedHashMap<String, PathItem>::new);
+        this.webhooks = ModelUtil.replace(webhooks);
     }
 
     @Override
     public OpenAPI addWebhook(String name, PathItem webhook) {
-        this.webhooks = ModelUtil.add(name, webhook, this.webhooks, LinkedHashMap<String, PathItem>::new);
+        this.webhooks = ModelUtil.add(name, webhook, this.webhooks);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/OperationImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/OperationImpl.java
@@ -1,7 +1,5 @@
 package io.smallrye.openapi.api.models;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +55,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public void setTags(List<String> tags) {
-        this.tags = ModelUtil.replace(tags, ArrayList<String>::new);
+        this.tags = ModelUtil.replace(tags);
     }
 
     /**
@@ -65,7 +63,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public Operation addTag(String tag) {
-        this.tags = ModelUtil.add(tag, this.tags, ArrayList<String>::new);
+        this.tags = ModelUtil.add(tag, this.tags);
         return this;
     }
 
@@ -154,7 +152,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public void setParameters(List<Parameter> parameters) {
-        this.parameters = ModelUtil.replace(parameters, ArrayList<Parameter>::new);
+        this.parameters = ModelUtil.replace(parameters);
     }
 
     /**
@@ -162,7 +160,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public Operation addParameter(Parameter parameter) {
-        this.parameters = ModelUtil.add(parameter, this.parameters, ArrayList<Parameter>::new);
+        this.parameters = ModelUtil.add(parameter, this.parameters);
         return this;
     }
 
@@ -219,7 +217,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public void setCallbacks(Map<String, Callback> callbacks) {
-        this.callbacks = ModelUtil.replace(callbacks, LinkedHashMap<String, Callback>::new);
+        this.callbacks = ModelUtil.replace(callbacks);
     }
 
     /**
@@ -228,7 +226,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public Operation addCallback(String key, Callback callback) {
-        this.callbacks = ModelUtil.add(key, callback, this.callbacks, LinkedHashMap<String, Callback>::new);
+        this.callbacks = ModelUtil.add(key, callback, this.callbacks);
         return this;
     }
 
@@ -269,7 +267,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public void setSecurity(List<SecurityRequirement> security) {
-        this.security = ModelUtil.replace(security, ArrayList<SecurityRequirement>::new);
+        this.security = ModelUtil.replace(security);
     }
 
     /**
@@ -277,7 +275,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public Operation addSecurityRequirement(SecurityRequirement securityRequirement) {
-        this.security = ModelUtil.add(securityRequirement, this.security, ArrayList<SecurityRequirement>::new);
+        this.security = ModelUtil.add(securityRequirement, this.security);
         return this;
     }
 
@@ -302,7 +300,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public void setServers(List<Server> servers) {
-        this.servers = ModelUtil.replace(servers, ArrayList<Server>::new);
+        this.servers = ModelUtil.replace(servers);
     }
 
     /**
@@ -310,7 +308,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
      */
     @Override
     public Operation addServer(Server server) {
-        this.servers = ModelUtil.add(server, this.servers, ArrayList<Server>::new);
+        this.servers = ModelUtil.add(server, this.servers);
         return this;
     }
 
@@ -335,7 +333,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
         this.methodRef = methodRef;
     }
 
-    static public String getMethodRef(Operation operation) {
+    public static String getMethodRef(Operation operation) {
         return (operation instanceof OperationImpl) ? ((OperationImpl) operation).getMethodRef() : null;
     }
 }

--- a/core/src/main/java/io/smallrye/openapi/api/models/PathItemImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/PathItemImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -290,7 +289,7 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem, 
      */
     @Override
     public void setServers(List<Server> servers) {
-        this.servers = ModelUtil.replace(servers, ArrayList<Server>::new);
+        this.servers = ModelUtil.replace(servers);
     }
 
     /**
@@ -298,7 +297,7 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem, 
      */
     @Override
     public PathItem addServer(Server server) {
-        this.servers = ModelUtil.add(server, this.servers, ArrayList<Server>::new);
+        this.servers = ModelUtil.add(server, this.servers);
         return this;
     }
 
@@ -323,7 +322,7 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem, 
      */
     @Override
     public void setParameters(List<Parameter> parameters) {
-        this.parameters = ModelUtil.replace(parameters, ArrayList<Parameter>::new);
+        this.parameters = ModelUtil.replace(parameters);
     }
 
     /**
@@ -331,7 +330,7 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem, 
      */
     @Override
     public PathItem addParameter(Parameter parameter) {
-        this.parameters = ModelUtil.add(parameter, this.parameters, ArrayList<Parameter>::new);
+        this.parameters = ModelUtil.add(parameter, this.parameters);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/PathsImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/PathsImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.PathItem;
@@ -21,7 +20,7 @@ public class PathsImpl extends ExtensibleImpl<Paths> implements Paths, ModelImpl
      */
     @Override
     public Paths addPathItem(String name, PathItem item) {
-        this.pathItems = ModelUtil.add(name, item, this.pathItems, LinkedHashMap<String, PathItem>::new);
+        this.pathItems = ModelUtil.add(name, item, this.pathItems);
         return this;
     }
 
@@ -46,7 +45,7 @@ public class PathsImpl extends ExtensibleImpl<Paths> implements Paths, ModelImpl
      */
     @Override
     public void setPathItems(Map<String, PathItem> items) {
-        this.pathItems = ModelUtil.replace(items, LinkedHashMap<String, PathItem>::new);
+        this.pathItems = ModelUtil.replace(items);
     }
 
     // Begin Methods to support implementation of Map for MicroProfile OpenAPI 1.1

--- a/core/src/main/java/io/smallrye/openapi/api/models/callbacks/CallbackImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/callbacks/CallbackImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.callbacks;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.PathItem;
@@ -54,7 +53,7 @@ public class CallbackImpl extends ExtensibleImpl<Callback> implements Callback, 
      */
     @Override
     public Callback addPathItem(String name, PathItem item) {
-        this.pathItems = ModelUtil.add(name, item, this.pathItems, LinkedHashMap<String, PathItem>::new);
+        this.pathItems = ModelUtil.add(name, item, this.pathItems);
         return this;
     }
 
@@ -79,7 +78,7 @@ public class CallbackImpl extends ExtensibleImpl<Callback> implements Callback, 
      */
     @Override
     public void setPathItems(Map<String, PathItem> items) {
-        this.pathItems = ModelUtil.replace(items, LinkedHashMap<String, PathItem>::new);
+        this.pathItems = ModelUtil.replace(items);
     }
 
     // Begin Methods to support implementation of Map for MicroProfile OpenAPI 1.1

--- a/core/src/main/java/io/smallrye/openapi/api/models/headers/HeaderImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/headers/HeaderImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.headers;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.examples.Example;
@@ -174,7 +173,7 @@ public class HeaderImpl extends ExtensibleImpl<Header> implements Header, ModelI
      */
     @Override
     public void setExamples(Map<String, Example> examples) {
-        this.examples = ModelUtil.replace(examples, LinkedHashMap<String, Example>::new);
+        this.examples = ModelUtil.replace(examples);
     }
 
     /**
@@ -183,7 +182,7 @@ public class HeaderImpl extends ExtensibleImpl<Header> implements Header, ModelI
      */
     @Override
     public Header addExample(String key, Example example) {
-        this.examples = ModelUtil.add(key, example, this.examples, LinkedHashMap<String, Example>::new);
+        this.examples = ModelUtil.add(key, example, this.examples);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/links/LinkImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/links/LinkImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.links;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.links.Link;
@@ -120,7 +119,7 @@ public class LinkImpl extends ExtensibleImpl<Link> implements Link, ModelImpl {
      */
     @Override
     public void setParameters(Map<String, Object> parameters) {
-        this.parameters = ModelUtil.replace(parameters, LinkedHashMap<String, Object>::new);
+        this.parameters = ModelUtil.replace(parameters);
     }
 
     /**
@@ -128,7 +127,7 @@ public class LinkImpl extends ExtensibleImpl<Link> implements Link, ModelImpl {
      */
     @Override
     public Link addParameter(String name, Object parameter) {
-        this.parameters = ModelUtil.add(name, parameter, this.parameters, LinkedHashMap<String, Object>::new);
+        this.parameters = ModelUtil.add(name, parameter, this.parameters);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/media/ContentImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/media/ContentImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.media;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.media.Content;
@@ -23,7 +22,7 @@ public class ContentImpl implements Content, ModelImpl, MapModel<MediaType> {
      */
     @Override
     public Content addMediaType(String name, MediaType mediaType) {
-        this.mediaTypes = ModelUtil.add(name, mediaType, this.mediaTypes, LinkedHashMap<String, MediaType>::new);
+        this.mediaTypes = ModelUtil.add(name, mediaType, this.mediaTypes);
         return this;
     }
 
@@ -48,7 +47,7 @@ public class ContentImpl implements Content, ModelImpl, MapModel<MediaType> {
      */
     @Override
     public void setMediaTypes(Map<String, MediaType> mediaTypes) {
-        this.mediaTypes = ModelUtil.replace(mediaTypes, LinkedHashMap<String, MediaType>::new);
+        this.mediaTypes = ModelUtil.replace(mediaTypes);
     }
 
     // Begin Methods to support implementation of Map for MicroProfile OpenAPI 1.1

--- a/core/src/main/java/io/smallrye/openapi/api/models/media/DiscriminatorImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/media/DiscriminatorImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.media;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.media.Discriminator;
@@ -37,7 +36,7 @@ public class DiscriminatorImpl implements Discriminator, ModelImpl {
      */
     @Override
     public Discriminator addMapping(String name, String value) {
-        this.mapping = ModelUtil.add(name, value, this.mapping, LinkedHashMap<String, String>::new);
+        this.mapping = ModelUtil.add(name, value, this.mapping);
         return this;
     }
 
@@ -62,7 +61,7 @@ public class DiscriminatorImpl implements Discriminator, ModelImpl {
      */
     @Override
     public void setMapping(Map<String, String> mapping) {
-        this.mapping = ModelUtil.replace(mapping, LinkedHashMap<String, String>::new);
+        this.mapping = ModelUtil.replace(mapping);
     }
 
 }

--- a/core/src/main/java/io/smallrye/openapi/api/models/media/EncodingImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/media/EncodingImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.media;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.headers.Header;
@@ -43,7 +42,7 @@ public class EncodingImpl extends ExtensibleImpl<Encoding> implements Encoding, 
      */
     @Override
     public Encoding addHeader(String key, Header header) {
-        this.headers = ModelUtil.add(key, header, this.headers, LinkedHashMap<String, Header>::new);
+        this.headers = ModelUtil.add(key, header, this.headers);
         return this;
     }
 
@@ -68,7 +67,7 @@ public class EncodingImpl extends ExtensibleImpl<Encoding> implements Encoding, 
      */
     @Override
     public void setHeaders(Map<String, Header> headers) {
-        this.headers = ModelUtil.replace(headers, LinkedHashMap<String, Header>::new);
+        this.headers = ModelUtil.replace(headers);
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/api/models/media/MediaTypeImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/media/MediaTypeImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.media;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.examples.Example;
@@ -51,7 +50,7 @@ public class MediaTypeImpl extends ExtensibleImpl<MediaType> implements MediaTyp
      */
     @Override
     public void setExamples(Map<String, Example> examples) {
-        this.examples = ModelUtil.replace(examples, LinkedHashMap<String, Example>::new);
+        this.examples = ModelUtil.replace(examples);
     }
 
     /**
@@ -60,7 +59,7 @@ public class MediaTypeImpl extends ExtensibleImpl<MediaType> implements MediaTyp
      */
     @Override
     public MediaType addExample(String key, Example example) {
-        this.examples = ModelUtil.add(key, example, this.examples, LinkedHashMap<String, Example>::new);
+        this.examples = ModelUtil.add(key, example, this.examples);
         return this;
     }
 
@@ -101,7 +100,7 @@ public class MediaTypeImpl extends ExtensibleImpl<MediaType> implements MediaTyp
      */
     @Override
     public void setEncoding(Map<String, Encoding> encoding) {
-        this.encoding = ModelUtil.replace(encoding, LinkedHashMap<String, Encoding>::new);
+        this.encoding = ModelUtil.replace(encoding);
     }
 
     /**
@@ -110,7 +109,7 @@ public class MediaTypeImpl extends ExtensibleImpl<MediaType> implements MediaTyp
      */
     @Override
     public MediaType addEncoding(String key, Encoding encodingItem) {
-        this.encoding = ModelUtil.add(key, encodingItem, this.encoding, LinkedHashMap<String, Encoding>::new);
+        this.encoding = ModelUtil.add(key, encodingItem, this.encoding);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/media/SchemaImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/media/SchemaImpl.java
@@ -130,7 +130,7 @@ public class SchemaImpl extends MapBasedModelImpl implements Schema, ModelImpl {
     public static void addTypeObserver(Schema observable, Schema observer) {
         if (observable instanceof SchemaImpl) {
             SchemaImpl obs = (SchemaImpl) observable;
-            obs.typeObservers = ModelUtil.add(observer, obs.typeObservers, ArrayList<Schema>::new);
+            obs.typeObservers = ModelUtil.add(observer, obs.typeObservers);
         }
 
         setTypeRetainingNull(observer, observable.getType());

--- a/core/src/main/java/io/smallrye/openapi/api/models/parameters/ParameterImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/parameters/ParameterImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.parameters;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.examples.Example;
@@ -211,7 +210,7 @@ public class ParameterImpl extends ExtensibleImpl<Parameter> implements Paramete
      */
     @Override
     public void setExamples(Map<String, Example> examples) {
-        this.examples = ModelUtil.replace(examples, LinkedHashMap<String, Example>::new);
+        this.examples = ModelUtil.replace(examples);
     }
 
     /**
@@ -220,7 +219,7 @@ public class ParameterImpl extends ExtensibleImpl<Parameter> implements Paramete
      */
     @Override
     public Parameter addExample(String key, Example example) {
-        this.examples = ModelUtil.add(key, example, this.examples, LinkedHashMap<String, Example>::new);
+        this.examples = ModelUtil.add(key, example, this.examples);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/responses/APIResponseImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/responses/APIResponseImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.responses;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.headers.Header;
@@ -73,7 +72,7 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
      */
     @Override
     public void setHeaders(Map<String, Header> headers) {
-        this.headers = ModelUtil.replace(headers, LinkedHashMap<String, Header>::new);
+        this.headers = ModelUtil.replace(headers);
     }
 
     /**
@@ -82,7 +81,7 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
      */
     @Override
     public APIResponse addHeader(String name, Header header) {
-        this.headers = ModelUtil.add(name, header, this.headers, LinkedHashMap<String, Header>::new);
+        this.headers = ModelUtil.add(name, header, this.headers);
         return this;
     }
 
@@ -123,7 +122,7 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
      */
     @Override
     public void setLinks(Map<String, Link> links) {
-        this.links = ModelUtil.replace(links, LinkedHashMap<String, Link>::new);
+        this.links = ModelUtil.replace(links);
     }
 
     /**
@@ -132,7 +131,7 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
      */
     @Override
     public APIResponse addLink(String name, Link link) {
-        this.links = ModelUtil.add(name, link, this.links, LinkedHashMap<String, Link>::new);
+        this.links = ModelUtil.add(name, link, this.links);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/responses/APIResponsesImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/responses/APIResponsesImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.responses;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
@@ -24,7 +23,7 @@ public class APIResponsesImpl extends ExtensibleImpl<APIResponses> implements AP
      */
     @Override
     public APIResponses addAPIResponse(String name, APIResponse apiResponse) {
-        this.apiResponses = ModelUtil.add(name, apiResponse, this.apiResponses, LinkedHashMap<String, APIResponse>::new);
+        this.apiResponses = ModelUtil.add(name, apiResponse, this.apiResponses);
         return this;
     }
 
@@ -43,7 +42,7 @@ public class APIResponsesImpl extends ExtensibleImpl<APIResponses> implements AP
 
     @Override
     public void setAPIResponses(Map<String, APIResponse> items) {
-        this.apiResponses = ModelUtil.replace(items, LinkedHashMap<String, APIResponse>::new);
+        this.apiResponses = ModelUtil.replace(items);
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/api/models/security/OAuthFlowImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/security/OAuthFlowImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.security;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.security.OAuthFlow;
@@ -80,7 +79,7 @@ public class OAuthFlowImpl extends ExtensibleImpl<OAuthFlow> implements OAuthFlo
      */
     @Override
     public void setScopes(Map<String, String> scopes) {
-        this.scopes = ModelUtil.replace(scopes, LinkedHashMap<String, String>::new);
+        this.scopes = ModelUtil.replace(scopes);
     }
 
     /*
@@ -88,7 +87,7 @@ public class OAuthFlowImpl extends ExtensibleImpl<OAuthFlow> implements OAuthFlo
      */
     @Override
     public OAuthFlow addScope(String scope, String description) {
-        this.scopes = ModelUtil.add(scope, description, this.scopes, LinkedHashMap<String, String>::new);
+        this.scopes = ModelUtil.add(scope, description, this.scopes);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/servers/ServerImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/servers/ServerImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.servers;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.servers.Server;
@@ -64,7 +63,7 @@ public class ServerImpl extends ExtensibleImpl<Server> implements Server, ModelI
      */
     @Override
     public void setVariables(Map<String, ServerVariable> variables) {
-        this.variables = ModelUtil.replace(variables, LinkedHashMap<String, ServerVariable>::new);
+        this.variables = ModelUtil.replace(variables);
     }
 
     /*
@@ -72,7 +71,7 @@ public class ServerImpl extends ExtensibleImpl<Server> implements Server, ModelI
      */
     @Override
     public Server addVariable(String variableName, ServerVariable variable) {
-        this.variables = ModelUtil.add(variableName, variable, this.variables, LinkedHashMap<String, ServerVariable>::new);
+        this.variables = ModelUtil.add(variableName, variable, this.variables);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/api/models/servers/ServerVariableImpl.java
+++ b/core/src/main/java/io/smallrye/openapi/api/models/servers/ServerVariableImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.openapi.api.models.servers;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
@@ -31,7 +30,7 @@ public class ServerVariableImpl extends ExtensibleImpl<ServerVariable> implement
      */
     @Override
     public void setEnumeration(List<String> enumeration) {
-        this.enumeration = ModelUtil.replace(enumeration, ArrayList<String>::new);
+        this.enumeration = ModelUtil.replace(enumeration);
     }
 
     /**
@@ -39,7 +38,7 @@ public class ServerVariableImpl extends ExtensibleImpl<ServerVariable> implement
      */
     @Override
     public ServerVariable addEnumeration(String enumeration) {
-        this.enumeration = ModelUtil.add(enumeration, this.enumeration, ArrayList<String>::new);
+        this.enumeration = ModelUtil.add(enumeration, this.enumeration);
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/ModelIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/ModelIO.java
@@ -61,6 +61,10 @@ public abstract class ModelIO<T, V, A extends V, O extends V, AB, OB> {
         this.modelName = modelName;
     }
 
+    public IOContext<V, A, O, AB, OB> ioContext() {
+        return context;
+    }
+
     public JsonIO<V, A, O, AB, OB> jsonIO() {
         return context.jsonIO();
     }

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/ModelUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/ModelUtil.java
@@ -3,6 +3,7 @@ package io.smallrye.openapi.runtime.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -360,8 +361,11 @@ public class ModelUtil {
         return map != null ? Collections.unmodifiableMap(map) : null;
     }
 
-    public static <V> Map<String, V> replace(Map<String, V> modified, UnaryOperator<Map<String, V>> factory) {
+    public static <V> Map<String, V> replace(Map<String, V> modified) {
+        return replace(modified, LinkedHashMap<String, V>::new);
+    }
 
+    public static <V> Map<String, V> replace(Map<String, V> modified, UnaryOperator<Map<String, V>> factory) {
         final Map<String, V> replacement;
 
         if (modified == null) {
@@ -371,6 +375,10 @@ public class ModelUtil {
         }
 
         return replacement;
+    }
+
+    public static <V> Map<String, V> add(String key, V value, Map<String, V> map) {
+        return add(key, value, map, LinkedHashMap<String, V>::new);
     }
 
     public static <V> Map<String, V> add(String key, V value, Map<String, V> map, Supplier<Map<String, V>> factory) {
@@ -393,6 +401,10 @@ public class ModelUtil {
         return list != null ? Collections.unmodifiableList(list) : null;
     }
 
+    public static <V> List<V> replace(List<V> modified) {
+        return replace(modified, ArrayList<V>::new);
+    }
+
     public static <V> List<V> replace(List<V> modified, UnaryOperator<List<V>> factory) {
         final List<V> replacement;
 
@@ -403,6 +415,10 @@ public class ModelUtil {
         }
 
         return replacement;
+    }
+
+    public static <V> List<V> add(V value, List<V> list) {
+        return add(value, list, ArrayList<V>::new);
     }
 
     public static <V> List<V> add(V value, List<V> list, Supplier<List<V>> factory) {


### PR DESCRIPTION
* Split builder API `build` method to enable downstream optimizations via override of the builder.
* Reduce use of initialization lambdas throughout model classes