### PR TITLE
fix: do not auto-expose properties absent from `@JsonIgnoreProperties`

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
@@ -215,7 +215,7 @@ public class IgnoreResolver {
         private Visibility declaringClassIgnore(String propertyName, AnnotationTarget target) {
             AnnotationInstance declaringClassJIP = context.annotations().getAnnotation(TypeUtil.getDeclaringClass(target),
                     getNames());
-            return shouldIgnoreTarget(declaringClassJIP, propertyName);
+            return shouldIgnoreTarget(declaringClassJIP, propertyName, Visibility.EXPOSED);
         }
 
         /**
@@ -244,10 +244,11 @@ public class IgnoreResolver {
                 return Visibility.UNSET;
             }
             AnnotationInstance nestedTypeJIP = context.annotations().getAnnotation(nesting, getNames());
-            return shouldIgnoreTarget(nestedTypeJIP, propertyName);
+            return shouldIgnoreTarget(nestedTypeJIP, propertyName, Visibility.UNSET);
         }
 
-        private Visibility shouldIgnoreTarget(AnnotationInstance jipAnnotation, String targetName) {
+        private Visibility shouldIgnoreTarget(AnnotationInstance jipAnnotation, String targetName,
+                Visibility unlistedVisibility) {
             if (jipAnnotation == null || jipAnnotation.value() == null) {
                 return Visibility.UNSET;
             }
@@ -255,7 +256,7 @@ public class IgnoreResolver {
             if (Arrays.asList(jipAnnotation.value().asStringArray()).contains(targetName)) {
                 return Visibility.IGNORED;
             } else {
-                return Visibility.EXPOSED;
+                return unlistedVisibility;
             }
         }
 
@@ -268,7 +269,7 @@ public class IgnoreResolver {
         public Visibility getDescendantVisibility(String propertyName, List<ClassInfo> descendants) {
             for (ClassInfo descendant : descendants) {
                 AnnotationInstance declaringClassJIP = context.annotations().getAnnotation(descendant, getNames());
-                Visibility visibility = shouldIgnoreTarget(declaringClassJIP, propertyName);
+                Visibility visibility = shouldIgnoreTarget(declaringClassJIP, propertyName, Visibility.EXPOSED);
 
                 if (visibility != Visibility.UNSET) {
                     return visibility;

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JsonViewTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/JsonViewTests.java
@@ -20,6 +20,7 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 
@@ -132,6 +133,9 @@ class JsonViewTests extends IndexScannerTestBase {
 
         @Schema(name = "Role")
         class Role {
+            @JsonIgnore
+            protected java.util.logging.Logger logger;
+
             @JsonView(Views.Full.class)
             private UUID id;
             @JsonView(Views.Ingest.class)


### PR DESCRIPTION
Additional fix for #2062

Do not automatically expose a property just because it is not listed in `@JsonIgnoreProperties` of a reference type. Only when annotation is used on the referencing type. Properties still exposed when annotation is on declaring class or descendant.