### PR TITLE
Fix OpenAPI 3.0 output of nullable references

### DIFF
--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaPropertyTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/SchemaPropertyTest.java
@@ -93,4 +93,29 @@ class SchemaPropertyTest extends IndexScannerTestBase {
         String shellPattern;
         Speed speed;
     }
+
+    @Test
+    void testNullableFieldReference() throws Exception {
+        Index index = indexOf(FieldTarget.class, FieldReferrer.class);
+        SmallRyeOpenAPI result1 = SmallRyeOpenAPI.builder()
+                .withConfig(config(Collections.emptyMap()))
+                .withIndex(index)
+                .defaultRequiredProperties(false)
+                .build();
+        printToConsole(result1.model());
+        assertJsonEquals("components.schemas.schemaproperty-nullable.json", result1.model());
+    }
+
+    @org.eclipse.microprofile.openapi.annotations.media.Schema
+    public static class FieldTarget {
+    }
+
+    @org.eclipse.microprofile.openapi.annotations.media.Schema
+    public static class FieldReferrer {
+        @org.eclipse.microprofile.openapi.annotations.media.Schema(nullable = true)
+        private FieldTarget a;
+        @org.eclipse.microprofile.openapi.annotations.media.Schema(nullable = true, description = "b")
+        private FieldTarget b;
+    }
+
 }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/io/schemas-with-nullable-reference.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/io/schemas-with-nullable-reference.json
@@ -13,6 +13,18 @@
           }
         ]
       },
+      "NullRefWithAnnotations": {
+        "description": "Description is an annotation. Scanner generates type as well here.",
+        "type": ["object", "null"],
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/mySchema"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "NullRefWithAnyOf": {
         "allOf": [
           {

--- a/core/src/test/resources/io/smallrye/openapi/runtime/io/schemas-with-nullable-reference30.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/io/schemas-with-nullable-reference30.json
@@ -11,6 +11,16 @@
           }
         ]
       },
+      "NullRefWithAnnotations": {
+        "description": "Description is an annotation. Scanner generates type as well here.",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/mySchema"
+          }
+        ],
+        "nullable": true
+      },
       "NullRefWithAnyOf": {
         "allOf": [
           {

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-nullable.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.schemaproperty-nullable.json
@@ -1,0 +1,31 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "FieldReferrer" : {
+        "type" : "object",
+        "properties" : {
+          "a" : {
+            "anyOf" : [ {
+              "$ref" : "#/components/schemas/FieldTarget"
+            }, {
+              "type" : "null"
+            } ]
+          },
+          "b" : {
+            "description" : "b",
+            "type" : "object",
+            "anyOf" : [ {
+              "$ref" : "#/components/schemas/FieldTarget"
+            }, {
+              "type" : "null"
+            } ]
+          }
+        }
+      },
+      "FieldTarget" : {
+        "type" : "object"
+      }
+    }
+  }
+}


### PR DESCRIPTION
When a nullable field or parameter references a non-nullable schema, we generate a schema for the field which uses anyOf to permit null. Any informational properties or additional assertions defined on the field are also put on the field schema and the type property is also retained.

When we were transforming this field schema for OpenAPI 3.0, we were only doing certain transformations if the type property is not present, which doesn't handle the case above.

Ensure the transformation to and from OpenAPI 3.0 schemas handles these nullable references which include the type property.

Fixes #2145