### PR TITLE
Skip deployment of testsuite modules, fix TCK version, UI source jar

### DIFF
--- a/.github/workflows/publish-tck.yml
+++ b/.github/workflows/publish-tck.yml
@@ -19,7 +19,7 @@ jobs:
         #- tck-version: "2.0.1"
         #- tck-version: "3.0"
         #- tck-version: "3.1.1"
-        - tck-version: "4.0.1"
+        - tck-version: "4.0.2"
 
     name: MicroProfile OpenAPI TCK ${{ matrix.tck-version }}
     steps:

--- a/testsuite/coverage/pom.xml
+++ b/testsuite/coverage/pom.xml
@@ -60,6 +60,13 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <configuration>

--- a/testsuite/data/pom.xml
+++ b/testsuite/data/pom.xml
@@ -286,6 +286,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/testsuite/extra/pom.xml
+++ b/testsuite/extra/pom.xml
@@ -130,6 +130,13 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -91,6 +91,13 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <configuration>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -56,6 +56,13 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/ui/open-api-ui-forms/pom.xml
+++ b/ui/open-api-ui-forms/pom.xml
@@ -17,6 +17,8 @@
     </properties>
 
     <build>
+        <sourceDirectory>src</sourceDirectory>
+
         <plugins>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -75,6 +77,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/ui/open-api-ui-forms/src/App.js
+++ b/ui/open-api-ui-forms/src/App.js
@@ -31,7 +31,7 @@ async function schemaOptions(openapiURL){
     }
   }
   const result = new SwaggerResult(endpoints, s);
-  return result;    
+  return result;
 }
 
 class OverrideRequestModal extends React.Component {
@@ -194,10 +194,10 @@ class MyOpenAPIForm extends React.Component {
       headers: {
         'Accept': 'application/json, text/plain',
         'Content-Type': 'application/json'
-    }, 
-      body: JSON.stringify(formData), 
+    },
+      body: JSON.stringify(formData),
       method: "POST",
-      mode: "cors" 
+      mode: "cors"
     };
     const destURL = this.state.selectedServer + this.state.selected.url;
     fetch(destURL, other_params)


### PR DESCRIPTION
Attempt to fix release failure [1]

```
Error:      [nexus2] smallrye-open-api-testsuite-coverage-4.0.0-beta1-sources.jar is missing
Error:      [nexus2] smallrye-open-api-ui-forms-4.0.0-beta1-sources.jar is missing
Error:      [nexus2] smallrye-open-api-testsuite-extra-4.0.0-beta1-sources.jar is missing
Error:      [nexus2] smallrye-open-api-testsuite-tck-4.0.0-beta1-sources.jar is missing
Error:      [nexus2] smallrye-open-api-testsuite-data-4.0.0-beta1-javadoc.jar is missing
```


[1] https://github.com/smallrye/smallrye-release/actions/runs/11470888959/job/31920887300