### PR TITLE
fix: scan property schema in next iteration when properties ignored

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/OpenApiDataObjectScanner.java
@@ -238,8 +238,10 @@ public class OpenApiDataObjectScanner {
              */
             Schema entrySchema = currentPathEntry.getSchema();
             SchemaRegistry registry = context.getSchemaRegistry();
+            AnnotationTarget currentTarget = currentPathEntry.getAnnotationTarget();
+            boolean allowRegistration = !IgnoreResolver.configuresVisibility(context, currentTarget);
 
-            if (registry.hasSchema(currentType, context.getJsonViews(), null)) {
+            if (allowRegistration && registry.hasSchema(currentType, context.getJsonViews(), null)) {
                 // This type has already been scanned and registered, don't do it again!
                 entrySchema.setRef(registry.lookupRef(currentType, context.getJsonViews()).getRef());
                 continue;
@@ -247,8 +249,6 @@ public class OpenApiDataObjectScanner {
 
             ClassInfo currentClass = currentPathEntry.getClazz();
             Schema currentSchema = currentPathEntry.getSchema();
-            AnnotationTarget currentTarget = currentPathEntry.getAnnotationTarget();
-            boolean allowRegistration = !IgnoreResolver.configuresVisibility(context, currentTarget);
 
             // First, handle class annotations (re-assign since readKlass may return new schema)
             currentSchema = readKlass(currentClass, currentType, currentSchema, allowRegistration);

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeProcessor.java
@@ -326,6 +326,8 @@ public class TypeProcessor {
             if (registry.hasSchema(valueType, context.getJsonViews(), typeResolver)) {
                 if (allowRegistration()) {
                     propsSchema = registry.lookupRef(valueType, context.getJsonViews());
+                } else {
+                    pushToStack(valueType, propsSchema);
                 }
             } else {
                 pushToStack(valueType, propsSchema);

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.bidirectionalIgnoreProperties.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/ignore.bidirectionalIgnoreProperties.json
@@ -1,0 +1,99 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "Base_Full" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "format" : "uuid",
+            "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "station" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "string",
+                "format" : "uuid",
+                "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+              },
+              "name" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      },
+      "Station_Full" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "format" : "uuid",
+            "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "baseCollection" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string",
+                  "format" : "uuid",
+                  "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Read-only entity details (only returned/used on detail queries).",
+            "readOnly" : true
+          }
+        }
+      }
+    }
+  },
+  "paths" : {
+    "/base" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Base_Full"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/station" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Station_Full"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2098

Make sure property schemas that are not eligible for entry in the schema registry due to ignore properties are scanned in the next pass in `OpenApiDataObjectScanner`.