### PR TITLE
Fix handling of parameters for generic subresource locator methods

### DIFF
--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
@@ -278,6 +278,7 @@ public class JaxRsParameterProcessor extends AbstractParameterProcessor {
         switch (method.returnType().kind()) {
             case CLASS:
             case PARAMETERIZED_TYPE:
+            case TYPE_VARIABLE:
                 return scannerContext.annotations().hasAnnotation(method, JaxRsConstants.PATH) &&
                         method.annotations()
                                 .stream()

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SubresourceScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SubresourceScanTests.java
@@ -6,6 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
@@ -111,5 +112,40 @@ class SubresourceScanTests extends IndexScannerTestBase {
 
         test("resource.subresource-tag-placement-priority.json",
                 RootResource.class, SubresourceA.class, SubresourceB.class, ProducesText.class, RootA2Tag.class);
+    }
+
+    static class GenericInterfaceSubresourceTypes {
+        interface ScopedResource<R> {
+            @Path("park/{ident}")
+            public R park(@PathParam("ident") final String parkIdent);
+        }
+
+        @Path("/")
+        interface Resource extends ScopedResource<SubResource> {
+        }
+
+        static class ResourceImpl implements Resource {
+            @Override
+            public SubResource park(String parkIdent) {
+                return new SubResource();
+            }
+
+        }
+
+        static class SubResource {
+            @GET
+            @Path("/")
+            String yes() {
+                return "";
+            }
+        }
+    }
+
+    @Test
+    void testGenericInterfaceSubresource() throws IOException, JSONException {
+        test("resource.subresource-generic-type-variable.json", GenericInterfaceSubresourceTypes.ScopedResource.class,
+                GenericInterfaceSubresourceTypes.Resource.class,
+                GenericInterfaceSubresourceTypes.ResourceImpl.class,
+                GenericInterfaceSubresourceTypes.SubResource.class);
     }
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.subresource-generic-type-variable.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.subresource-generic-type-variable.json
@@ -1,0 +1,29 @@
+{
+  "openapi" : "3.1.0",
+  "paths" : {
+    "/park/{ident}" : {
+      "parameters" : [ {
+        "name" : "ident",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ],
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2074 