### PR TITLE
fix: use UTF-8 for InputStreamReaders relying on platform encoding

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -585,7 +586,7 @@ public class SmallRyeOpenAPI {
 
         private <V, A extends V, O extends V, AB, OB> void addStaticModel(BuildContext<V, A, O, AB, OB> ctx, InputStream stream,
                 String source, Format fileFormat) {
-            try (Reader reader = new InputStreamReader(stream)) {
+            try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
                 V dom = ctx.modelIO.jsonIO().fromReader(reader, fileFormat);
                 OpenAPI fileModel = ctx.modelIO.readValue(dom);
                 debugModel(source, fileModel);

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/JsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/JsonIO.java
@@ -8,6 +8,7 @@ import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -457,7 +458,7 @@ public interface JsonIO<V, A extends V, O extends V, AB, OB> {
      * @return the root JSON value from the document
      */
     default V fromStream(InputStream stream, Format format) {
-        try (Reader reader = new InputStreamReader(stream)) {
+        try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
             return fromReader(reader, format);
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
Make sure readers do not rely on platform default encoding when reading input streams. This will be back-ported to 4.0.x also.

For quarkusio/quarkus#44569