### PR TITLE
Add support for managed JAX-RS subresource locators

### DIFF
--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -402,7 +402,17 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             OpenAPI openApi,
             List<Parameter> locatorPathParameters,
             Set<String> tagRefs) {
-        final Type methodReturnType = context.getResourceTypeResolver().resolve(method.returnType());
+
+        // Extract the method return type, if the method return type is Class<?> then extract the type parameter.
+        Type methodReturnType;
+        if (method.returnType().kind() == Type.Kind.PARAMETERIZED_TYPE
+                && method.returnType().asParameterizedType().name().equals(DotName.createSimple(Class.class))
+                && method.returnType().asParameterizedType().arguments().size() == 1) {
+            methodReturnType = context.getResourceTypeResolver()
+                    .resolve(method.returnType().asParameterizedType().arguments().get(0));
+        } else {
+            methodReturnType = context.getResourceTypeResolver().resolve(method.returnType());
+        }
 
         if (Type.Kind.VOID.equals(methodReturnType.kind())) {
             // Can sub-resource locators return a CompletionStage?

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsAnnotationScanner.java
@@ -404,14 +404,10 @@ public class JaxRsAnnotationScanner extends AbstractAnnotationScanner {
             Set<String> tagRefs) {
 
         // Extract the method return type, if the method return type is Class<?> then extract the type parameter.
-        Type methodReturnType;
-        if (method.returnType().kind() == Type.Kind.PARAMETERIZED_TYPE
-                && method.returnType().asParameterizedType().name().equals(DotName.createSimple(Class.class))
-                && method.returnType().asParameterizedType().arguments().size() == 1) {
-            methodReturnType = context.getResourceTypeResolver()
-                    .resolve(method.returnType().asParameterizedType().arguments().get(0));
-        } else {
-            methodReturnType = context.getResourceTypeResolver().resolve(method.returnType());
+        Type methodReturnType = context.getResourceTypeResolver().resolve(method.returnType());
+        if (methodReturnType.kind() == Type.Kind.PARAMETERIZED_TYPE
+                && methodReturnType.asParameterizedType().name().equals(DotName.createSimple(Class.class))) {
+            methodReturnType = methodReturnType.asParameterizedType().arguments().get(0);
         }
 
         if (Type.Kind.VOID.equals(methodReturnType.kind())) {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SubresourceScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/SubresourceScanTests.java
@@ -33,6 +33,7 @@ class SubresourceScanTests extends IndexScannerTestBase {
                 test.io.smallrye.openapi.runtime.scanner.javax.MainTestResource.class,
                 test.io.smallrye.openapi.runtime.scanner.javax.Sub1TestResource.class,
                 test.io.smallrye.openapi.runtime.scanner.javax.Sub2TestResource.class,
+                test.io.smallrye.openapi.runtime.scanner.javax.Sub3TestResource.class,
                 test.io.smallrye.openapi.runtime.scanner.javax.RecursiveLocatorResource.class);
     }
 
@@ -42,6 +43,7 @@ class SubresourceScanTests extends IndexScannerTestBase {
                 test.io.smallrye.openapi.runtime.scanner.jakarta.MainTestResource.class,
                 test.io.smallrye.openapi.runtime.scanner.jakarta.Sub1TestResource.class,
                 test.io.smallrye.openapi.runtime.scanner.jakarta.Sub2TestResource.class,
+                test.io.smallrye.openapi.runtime.scanner.jakarta.Sub3TestResource.class,
                 test.io.smallrye.openapi.runtime.scanner.jakarta.RecursiveLocatorResource.class);
     }
 

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/Sub1TestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/Sub1TestResource.java
@@ -39,4 +39,8 @@ public class Sub1TestResource<T> {
         return new Sub2TestResource<T>();
     }
 
+    @Path(value = "/sub3/{sub3-id}")
+    public Class<Sub3TestResource> getSub3(@PathParam("sub3-id") String sub3Id) {
+        return Sub3TestResource.class;
+    }
 }

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/Sub3TestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/Sub3TestResource.java
@@ -1,0 +1,16 @@
+package test.io.smallrye.openapi.runtime.scanner.jakarta;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@SuppressWarnings(value = "unused")
+public class Sub3TestResource {
+
+    @GET
+    @Path(value = "{subsubid}")
+    public String getSub3(@PathParam("sub3-id") String sub3Id, @PathParam(value = "subsubid") String subsubid) {
+        return "Sub3TestResource";
+    }
+
+}

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/javax/Sub1TestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/javax/Sub1TestResource.java
@@ -39,4 +39,8 @@ public class Sub1TestResource<T> {
         return new Sub2TestResource<T>();
     }
 
+    @Path(value = "/sub3/{sub3-id}")
+    public Class<Sub3TestResource> getSub3(@PathParam("sub3-id") String sub3Id) {
+        return Sub3TestResource.class;
+    }
 }

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/javax/Sub3TestResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/javax/Sub3TestResource.java
@@ -1,0 +1,16 @@
+package test.io.smallrye.openapi.runtime.scanner.javax;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@SuppressWarnings(value = "unused")
+public class Sub3TestResource {
+
+    @GET
+    @Path(value = "{subsubid}")
+    public String getSub3(@PathParam("sub3-id") String sub3Id, @PathParam(value = "subsubid") String subsubid) {
+        return "Sub3TestResource";
+    }
+
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.subresources-with-params.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.subresources-with-params.json
@@ -301,6 +301,93 @@
         }
       ]
     },
+    "/resource{resource}/sub/{id}{idMatrix}/sub3/{sub3-id}/{subsubid}" : {
+      "parameters" : [ {
+        "style" : "matrix",
+        "explode" : true,
+        "schema" : {
+          "type" : "object",
+          "properties" : {
+            "r0m0" : {
+              "$ref" : "#/components/schemas/LocalDateTime"
+            },
+            "r0m1" : {
+              "$ref" : "#/components/schemas/LocalDateTime"
+            }
+          }
+        },
+        "name" : "resource",
+        "in" : "path",
+        "required" : true
+      }, {
+        "description" : "Resource Identifier",
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "style" : "matrix",
+        "explode" : true,
+        "schema" : {
+          "type" : "object",
+          "properties" : {
+            "m1" : {
+              "type" : "string"
+            },
+            "m2" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          }
+        },
+        "name" : "idMatrix",
+        "in" : "path",
+        "required" : true
+      }, {
+        "name" : "q1",
+        "in" : "query",
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "q2",
+        "in" : "query",
+        "schema" : {
+          "type" : "string"
+        }
+      } ],
+      "get" : {
+        "parameters" : [ {
+          "name" : "sub3-id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "subsubid",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/resource{resource}/sub0": {
       "get": {
         "parameters": [


### PR DESCRIPTION
This addresses #2168. The problem originates from the fact that `context.getResourceTypeResolver().resolve(method.returnType());` was assumed to contain the type of the sub resource. However, when dealing with managed resources, the `methodReturnType` will be set to `Class<SomeManagedResource>` which will not be found by `context.getIndex().getClassByName(methodReturnType.name());` (since it expects `SomeManagedResource` and not `Class<SomeManagedResource>` and therefore the managed sub resource is not processed. 

Questions:
- I am not familiar with the Jandex API at all, so please advice if there is a better way to implement the extraction of the type parameter from the generic class.
- Where is the best place to introduce tests for this? I quickly tested this by modifying the `GreetingGetResource`.