### PR TITLE
Permit Callback.pathItemRef to be any JSON path

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/callbacks/CallbackIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/callbacks/CallbackIO.java
@@ -32,7 +32,7 @@ public class CallbackIO<V, A extends V, O extends V, AB, OB> extends MapModelIO<
         callback.setRef(ReferenceType.CALLBACK.refValue(annotation));
 
         Optional.ofNullable(this.<String> value(annotation, PROP_PATH_ITEM_REF))
-                .map(ReferenceType.PATH_ITEM::referenceOf)
+                .map(ReferenceType.PATH_ITEM::parseRefValue)
                 .ifPresent(ref -> callback.addPathItem(
                         value(annotation, PROP_CALLBACK_URL_EXPRESSION),
                         OASFactory.createPathItem().ref(ref)));

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/callback.reference-component-pathitem.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/callback.reference-component-pathitem.json
@@ -1,0 +1,53 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Greetings",
+    "version" : "0.0.1"
+  },
+  "components" : {
+    "pathItems" : {
+      "myPathItem" : {
+        "post" : {
+          "responses" : {
+            "2XX" : {
+              "description" : "Ok"
+            },
+            "5XX" : {
+              "description" : "Failed"
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths" : {
+    "/" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "callbacks" : {
+          "cb1" : {
+            "/test1" : {
+              "$ref" : "#/components/pathItems/myPathItem"
+            }
+          },
+          "cb2" : {
+            "/test2" : {
+              "$ref" : "#/components/pathItems/myPathItem"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/model/src/main/java/io/smallrye/openapi/model/ReferenceType.java
+++ b/model/src/main/java/io/smallrye/openapi/model/ReferenceType.java
@@ -83,15 +83,13 @@ public enum ReferenceType {
     }
 
     /**
-     * Reads a string property named "ref" value from the given annotation and converts it
-     * to a value appropriate for setting on a model's "$ref" property.
+     * Takes the value from a ref property from an annotation, and converts it to a JSON Pointer, suitable for use as a
+     * reference in an OpenAPI model.
      *
-     * @param annotation AnnotationInstance
-     * @return String value
+     * @param ref the ref value read from an annotation
+     * @return a value suitable for use in an OpenAPI model.
      */
-    public String refValue(AnnotationInstance annotation) {
-        String ref = referenceValue(annotation);
-
+    public String parseRefValue(String ref) {
         if (ref == null) {
             return null;
         }
@@ -101,5 +99,17 @@ public enum ReferenceType {
         }
 
         return referenceOf(ref);
+    }
+
+    /**
+     * Reads a string property named "ref" value from the given annotation and converts it
+     * to a value appropriate for setting on a model's "$ref" property.
+     *
+     * @param annotation AnnotationInstance
+     * @return String value
+     */
+    public String refValue(AnnotationInstance annotation) {
+        String ref = referenceValue(annotation);
+        return parseRefValue(ref);
     }
 }


### PR DESCRIPTION
Change processing of Callback.pathItemRef so that it doesn't always prefix the value with #/components/pathItems/ when adding the reference to the model.

Fixes #2155