### PR TITLE
fix: check value type before Jackson getJsonBigDecimal

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/JacksonJsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/JacksonJsonIO.java
@@ -153,7 +153,7 @@ class JacksonJsonIO implements JsonIO<JsonNode, ArrayNode, ObjectNode, ArrayNode
     @Override
     public BigDecimal getJsonBigDecimal(ObjectNode object, String key) {
         JsonNode value = object.get(key);
-        return value != null ? new BigDecimal(value.asText()) : null;
+        return value != null && value.isNumber() ? value.decimalValue() : null;
     }
 
     @Override
@@ -300,10 +300,10 @@ class JacksonJsonIO implements JsonIO<JsonNode, ArrayNode, ObjectNode, ArrayNode
             return null;
         }
         if (value.isBigDecimal()) {
-            return new BigDecimal(value.asText());
+            return value.decimalValue();
         }
         if (value.isBigInteger()) {
-            return new BigInteger(value.asText());
+            return value.bigIntegerValue();
         }
         if (value.isBoolean()) {
             return value.asBoolean();

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/JacksonJsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/JacksonJsonIOTest.java
@@ -1,0 +1,19 @@
+package io.smallrye.openapi.runtime.io;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+class JacksonJsonIOTest extends JsonIOTest<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
+
+    @BeforeEach
+    void setup() {
+        super.target = new JacksonJsonIO(new ObjectMapper()
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS));
+    }
+
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/JakartaJsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/JakartaJsonIOTest.java
@@ -1,0 +1,18 @@
+package io.smallrye.openapi.runtime.io;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+
+import org.junit.jupiter.api.BeforeEach;
+
+class JakartaJsonIOTest extends JsonIOTest<JsonValue, JsonArray, JsonObject, JsonArrayBuilder, JsonObjectBuilder> {
+
+    @BeforeEach
+    void setup() {
+        super.target = new JakartaJsonIO();
+    }
+
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/JsonIOTest.java
@@ -1,0 +1,37 @@
+package io.smallrye.openapi.runtime.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+abstract class JsonIOTest<V, A extends V, O extends V, AB, OB> {
+
+    protected JsonIO<V, A, O, AB, OB> target;
+
+    @ParameterizedTest
+    @CsvSource({
+            "{ \"key\": 3.1415 }, 3.1415",
+            "{ \"key\": \"3.1415\" }, ",
+            "{ \"key\": [ 3.1415 ] }, ",
+    })
+    void testGetJsonBigDecimal(String input, BigDecimal expected) {
+        @SuppressWarnings("unchecked")
+        O value = (O) target.fromString(input, Format.JSON);
+        assertEquals(expected, target.getJsonBigDecimal(value, "key"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "{ \"key\": 3.141592653589793238462643383279 }, 3.141592653589793238462643383279",
+    })
+    void testFromJsonBigDecimal(String input, String expected) {
+        @SuppressWarnings("unchecked")
+        O value = (O) target.fromString(input, Format.JSON);
+        V jsonValue = target.getValue(value, "key");
+        Object javaValue = target.fromJson(jsonValue);
+        assertEquals(new BigDecimal(expected), javaValue);
+    }
+}


### PR DESCRIPTION
Fixes #2054 

Also avoid re-parsing BigDecimal/BigInteger values in fromJson