### PR TITLE
fix: restore core dependency on model-apt for correct build order

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,6 +35,12 @@
             <artifactId>smallrye-open-api-model</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-open-api-model-apt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Third Party Libraries -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Restore `core` dependency on `model-apt` module, removed in #2179 . The build failure was masked by the presence of model-apt in the GitHub Maven cache, which is now missing.