### PR TITLE
Add test for schema creation for custom collection classes

### DIFF
--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -474,6 +474,30 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
 
     /****************************************************************/
 
+    @Test
+    void testNonNestedCustomCollectionSchemas() throws IOException, JSONException {
+        assertJsonEquals("components.schemas.non-nested-custom-collections.json", MyMap.class, MyList.class,
+                MyDataObject.class);
+    }
+
+    @SuppressWarnings("serial")
+    @Schema
+    static class MyMap extends HashMap<String, MyDataObject> {
+    }
+
+    @SuppressWarnings("serial")
+    @Schema
+    static class MyList extends ArrayList<MyDataObject> {
+    }
+
+    @Schema
+    static class MyDataObject {
+        String name;
+        long value;
+    }
+
+    /****************************************************************/
+
     /*
      * https://github.com/smallrye/smallrye-open-api/issues/715
      */

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.non-nested-custom-collections.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.non-nested-custom-collections.json
@@ -1,0 +1,31 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "MyDataObject" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      },
+      "MyList" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/MyDataObject"
+        }
+      },
+      "MyMap" : {
+        "type" : "object",
+        "additionalProperties" : {
+          "$ref" : "#/components/schemas/MyDataObject"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These examples work fine in the current version but were broken in previous versions and I couldn't see a test for them.

I think this function was implemented in 3.3.0 with #1360.