### PR TITLE
fix: improve handling of nullable parameters

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/internal/models/media/SchemaSupport.java
+++ b/core/src/main/java/io/smallrye/openapi/internal/models/media/SchemaSupport.java
@@ -128,6 +128,13 @@ public final class SchemaSupport {
         setTypesRetainingNull(observer, getTypeList(observed));
     }
 
+    public static Boolean isEmpty(Schema schema) {
+        if (schema instanceof BaseModel) {
+            return ((BaseModel<?>) schema).getAllProperties().isEmpty();
+        }
+        return null;
+    }
+
     static void notifyTypeObservers(Schema observed, Consumer<Schema> observerAction) {
         List<Schema> typeObservers = Extensions.getTypeObservers(observed);
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -716,9 +716,21 @@ public abstract class AbstractParameterProcessor {
         setDefaultValue(localSchema, context.defaultValue);
 
         if (localOnlySchemaModified(paramSchema, localSchema, modCount)) {
-            // Add new `allOf` schema, erasing `type` derived above from the local schema
-            Schema allOf = OASFactory.createSchema().addAllOf(paramSchema).addAllOf(localSchema.type((List<SchemaType>) null));
-            param.setSchema(allOf);
+            Boolean nullable = SchemaSupport.getNullable(localSchema);
+            localSchema.setType(null);
+
+            if (Boolean.FALSE.equals(SchemaSupport.isEmpty(localSchema))) {
+                // Add new `allOf` schema, erasing `type` derived above from the local schema
+                localSchema = OASFactory.createSchema()
+                        .addAllOf(paramSchema)
+                        .addAllOf(localSchema);
+                param.setSchema(localSchema);
+            } else if (Boolean.TRUE.equals(nullable)) {
+                localSchema = OASFactory.createSchema()
+                        .addAnyOf(paramSchema)
+                        .addAnyOf(SchemaSupport.nullSchema());
+                param.setSchema(localSchema);
+            }
         }
     }
 

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.nullable-ref-param-3.0.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.nullable-ref-param-3.0.json
@@ -1,0 +1,39 @@
+{
+  "openapi" : "3.0.3",
+  "components" : {
+    "schemas" : {
+      "StatusEnum" : {
+        "enum" : [ "VAL1", "VAL2" ],
+        "type" : "string"
+      }
+    }
+  },
+  "paths" : {
+    "/status" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "status",
+          "in" : "query",
+          "schema" : {
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/StatusEnum"
+            } ],
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.nullable-ref-param-3.1.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.nullable-ref-param-3.1.json
@@ -1,0 +1,40 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "StatusEnum" : {
+        "enum" : [ "VAL1", "VAL2" ],
+        "type" : "string"
+      }
+    }
+  },
+  "paths" : {
+    "/status" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "status",
+          "in" : "query",
+          "schema" : {
+            "anyOf" : [ {
+              "$ref" : "#/components/schemas/StatusEnum"
+            }, {
+              "type": "null"
+            } ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #2144

Since #2144 is using a slightly older pre-4.0 release, the current behavior is not exactly as described. 

With this change, given

```java
enum StatusEnum {
    VAL1,
    VAL2;
}

@jakarta.ws.rs.Path("/status")
static class FruitResource {
    @jakarta.ws.rs.GET
    public String get(@jakarta.ws.rs.QueryParam("status") @org.jetbrains.annotations.Nullable StatusEnum status) {
        return null;
    }
}
```


the expected `status` parameter schema would look like this for 3.0.x
```json
{
  "allOf" : [ {
    "$ref" : "#/components/schemas/StatusEnum"
  } ],
  "nullable" : true
}
```

or this for 3.1.x
```json
{
  "anyOf" : [ {
    "$ref" : "#/components/schemas/StatusEnum"
  }, {
    "type": "null"
  } ]
}
```