### PR TITLE
fix: save parent field information to type resolver's target queue

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -284,7 +284,15 @@ public class TypeResolver {
     }
 
     private void setField(FieldInfo field) {
+        if (this.field != null) {
+            targets.remove(this.field);
+        }
+
         this.field = field;
+
+        if (field != null) {
+            targets.add(field);
+        }
     }
 
     /**
@@ -824,7 +832,9 @@ public class TypeResolver {
         if (properties.containsKey(propertyName)) {
             resolver = properties.get(propertyName);
 
-            if (resolver.getField() == null && (Modifier.isPublic(field.flags()) || Modifier.isProtected(field.flags()))) {
+            if (resolver.getField() == null && (Modifier.isPublic(field.flags())
+                    || Modifier.isProtected(field.flags())
+                    || context.getConfig().privatePropertiesEnable())) {
                 /*
                  * Field is declared in parent class and the getter/setter was
                  * declared/overridden in child class

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -284,15 +284,8 @@ public class TypeResolver {
     }
 
     private void setField(FieldInfo field) {
-        if (this.field != null) {
-            targets.remove(this.field);
-        }
-
         this.field = field;
-
-        if (field != null) {
-            targets.add(field);
-        }
+        targets.add(field);
     }
 
     /**

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -901,4 +901,47 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
 
         assertJsonEquals("components.schemas.multi-array-generic.json", Bean.class);
     }
+
+    static class ParentClassFieldSchemaAnnotationTestClasses {
+        static Class<?>[] CLASSES = {
+                FieldInterface.class,
+                ParentClass.class,
+                ChildClass.class
+        };
+
+        interface FieldInterface {
+            public String getRequiredField();
+
+            public void setRequiredField(String requiredField);
+        }
+
+        class ParentClass {
+            @jakarta.validation.constraints.Size(min = 1, max = 32)
+            @jakarta.validation.constraints.NotNull
+            @Schema(readOnly = true, description = "Required field", examples = "Required field data")
+            private String requiredField;
+
+            public void setRequiredField(String requiredField) {
+                this.requiredField = requiredField;
+            }
+
+            public String getRequiredField() {
+                return this.requiredField;
+            }
+        }
+
+        @Schema(description = "Child class description")
+        class ChildClass extends ParentClass implements FieldInterface {
+            @jakarta.validation.constraints.Size(min = 1, max = 32)
+            @jakarta.validation.constraints.NotNull
+            @Schema(readOnly = true, description = "Other field", examples = "other field data")
+            private String otherField;
+        }
+
+    }
+
+    @Test
+    void testParentClassFieldSchemaAnnotation() throws IOException, JSONException {
+        assertJsonEquals("components.schemas.annotated-parent-field.json", ParentClassFieldSchemaAnnotationTestClasses.CLASSES);
+    }
 }

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -171,7 +171,7 @@ class TypeResolverTests extends IndexScannerTestBase {
         assertEquals("c_name", schema.value("name").asString());
         assertEquals(50, schema.value("maxLength").asInt());
         assertEquals("The name of the canine", schema.value("description").asString());
-        assertArrayEquals(new String[] { "age", "type", "c_name", "bark", "speciesName", "extinct" },
+        assertArrayEquals(new String[] { "age", "pet_type", "c_name", "bark", "speciesName", "extinct" },
                 properties.values().stream().map(TypeResolver::getPropertyName).toArray());
     }
 

--- a/core/src/test/java/test/io/smallrye/openapi/runtime/scanner/dataobject/AbstractAnimal.java
+++ b/core/src/test/java/test/io/smallrye/openapi/runtime/scanner/dataobject/AbstractAnimal.java
@@ -6,7 +6,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @com.fasterxml.jackson.annotation.JsonPropertyOrder(value = { "age", "type" })
 public abstract class AbstractAnimal implements Animal {
 
-    @Schema
     private String type;
     protected Integer age;
     private boolean extinct;

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.annotated-parent-field.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.annotated-parent-field.json
@@ -1,0 +1,30 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "ChildClass" : {
+        "description" : "Child class description",
+        "type" : "object",
+        "required" : [ "requiredField", "otherField" ],
+        "properties" : {
+          "requiredField" : {
+            "type" : "string",
+            "description" : "Required field",
+            "readOnly" : true,
+            "examples" : [ "Required field data" ],
+            "minLength" : 1,
+            "maxLength" : 32
+          },
+          "otherField" : {
+            "type" : "string",
+            "description" : "Other field",
+            "readOnly" : true,
+            "examples" : [ "other field data" ],
+            "minLength" : 1,
+            "maxLength" : 32
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Save a discovered field to the `TypeResolver`'s `targets` queue. This queue will later be used to find the best `AnnotationTarget` that represents the property
- Save fields for previously-known properties that are private when `privatePropertiesEnable` is true

Fixes #2148 