### PR TITLE
Avoid locking JARs on Windows when opening input streams

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-classloader</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
                 <version>${version.io.smallrye.jandex}</version>
             </dependency>
             <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-classloader</artifactId>
+                <version>2.8.0</version>
+            </dependency>
+            <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>
                 <version>${version.io.smallrye.smallrye-config}</version>


### PR DESCRIPTION
This **may** help with https://github.com/quarkusio/quarkus/issues/43940
Needs to be confirmed by testing on Windows.