### PR TITLE
Add OperationHandler callback

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OperationHandler.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OperationHandler.java
@@ -1,0 +1,38 @@
+package io.smallrye.openapi.api;
+
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+
+/**
+ * Handler interface for a platform integration layer to inspect or modify an operation.
+ *
+ * The resource method and class from which the operation was constructed are
+ * also provided.
+ *
+ * @since 4.0
+ */
+@FunctionalInterface
+public interface OperationHandler {
+
+    static final OperationHandler DEFAULT = (o, c, m) -> {
+    };
+
+    /**
+     * Callback to allow modification to an {@link Operation operation},
+     * together with the associated resource class and resource method
+     * associated with the operation.
+     *
+     * @param operation
+     *        the OpenAPI operation model created from the resource
+     *        class/method
+     * @param resourceClass
+     *        the resource class that hosts REST endpoint methods
+     * @param resourceMethod
+     *        resource method for a REST request. The method's declaring
+     *        class may differ from the resource class. For example it may
+     *        have been declared in an abstract class or interface.
+     */
+    void handleOperation(Operation operation, ClassInfo resourceClass, MethodInfo resourceMethod);
+
+}

--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
@@ -112,6 +112,7 @@ public class SmallRyeOpenAPI {
         private boolean enableUnannotatedPathParameters = false;
         private ClassLoader scannerClassLoader;
         private Predicate<String> scannerFilter = n -> true;
+        private OperationHandler operationHandler = OperationHandler.DEFAULT;
 
         private Function<Collection<ClassInfo>, String> contextRootResolver = apps -> null;
         private UnaryOperator<Type> typeConverter = UnaryOperator.identity();
@@ -419,6 +420,19 @@ public class SmallRyeOpenAPI {
         }
 
         /**
+         * Provide an {@link OperationHandler} to be called for each operation discovered
+         * during annotation scanning.
+         *
+         * @param handler a non-null implementation of an {@link OperationHandler}
+         * @return this builder
+         */
+        public Builder withOperationHandler(OperationHandler handler) {
+            removeContext();
+            this.operationHandler = Objects.requireNonNull(handler);
+            return this;
+        }
+
+        /**
          * Provide a collection of OASFilter instances to apply to the final OpenAPI model. The
          * filters will be executed in the same order as given in the collection.
          *
@@ -585,7 +599,7 @@ public class SmallRyeOpenAPI {
                 ctx.buildConfig.setAllowNakedPathParameter(enableUnannotatedPathParameters);
                 AnnotationScannerExtension ext = newExtension(ctx.modelIO);
                 AnnotationScannerContext scannerContext = new AnnotationScannerContext(ctx.filteredIndex, ctx.appClassLoader,
-                        Collections.singletonList(ext), false, ctx.buildConfig, ctx.modelIO, new OpenAPIImpl());
+                        Collections.singletonList(ext), false, ctx.buildConfig, operationHandler, new OpenAPIImpl());
                 ctx.modelIO.ioContext().scannerContext(scannerContext);
                 Supplier<Iterable<AnnotationScanner>> supplier = Optional.ofNullable(scannerClassLoader)
                         .map(AnnotationScannerFactory::new)

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -307,6 +307,8 @@ public interface AnnotationScanner {
             operation.setOperationId(operationId);
         }
 
+        context.getOperationHandler().handleOperation(operation, resourceClass, method);
+
         // validate operationId
         String operationId = operation.getOperationId();
         if (operationId != null) {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationHandlerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationHandlerTest.java
@@ -1,0 +1,46 @@
+package io.smallrye.openapi.runtime.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
+
+class OperationHandlerTest {
+
+    @Test
+    void testOperationHandlerInvoked() throws Exception {
+        @jakarta.ws.rs.Path("/names")
+        class NameResource {
+            @jakarta.ws.rs.GET
+            @jakarta.ws.rs.Path("{id}")
+            public String getNameById(@jakarta.ws.rs.PathParam("id") String id) {
+                return null;
+            }
+        }
+
+        SmallRyeOpenAPI result = SmallRyeOpenAPI.builder()
+                .enableModelReader(false)
+                .enableStandardFilter(false)
+                .enableStandardStaticFiles(false)
+                .enableAnnotationScan(true)
+                .withIndex(Index.of(NameResource.class))
+                .withOperationHandler((o, c, m) -> {
+                    String className = c.simpleName();
+                    String methodName = m.name();
+                    o.addExtension("x-method-info", className + '#' + methodName);
+                })
+                .build();
+
+        OpenAPI model = result.model();
+        Map<String, Object> extensions = model.getPaths().getPathItem("/names/{id}").getGET().getExtensions();
+        String methodInfo = (String) extensions.get("x-method-info");
+
+        assertEquals(NameResource.class.getSimpleName() + "#getNameById", methodInfo);
+    }
+
+}


### PR DESCRIPTION
This feature is meant to be used as a replacement for `OperationImpl#setMethodRef` and `OperationImpl#getMethodRef`, moving the responsibility for the calculation of those values to the platform integration layer (e.g. Quarkus). An upcoming PR will deprecate the existing `io.smallrye.openapi.models` with a set of new internal model classes based on `Map`s. This feature provides a migration path from the to-be-deprecated classes.