### PR TITLE
Jackson views/ignored properties: fix view names, in-line custom schemas

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/MapModelIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/MapModelIO.java
@@ -2,6 +2,7 @@ package io.smallrye.openapi.runtime.io;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -65,6 +66,9 @@ public abstract class MapModelIO<T, V, A extends V, O extends V, AB, OB> extends
 
     protected Map<String, T> readMap(Collection<AnnotationInstance> annotations,
             Function<AnnotationInstance, Optional<String>> nameFn, BiFunction<String, AnnotationInstance, T> reader) {
+        if (annotations.isEmpty()) {
+            return new LinkedHashMap<>(0);
+        }
         IoLogging.logger.annotationsMap('@' + annotationName.local());
         return annotations.stream()
                 .map(annotation -> nameFn.apply(annotation).map(name -> entry(name, reader.apply(name, annotation))))

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/media/DiscriminatorIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/media/DiscriminatorIO.java
@@ -39,7 +39,6 @@ public class DiscriminatorIO<V, A extends V, O extends V, AB, OB> extends ModelI
      */
     @Override
     public Discriminator read(AnnotationInstance annotation) {
-        IoLogging.logger.singleAnnotationAs("@Schema", "Discriminator");
         String propertyName = value(annotation, SchemaConstant.PROP_DISCRIMINATOR_PROPERTY);
         AnnotationInstance[] mapping = value(annotation, SchemaConstant.PROP_DISCRIMINATOR_MAPPING);
 
@@ -47,6 +46,7 @@ public class DiscriminatorIO<V, A extends V, O extends V, AB, OB> extends ModelI
             return null;
         }
 
+        IoLogging.logger.singleAnnotationAs("@Schema", "Discriminator");
         Discriminator discriminator = OASFactory.createDiscriminator();
 
         /*

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/servers/ServerIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/servers/ServerIO.java
@@ -44,6 +44,9 @@ public class ServerIO<V, A extends V, O extends V, AB, OB> extends ModelIO<Serve
     }
 
     public List<Server> readList(Collection<AnnotationInstance> annotations) {
+        if (annotations.isEmpty()) {
+            return new ArrayList<>(0);
+        }
         IoLogging.logger.annotationsArray("@Server");
         return annotations.stream()
                 .map(this::read)

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AnnotationTargetProcessor.java
@@ -159,6 +159,7 @@ public class AnnotationTargetProcessor implements RequirementHandler {
             // The registeredTypeSchema will be a reference to typeSchema if registration occurs
             registrationType = TypeUtil.isWrappedType(entityType) ? fieldType : entityType;
             registrationCandidate = !JandexUtil.isRef(schemaAnnotation) &&
+                    typeProcessor.allowRegistration() &&
                     schemaRegistry.register(registrationType, context.getJsonViews(), typeResolver,
                             initTypeSchema,
                             (reg, key) -> null) != initTypeSchema;

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScannerContext.java
@@ -5,12 +5,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import org.eclipse.microprofile.openapi.OASFactory;
@@ -53,7 +52,7 @@ public class AnnotationScannerContext {
     private final Deque<Type> scanStack = new ArrayDeque<>();
     private Deque<TypeResolver> resolverStack = new ArrayDeque<>();
     private final Optional<BeanValidationScanner> beanValidationScanner;
-    private final Set<Type> jsonViews = new LinkedHashSet<>();
+    private final Map<Type, Boolean> jsonViews = new LinkedHashMap<>();
     private String[] currentConsumes;
     private String[] currentProduces;
     private String[] defaultConsumes;
@@ -163,7 +162,7 @@ public class AnnotationScannerContext {
         return beanValidationScanner;
     }
 
-    public Set<Type> getJsonViews() {
+    public Map<Type, Boolean> getJsonViews() {
         return jsonViews;
     }
 

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -863,22 +863,22 @@ class TypeResolverTests extends IndexScannerTestBase {
         AnnotationScannerContext context = buildContext(emptyConfig(), Bean.class, Views.View0.class, Views.View1.class,
                 Views.View2.class, Views.View3.class);
 
-        context.getJsonViews().add(Type.create(DotName.createSimple(Views.View0.class), Type.Kind.CLASS));
+        context.getJsonViews().put(Type.create(DotName.createSimple(Views.View0.class), Type.Kind.CLASS), true);
         Map<String, TypeResolver> p0 = getProperties(context, Bean.class);
         assertFalse(p0.get("field0").isIgnored());
         Stream.of("field1", "field2", "field3").forEach(f -> assertTrue(p0.get(f).isIgnored()));
 
-        context.getJsonViews().add(Type.create(DotName.createSimple(Views.View1.class), Type.Kind.CLASS));
+        context.getJsonViews().put(Type.create(DotName.createSimple(Views.View1.class), Type.Kind.CLASS), true);
         Map<String, TypeResolver> p1 = getProperties(context, Bean.class);
         Stream.of("field0", "field1").forEach(f -> assertFalse(p1.get(f).isIgnored()));
         Stream.of("field2", "field3").forEach(f -> assertTrue(p1.get(f).isIgnored()));
 
-        context.getJsonViews().add(Type.create(DotName.createSimple(Views.View2.class), Type.Kind.CLASS));
+        context.getJsonViews().put(Type.create(DotName.createSimple(Views.View2.class), Type.Kind.CLASS), true);
         Map<String, TypeResolver> p2 = getProperties(context, Bean.class);
         Stream.of("field0", "field1", "field2").forEach(f -> assertFalse(p2.get(f).isIgnored()));
         Stream.of("field3").forEach(f -> assertTrue(p2.get(f).isIgnored()));
 
-        context.getJsonViews().add(Type.create(DotName.createSimple(Views.View3.class), Type.Kind.CLASS));
+        context.getJsonViews().put(Type.create(DotName.createSimple(Views.View3.class), Type.Kind.CLASS), true);
         Map<String, TypeResolver> p3 = getProperties(context, Bean.class);
         Stream.of("field0", "field1", "field2", "field3").forEach(f -> assertFalse(p3.get(f).isIgnored()));
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ExpectationWithRefsTests.java
@@ -38,7 +38,7 @@ class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, type);
 
         Schema result = scanner.process();
-        registry.register(type, Collections.emptySet(), result);
+        registry.register(type, Collections.emptyMap(), result);
 
         printToConsole(oai);
         assertJsonEquals(expectedResourceName, oai);
@@ -54,7 +54,7 @@ class ExpectationWithRefsTests extends JaxRsDataObjectScannerTestBase {
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, parentType);
 
         Schema result = scanner.process();
-        registry.register(parentType, Collections.emptySet(), result);
+        registry.register(parentType, Collections.emptyMap(), result);
 
         printToConsole(oai);
         assertJsonEquals(expectedResourceName, oai);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JaxRsAnnotationScannerTest.java
@@ -410,7 +410,7 @@ class JaxRsAnnotationScannerTest extends JaxRsDataObjectScannerTestBase {
             schema.setTitle("UUID");
             schema.setDescription("Universally Unique Identifier");
             schema.setExample("de8681db-b4d6-4c47-a428-4b959c1c8e9a");
-            schemaRegistry.register(uuidType, Collections.emptySet(), schema);
+            schemaRegistry.register(uuidType, Collections.emptyMap(), schema);
         }
 
     }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JsonViewTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JsonViewTests.java
@@ -1,9 +1,27 @@
 package io.smallrye.openapi.runtime.scanner;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiDocument;
@@ -94,5 +112,106 @@ class JsonViewTests extends IndexScannerTestBase {
         OpenAPI result = document.get();
         printToConsole(result);
         assertJsonEquals("special.jsonview-schemas-basic.json", result);
+    }
+
+    @Test
+    void testJsonViewsWithIgnoredProperties() throws Exception {
+        class Views {
+            class Max extends Full {
+            }
+
+            class Full extends Ingest {
+            }
+
+            class Ingest extends Abridged {
+            }
+
+            class Abridged {
+            }
+        }
+
+        @Schema(name = "Role")
+        class Role {
+            @JsonView(Views.Full.class)
+            private UUID id;
+            @JsonView(Views.Ingest.class)
+            private String name;
+            @JsonView(Views.Full.class)
+            private LocalDateTime createdAt;
+            // Adding @Schema() here does fix the problem were  @JsonIgnoreProperties in Group was removing description gobally.
+            // but now the @JsonView is being ignored and description field is in all JsonViews.
+            @Schema(title = "Title of description")
+            @JsonView(Views.Full.class)
+            private String description;
+        }
+
+        @Schema(name = "Group")
+        class Group {
+            @JsonView(Views.Full.class)
+            private UUID id;
+            @JsonView(Views.Abridged.class)
+            private String name;
+            @JsonView(Views.Full.class)
+            private LocalDateTime createdAt;
+            @JsonView(Views.Full.class)
+            private String description;
+            @JsonView(Views.Ingest.class)
+            private String roleId;
+            @JsonView(Views.Abridged.class)
+            //  @JsonIgnoreProperties should only apply to this the Group entity use case of Role.  Currently, it's global.
+            @JsonIgnoreProperties("description")
+            private List<Role> roles;
+        }
+
+        @Schema(name = "User")
+        class User {
+            @JsonView(Views.Full.class)
+            private UUID id;
+
+            @JsonView(Views.Ingest.class)
+            private String name;
+
+            @JsonView(Views.Ingest.class)
+            private String groupId;
+
+            @JsonView(Views.Abridged.class)
+            @Schema(type = SchemaType.STRING, format = "date-time", description = "test date-time field")
+            private LocalDateTime birthday;
+
+            @JsonView(Views.Full.class)
+            @Schema
+            private Group group;
+        }
+
+        @Path("/user")
+        class UserResource {
+            @GET
+            @Produces(MediaType.APPLICATION_JSON)
+            @JsonView(Views.Full.class)
+            @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = User.class)))
+            public Response get() {
+                return null;
+            }
+
+            @POST
+            public Response post(@RequestBody @JsonView(Views.Ingest.class) User group) {
+                return null;
+            }
+        }
+
+        Index index = Index.of(Views.class, Views.Max.class, Views.Full.class, Views.Ingest.class, Views.Abridged.class,
+                User.class, Group.class, Role.class, UserResource.class, LocalDateTime.class);
+        OpenApiConfig config = dynamicConfig(SmallRyeOASConfig.SMALLRYE_REMOVE_UNUSED_SCHEMAS, Boolean.TRUE);
+        OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, index);
+
+        OpenApiDocument document = OpenApiDocument.newInstance();
+        document.reset();
+        document.config(config);
+        document.modelFromAnnotations(scanner.scan());
+        document.initialize();
+
+        OpenAPI result = document.get();
+        printToConsole(result);
+        assertJsonEquals("special.jsonview-with-ignored.json", result);
     }
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/KitchenSinkTest.java
@@ -67,7 +67,7 @@ class KitchenSinkTest extends JaxRsDataObjectScannerTestBase {
         SchemaRegistry registry = context.getSchemaRegistry();
 
         Schema result = scanner.process();
-        registry.register(type, Collections.emptySet(), result);
+        registry.register(type, Collections.emptyMap(), result);
 
         printToConsole(oai);
         assertJsonEquals("refsEnabled.kitchenSink.expected.json", oai);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/NestedSchemaReferenceTests.java
@@ -30,7 +30,7 @@ class NestedSchemaReferenceTests extends JaxRsDataObjectScannerTestBase {
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, parentType);
 
         Schema result = scanner.process();
-        registry.register(parentType, Collections.emptySet(), result);
+        registry.register(parentType, Collections.emptyMap(), result);
 
         printToConsole(oai);
         assertJsonEquals("refsEnabled.nested.schema.family.expected.json", oai);

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaRegistryTests.java
@@ -43,9 +43,9 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         FieldInfo n2 = cInfo.field("n2");
         FieldInfo n3 = cInfo.field("n3");
 
-        Schema s1 = registry.register(n1.type(), Collections.emptySet(), OASFactory.createSchema());
-        Schema s2 = registry.register(n2.type(), Collections.emptySet(), OASFactory.createSchema());
-        Schema s3 = registry.register(n3.type(), Collections.emptySet(), OASFactory.createSchema());
+        Schema s1 = registry.register(n1.type(), Collections.emptyMap(), OASFactory.createSchema());
+        Schema s2 = registry.register(n2.type(), Collections.emptyMap(), OASFactory.createSchema());
+        Schema s3 = registry.register(n3.type(), Collections.emptyMap(), OASFactory.createSchema());
 
         assertEquals("#/components/schemas/NestableStringNestableStringString", s1.getRef());
         assertEquals("#/components/schemas/NestableStringNestableStringObject", s2.getRef());
@@ -67,7 +67,7 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         ClassInfo cInfo = index.getClassByName(cName);
 
         FieldInfo n4 = cInfo.field("n4");
-        Schema s4 = registry.register(n4.type(), Collections.emptySet(), OASFactory.createSchema());
+        Schema s4 = registry.register(n4.type(), Collections.emptyMap(), OASFactory.createSchema());
         assertEquals("#/components/schemas/NestableStringSuperInteger", s4.getRef());
     }
 
@@ -86,7 +86,7 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         ClassInfo cInfo = index.getClassByName(cName);
 
         FieldInfo n5 = cInfo.field("n5");
-        Schema s5 = registry.register(n5.type(), Collections.emptySet(), OASFactory.createSchema());
+        Schema s5 = registry.register(n5.type(), Collections.emptyMap(), OASFactory.createSchema());
         assertEquals("#/components/schemas/NestableExtendsCharSequenceExtendsNumber", s5.getRef());
     }
 
@@ -106,7 +106,7 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         ClassInfo cInfo = index.getClassByName(cName);
 
         FieldInfo n6 = cInfo.field("n6");
-        Schema s6 = registry.register(n6.type(), Collections.emptySet(), OASFactory.createSchema());
+        Schema s6 = registry.register(n6.type(), Collections.emptyMap(), OASFactory.createSchema());
         assertEquals("#/components/schemas/n6", s6.getRef());
     }
 
@@ -129,7 +129,7 @@ class SchemaRegistryTests extends IndexScannerTestBase {
         OpenApiDataObjectScanner scanner = new OpenApiDataObjectScanner(context, n6Type);
 
         Schema result = scanner.process();
-        registry.register(n6Type, Collections.emptySet(), result);
+        registry.register(n6Type, Collections.emptyMap(), result);
         printToConsole(context.getOpenApi());
 
         String field3SchemaName = ModelUtil.nameFromRef(result.getProperties().get("field3").getRef());

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-schemas-basic.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-schemas-basic.json
@@ -13,7 +13,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BeanName_Internal_Public"
+                  "$ref": "#/components/schemas/BeanName_Internal"
                 }
               }
             }
@@ -42,7 +42,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/BeanName_WriteOnly_Public"
+                "$ref": "#/components/schemas/BeanName_WriteOnly"
               }
             }
           }
@@ -64,7 +64,7 @@
   },
   "components": {
     "schemas": {
-      "BeanName_Internal_Public": {
+      "BeanName_Internal": {
         "type": "object",
         "properties": {
           "id": {
@@ -74,7 +74,7 @@
             "type": "string"
           },
           "inner1": {
-            "$ref": "#/components/schemas/Inner1_Internal_Public"
+            "$ref": "#/components/schemas/Inner1_Internal"
           }
         }
       },
@@ -89,7 +89,7 @@
           }
         }
       },
-      "BeanName_WriteOnly_Public": {
+      "BeanName_WriteOnly": {
         "type": "object",
         "properties": {
           "name": {
@@ -99,11 +99,11 @@
             "type": "string"
           },
           "inner1": {
-            "$ref": "#/components/schemas/Inner1_WriteOnly_Public"
+            "$ref": "#/components/schemas/Inner1_WriteOnly"
           }
         }
       },
-      "Inner1_Internal_Public": {
+      "Inner1_Internal": {
         "type": "object",
         "properties": {
           "value": {
@@ -125,7 +125,7 @@
           }
         }
       },
-      "Inner1_WriteOnly_Public": {
+      "Inner1_WriteOnly": {
         "type": "object",
         "properties": {
           "value": {

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-with-ignored.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-with-ignored.json
@@ -1,0 +1,157 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "Group_Full" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "format" : "uuid",
+            "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "createdAt" : {
+            "$ref" : "#/components/schemas/LocalDateTime"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "roleId" : {
+            "type" : "string"
+          },
+          "roles" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string",
+                  "format" : "uuid",
+                  "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "createdAt" : {
+                  "$ref" : "#/components/schemas/LocalDateTime"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Group_Ingest" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "roleId" : {
+            "type" : "string"
+          },
+          "roles" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "LocalDateTime" : {
+        "type" : "string",
+        "format" : "date-time",
+        "examples" : [ "2022-03-10T12:15:50" ]
+      },
+      "User_Full" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "format" : "uuid",
+            "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "groupId" : {
+            "type" : "string"
+          },
+          "birthday" : {
+            "description" : "test date-time field",
+            "type" : "string",
+            "$ref" : "#/components/schemas/LocalDateTime"
+          },
+          "group" : {
+            "$ref" : "#/components/schemas/Group_Full"
+          }
+        }
+      },
+      "User_Ingest" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "groupId" : {
+            "type" : "string"
+          },
+          "birthday" : {
+            "description" : "test date-time field",
+            "type" : "string",
+            "$ref" : "#/components/schemas/LocalDateTime"
+          },
+          "group" : {
+            "$ref" : "#/components/schemas/Group_Ingest"
+          }
+        }
+      }
+    }
+  },
+  "paths" : {
+    "/user" : {
+      "post" : {
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/User_Ingest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User_Full"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "info" : {
+    "title" : "Generated API",
+    "version" : "1.0"
+  }
+}


### PR DESCRIPTION
This change addresses the issues raised in #2062 

1. Do not register view-specific schemas for JDK types. These types are not introspected and do not change based on the view in effect.
2. Limit the names of view-specific schemas to include only the views directly effective. The views inherited by the active views will no longer display.
3. In-line the schema of a type reference that includes `@JsonIgnoreProperties`. In these cases the schema is specific to the point of reference and will not be considered reusable. 
4. Unrelated: reduce misleading logging in a few IO classes. This reduces logging that indicates processing of annotations that aren't actually present in the classes being scanned.

For number 2 above, given the views:
```java
class Views {
    class Max extends Full {
    }

    class Full extends Ingest {
    }

    class Ingest extends Abridged {
    }

    class Abridged {
    }
}
```
the old process would append `_Max_Full_Ingest_Abridged` to schema names when the `Max` view is in effect. With this change we will now simply append `_Max`.