### PR TITLE
fix: additional logic to avoid registration of partial schemas

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -93,8 +93,9 @@ public class SchemaFactory {
     public static Schema readSchema(final AnnotationScannerContext context,
             Schema schema,
             AnnotationInstance annotation,
-            ClassInfo clazz) {
-        return readSchema(context, schema, annotation, clazz, Collections.emptyMap());
+            ClassInfo clazz,
+            boolean registerSchema) {
+        return readSchema(context, schema, annotation, clazz, registerSchema, Collections.emptyMap());
     }
 
     /**
@@ -113,6 +114,7 @@ public class SchemaFactory {
             Schema schema,
             AnnotationInstance annotation,
             ClassInfo clazz,
+            boolean registerSchema,
             Map<String, Object> defaults) {
 
         if (isAnnotationMissingOrHidden(context, annotation, defaults)) {
@@ -129,7 +131,9 @@ public class SchemaFactory {
          *
          * Ignore the reference returned by register, the caller expects the full schema.
          */
-        schemaRegistration(context, clazzType, schema);
+        if (registerSchema) {
+            schemaRegistration(context, clazzType, schema);
+        }
 
         return schema;
     }
@@ -641,7 +645,7 @@ public class SchemaFactory {
             Map<String, Object> defaults = new LinkedHashMap<>(TypeUtil.getTypeAttributes(enumValueType));
             defaults.put(SchemaConstant.PROP_ENUMERATION, enumeration);
 
-            enumSchema = readSchema(context, enumSchema, schemaAnnotation, enumKlazz, defaults);
+            enumSchema = readSchema(context, enumSchema, schemaAnnotation, enumKlazz, true, defaults);
         } else {
             TypeUtil.applyTypeAttributes(enumValueType, enumSchema);
             enumSchema.setEnumeration(enumeration);

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
@@ -78,6 +78,40 @@ public class IgnoreResolver {
         return Visibility.UNSET;
     }
 
+    /**
+     * Check whether the given target contains annotations that configure the
+     * visibility of the properties of the type annotated.
+     *
+     * This is used to only allow registration of a type if the annotation
+     * target (field or method) that refers to the type's class is not annotated
+     * with an annotation that alters the visibility of fields in the class.
+     *
+     * <p>
+     * For example, in this scenario when we process `fieldB`, registration of
+     * class B's schema will not occur because it's definition is altered by and
+     * specific to its use in class A.
+     *
+     * <pre>
+     * <code>
+     * class A {
+     *   &#64;JsonIgnoreProperties({"field2"})
+     *   B fieldB;
+     * }
+     *
+     * class B {
+     *   int field1;
+     *   int field2;
+     * }
+     * </code>
+     * </pre>
+     */
+    public static boolean configuresVisibility(AnnotationScannerContext context, AnnotationTarget target) {
+        if (target != null) {
+            return context.getIgnoreResolver().configuresVisibility(target);
+        }
+        return false;
+    }
+
     public boolean configuresVisibility(AnnotationTarget reference) {
         for (IgnoreAnnotationHandler handler : ignoreHandlers) {
             if (handler.configuresVisibility(reference)) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
@@ -155,27 +155,10 @@ public class TypeProcessor {
      * refers to the type's class is not annotated with an annotation that alters
      * the visibility of fields in the class.
      *
-     * <p>
-     * For example, in this scenario when we process `fieldB`, registration of class B's
-     * schema will not occur because it's definition is altered by and specific to its
-     * use in class A.
-     *
-     * <pre>
-     * <code>
-     * class A {
-     *   &#64;JsonIgnoreProperties({"field2"})
-     *   B fieldB;
-     * }
-     *
-     * class B {
-     *   int field1;
-     *   int field2;
-     * }
-     * </code>
-     * </pre>
+     * @see IgnoreResolver#configuresVisibility(AnnotationScannerContext, AnnotationTarget)
      */
     public boolean allowRegistration() {
-        return !context.getIgnoreResolver().configuresVisibility(annotationTarget);
+        return !IgnoreResolver.configuresVisibility(context, annotationTarget);
     }
 
     private Type readArrayType(ArrayType arrayType, Schema arraySchema) {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JsonViewTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JsonViewTests.java
@@ -136,10 +136,6 @@ class JsonViewTests extends IndexScannerTestBase {
             private UUID id;
             @JsonView(Views.Ingest.class)
             private String name;
-            @JsonView(Views.Full.class)
-            private LocalDateTime createdAt;
-            // Adding @Schema() here does fix the problem were  @JsonIgnoreProperties in Group was removing description gobally.
-            // but now the @JsonView is being ignored and description field is in all JsonViews.
             @Schema(title = "Title of description")
             @JsonView(Views.Full.class)
             private String description;
@@ -152,13 +148,10 @@ class JsonViewTests extends IndexScannerTestBase {
             @JsonView(Views.Abridged.class)
             private String name;
             @JsonView(Views.Full.class)
-            private LocalDateTime createdAt;
-            @JsonView(Views.Full.class)
             private String description;
             @JsonView(Views.Ingest.class)
             private String roleId;
             @JsonView(Views.Abridged.class)
-            //  @JsonIgnoreProperties should only apply to this the Group entity use case of Role.  Currently, it's global.
             @JsonIgnoreProperties("description")
             private List<Role> roles;
         }
@@ -199,8 +192,41 @@ class JsonViewTests extends IndexScannerTestBase {
             }
         }
 
+        @Path("/role")
+        class RoleResource {
+            @GET
+            @Produces(MediaType.APPLICATION_JSON)
+            @JsonView(Views.Full.class)
+            @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = Role.class)))
+            public Response getRole() {
+                return null;
+            }
+
+            @POST
+            public Response post(@RequestBody @JsonView(Views.Ingest.class) Role role) {
+                return null;
+            }
+        }
+
+        @Path("/group")
+        class GroupResource {
+            @GET
+            @Produces(MediaType.APPLICATION_JSON)
+            @JsonView(Views.Full.class)
+            @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = Group.class)))
+            public Response get() {
+                return null;
+            }
+
+            @POST
+            public Response post(@RequestBody @JsonView(Views.Ingest.class) Group group) {
+                return null;
+            }
+        }
+
         Index index = Index.of(Views.class, Views.Max.class, Views.Full.class, Views.Ingest.class, Views.Abridged.class,
-                User.class, Group.class, Role.class, UserResource.class, LocalDateTime.class);
+                User.class, Group.class, Role.class, UserResource.class, LocalDateTime.class, RoleResource.class,
+                GroupResource.class);
         OpenApiConfig config = dynamicConfig(SmallRyeOASConfig.SMALLRYE_REMOVE_UNUSED_SCHEMAS, Boolean.TRUE);
         OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(config, index);
 

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-with-ignored.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-with-ignored.json
@@ -13,9 +13,6 @@
           "name" : {
             "type" : "string"
           },
-          "createdAt" : {
-            "$ref" : "#/components/schemas/LocalDateTime"
-          },
           "description" : {
             "type" : "string"
           },
@@ -34,9 +31,6 @@
                 },
                 "name" : {
                   "type" : "string"
-                },
-                "createdAt" : {
-                  "$ref" : "#/components/schemas/LocalDateTime"
                 }
               }
             }
@@ -69,6 +63,31 @@
         "type" : "string",
         "format" : "date-time",
         "examples" : [ "2022-03-10T12:15:50" ]
+      },
+      "Role_Full" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "format" : "uuid",
+            "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Title of description"
+          }
+        }
+      },
+      "Role_Ingest" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          }
+        }
       },
       "User_Full" : {
         "type" : "object",
@@ -107,15 +126,78 @@
             "description" : "test date-time field",
             "type" : "string",
             "$ref" : "#/components/schemas/LocalDateTime"
-          },
-          "group" : {
-            "$ref" : "#/components/schemas/Group_Ingest"
           }
         }
       }
     }
   },
   "paths" : {
+    "/group" : {
+      "post" : {
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Group_Ingest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Group_Full"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/role" : {
+      "post" : {
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Role_Ingest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Role_Full"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/user" : {
       "post" : {
         "requestBody" : {


### PR DESCRIPTION
Additional fixes for #2062 

Avoid registration of schemas for reuse when referencing property applies property customization, e.g. `@JsonIgnoreProperties`.