### PR TITLE
Bump MicroProfile OpenAPI from 4.0.2 to 4.1-RC1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,8 @@ jobs:
         #- tck-version: "3.1.1"
         - title: "4.0.x"
           tck-version: "4.0.2"
+        - title: "4.1.x"
+          tck-version: "4.1-RC1"
 
     name: MicroProfile OpenAPI TCK ${{ matrix.title }}
     steps:

--- a/.github/workflows/publish-tck.yml
+++ b/.github/workflows/publish-tck.yml
@@ -20,6 +20,7 @@ jobs:
         #- tck-version: "3.0"
         #- tck-version: "3.1.1"
         - tck-version: "4.0.2"
+        - tck-version: "4.1-RC1"
 
     name: MicroProfile OpenAPI TCK ${{ matrix.tck-version }}
     steps:

--- a/core/src/main/java/io/smallrye/openapi/internal/models/package-info.java
+++ b/core/src/main/java/io/smallrye/openapi/internal/models/package-info.java
@@ -24,6 +24,7 @@
         @OASModelProperty(name = "paths", type = org.eclipse.microprofile.openapi.models.Paths.class),
         @OASModelProperty(name = "webhooks", type = Map.class, valueType = org.eclipse.microprofile.openapi.models.PathItem.class, minVersion = OpenApiVersion.V3_1),
         @OASModelProperty(name = "components", type = org.eclipse.microprofile.openapi.models.Components.class),
+        @OASModelProperty(name = "jsonSchemaDialect", type = String.class, minVersion = OpenApiVersion.V3_1),
 })
 @OASModelType(name = "Operation", constructible = org.eclipse.microprofile.openapi.models.Operation.class, properties = {
         @OASModelProperty(name = "tags", type = List.class, valueType = String.class),

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <version.eclipse.microprofile.config>3.0.3</version.eclipse.microprofile.config>
         <version.io.smallrye.jandex>3.2.7</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-config>3.10.2</version.io.smallrye.smallrye-config>
-        <version.eclipse.microprofile.openapi>4.0.2</version.eclipse.microprofile.openapi>
+        <version.eclipse.microprofile.openapi>4.1-RC1</version.eclipse.microprofile.openapi>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.3</version.org.skyscreamer>
@@ -77,6 +77,14 @@
         <url>https://github.com/smallrye/smallrye-open-api/</url>
         <tag>HEAD</tag>
     </scm>
+
+    <repositories>
+        <repository>
+            <id>orgeclipsemicroprofile-1732</id>
+            <name>microprofile-openapi-4.1-RC1</name>
+            <url>https://oss.sonatype.org/content/repositories/orgeclipsemicroprofile-1732</url>
+        </repository>
+    </repositories>
 
     <modules>
         <module>core</module>

--- a/testsuite/data/pom.xml
+++ b/testsuite/data/pom.xml
@@ -13,7 +13,7 @@
     <name>SmallRye: OpenAPI Test Data</name>
 
     <properties>
-        <eclipse.microprofile.openapi.version>4.0.2</eclipse.microprofile.openapi.version>
+        <eclipse.microprofile.openapi.version>4.1-RC1</eclipse.microprofile.openapi.version>
         <kotlin.version>2.0.21</kotlin.version>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -25,6 +25,14 @@
         <quarkus.package.type>uber-jar</quarkus.package.type>
         <quarkus.package.add-runner-suffix>false</quarkus.package.add-runner-suffix>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>orgeclipsemicroprofile-1732</id>
+            <name>microprofile-openapi-4.1-RC1</name>
+            <url>https://oss.sonatype.org/content/repositories/orgeclipsemicroprofile-1732</url>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Update MicroProfile OpenAPI to 4.1-RC1. Includes staging repository reference due to MP OpenAPI's pre-release status.