### PR TITLE
Remove snapshot repositories from parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,20 +79,6 @@
         <module>tools</module>
     </modules>
 
-    <repositories>
-        <repository>
-            <id>ossrh</id>
-            <name>Sonatype OSSRH Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <releases>
-               <enabled>false</enabled>
-            </releases>
-            <snapshots>
-              <enabled>true</enabled>
-           </snapshots>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <!-- MP OpenAPI -->


### PR DESCRIPTION
The new release process does not allow `<repositories>` in the POM and we don't need the snapshot repository.