### PR TITLE
Implement `Extensible.hasExtension`

### DIFF
--- a/model/src/main/java/io/smallrye/openapi/model/BaseExtensibleModel.java
+++ b/model/src/main/java/io/smallrye/openapi/model/BaseExtensibleModel.java
@@ -237,6 +237,12 @@ public abstract class BaseExtensibleModel<C extends Extensible<C> & Constructibl
         }
     }
 
+    @Override
+    public boolean hasExtension(String name) {
+        return extensionNames.contains(name);
+    }
+
+    @Override
     public Object getExtension(String name) {
         if (extensionNames.contains(name)) {
             return super.getProperty(name);

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <version.eclipse.microprofile.config>3.0.3</version.eclipse.microprofile.config>
         <version.io.smallrye.jandex>3.2.3</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-config>3.10.2</version.io.smallrye.smallrye-config>
-        <version.eclipse.microprofile.openapi>4.0.2</version.eclipse.microprofile.openapi>
+        <version.eclipse.microprofile.openapi>4.1-SNAPSHOT</version.eclipse.microprofile.openapi>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.3</version.org.skyscreamer>


### PR DESCRIPTION
Implementing eclipse/microprofile-open-api#666, `Extensible.getExtension` already has an implementation.

Allow `hasExtension` and `getExtension` to handle internal extensions, as `addExtension` and `removeExtension` do. This means that they're not exactly equivalent to `getExtensions().hasKey` and `getExtensions().get`.

I think the tests added to the TCK are sufficient here.

Left in draft because it requires an update to a snapshot version of the spec, or the removal of `@Override`. I'm happy to remove the `@Override` annotations, unless we're going to update to a snapshot version anyway for #2163.