### PR TITLE
Make some ModelIO instance fields constants

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/ModelIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/ModelIO.java
@@ -251,13 +251,13 @@ public abstract class ModelIO<T, V, A extends V, O extends V, AB, OB> implements
 
     public abstract T read(AnnotationInstance annotation);
 
-    private SmallRyeOASModels modelTypes = new SmallRyeOASModels();
+    private static final SmallRyeOASModels MODEL_TYPES = new SmallRyeOASModels();
 
     @SuppressWarnings("unchecked")
     public <C extends Constructible> T readObject(Class<C> type, O node) {
         var jsonIO = jsonIO();
         BaseModel<C> model = (BaseModel<C>) OASFactory.createObject(type);
-        var modelType = modelTypes.getModel(type);
+        var modelType = MODEL_TYPES.getModel(type);
 
         for (Map.Entry<String, V> property : jsonIO.properties(node)) {
             String name = property.getKey();
@@ -383,7 +383,7 @@ public abstract class ModelIO<T, V, A extends V, O extends V, AB, OB> implements
         throw new UnsupportedOperationException(getClass() + "#write(T)");
     }
 
-    Set<String> REF_PROPERTIES = Set.of(ReferenceIO.REF, "summary", "description");
+    private static final Set<String> REF_PROPERTIES = Set.of(ReferenceIO.REF, "summary", "description");
 
     @Override
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
The initialization of these two fields showed up in performance testing, since we create quite a few ModelIO-based objects when parsing or serializing and `SmallRyeOASModels` populates a large map in its constructor.

An alternative would be to make `SmallRyeOASModels` a singleton, but since this is the only place it's used, making the field a constant should fix the performance issue.