### PR TITLE
Create properties for record accessors

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -1027,7 +1027,8 @@ public class TypeResolver {
     /**
      * Returns whether a method follows the Java bean convention for an accessor
      * method (getter). The method name typically begins with "get", but may also
-     * begin with "is" when the return type is boolean.
+     * begin with "is" when the return type is boolean. Record component accessor
+     * methods are also accessors.
      *
      * @param method the method to check
      * @return true if the method is a Java bean getter, otherwise false
@@ -1035,6 +1036,11 @@ public class TypeResolver {
     private static boolean isAccessor(AnnotationScannerContext context, MethodInfo method) {
         if (!JandexUtil.isSupplier(method)) {
             return false;
+        }
+
+        ClassInfo clazz = method.declaringClass();
+        if (clazz.isRecord() && clazz.recordComponent(method.name()) != null) {
+            return true;
         }
 
         String namePrefix = methodNamePrefix(method);

--- a/testsuite/data/src/test/java/io/smallrye/openapi/testdata/RecordSchemaTest.java
+++ b/testsuite/data/src/test/java/io/smallrye/openapi/testdata/RecordSchemaTest.java
@@ -1,0 +1,100 @@
+package io.smallrye.openapi.testdata;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.jboss.jandex.Index;
+import org.jboss.logging.Logger;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.openapi.api.SmallRyeOASConfig;
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
+
+/**
+ * These tests can be moved to StandaloneSchemaScanTest once those tests are changed to compile with Java 17
+ */
+public class RecordSchemaTest {
+
+    private static final Logger LOG = Logger.getLogger(RecordSchemaTest.class);
+
+    @Schema
+    record TestRecord(String a,
+            @Schema(description = "b") String b) {
+    }
+
+    @Test
+    void testRecordSchema() throws IOException, JSONException {
+
+        Index index = Index.of(TestRecord.class);
+
+        String result = SmallRyeOpenAPI.builder()
+                .defaultRequiredProperties(false)
+                .withIndex(index)
+                .withConfig(config(emptyMap()))
+                .build()
+                .toJSON();
+
+        LOG.debug(result);
+        assertJsonEquals("components.schemas.record.json", result);
+    }
+
+    @Test
+    void testRecordSchemaNoPrivateFields() throws IOException, JSONException {
+
+        Index index = Index.of(TestRecord.class);
+
+        String result = SmallRyeOpenAPI.builder()
+                .defaultRequiredProperties(false)
+                .withIndex(index)
+                .withConfig(config(singletonMap(
+                        SmallRyeOASConfig.SMALLRYE_PRIVATE_PROPERTIES_ENABLE,
+                        "false")))
+                .build()
+                .toJSON();
+
+        LOG.debug(result);
+        assertJsonEquals("components.schemas.record.json", result);
+    }
+
+    private void assertJsonEquals(String expectedResource, String result) throws IOException, JSONException {
+        String expected = loadResource(RecordSchemaTest.class.getResource(expectedResource));
+        JSONAssert.assertEquals(expected, result, JSONCompareMode.STRICT);
+    }
+
+    public static String loadResource(URL testResource) throws IOException {
+        final char[] buffer = new char[8192];
+        final StringBuilder result = new StringBuilder();
+
+        try (Reader reader = new InputStreamReader(testResource.openStream(), StandardCharsets.UTF_8)) {
+            int count;
+            while ((count = reader.read(buffer, 0, buffer.length)) > 0) {
+                result.append(buffer, 0, count);
+            }
+        }
+
+        return result.toString();
+    }
+
+    private static Config config(Map<String, String> properties) {
+        return new SmallRyeConfigBuilder()
+                .addDefaultSources()
+                .withSources(new PropertiesConfigSource(properties, "unit-test", ConfigSource.DEFAULT_ORDINAL))
+                .build();
+    }
+
+}

--- a/testsuite/data/src/test/resources/io/smallrye/openapi/testdata/components.schemas.record.json
+++ b/testsuite/data/src/test/resources/io/smallrye/openapi/testdata/components.schemas.record.json
@@ -1,0 +1,19 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "TestRecord" : {
+        "type" : "object",
+        "properties" : {
+          "a" : {
+            "type" : "string"
+          },
+          "b" : {
+            "type" : "string",
+            "description" : "b"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Consider record accessor methods as similar to getters so that we create object properties for them.

Fixes #2157