### PR TITLE
build(deps): Bump org.mvnpm:swagger-ui-dist from 5.18.2 to 5.20.1

### DIFF
--- a/ui/open-api-ui/pom.xml
+++ b/ui/open-api-ui/pom.xml
@@ -13,7 +13,7 @@
     <name>SmallRye: OpenAPI UI</name>
 
     <properties>
-        <swagger-ui.version>5.18.3</swagger-ui.version>
+        <swagger-ui.version>5.19.0</swagger-ui.version>
         <swagger-ui-theme.version>3.0.1</swagger-ui-theme.version>
         <path.swagger-ui>openapi-ui</path.swagger-ui>
         <sonar.skip>true</sonar.skip>

--- a/ui/open-api-ui/pom.xml
+++ b/ui/open-api-ui/pom.xml
@@ -13,7 +13,7 @@
     <name>SmallRye: OpenAPI UI</name>
 
     <properties>
-        <swagger-ui.version>5.18.2</swagger-ui.version>
+        <swagger-ui.version>5.18.3</swagger-ui.version>
         <swagger-ui-theme.version>3.0.1</swagger-ui-theme.version>
         <path.swagger-ui>openapi-ui</path.swagger-ui>
         <sonar.skip>true</sonar.skip>

--- a/ui/open-api-ui/pom.xml
+++ b/ui/open-api-ui/pom.xml
@@ -13,7 +13,7 @@
     <name>SmallRye: OpenAPI UI</name>
 
     <properties>
-        <swagger-ui.version>5.19.0</swagger-ui.version>
+        <swagger-ui.version>5.20.0</swagger-ui.version>
         <swagger-ui-theme.version>3.0.1</swagger-ui-theme.version>
         <path.swagger-ui>openapi-ui</path.swagger-ui>
         <sonar.skip>true</sonar.skip>

--- a/ui/open-api-ui/pom.xml
+++ b/ui/open-api-ui/pom.xml
@@ -13,7 +13,7 @@
     <name>SmallRye: OpenAPI UI</name>
 
     <properties>
-        <swagger-ui.version>5.20.0</swagger-ui.version>
+        <swagger-ui.version>5.20.1</swagger-ui.version>
         <swagger-ui-theme.version>3.0.1</swagger-ui-theme.version>
         <path.swagger-ui>openapi-ui</path.swagger-ui>
         <sonar.skip>true</sonar.skip>


### PR DESCRIPTION
Backport dependabot updates for swagger-ui from `main`.

Bumps [org.mvnpm:swagger-ui-dist](https://github.com/swagger-api/swagger-ui) from 5.18.2 to 5.20.1.
- [Release notes](https://github.com/swagger-api/swagger-ui/releases)
- [Changelog](https://github.com/swagger-api/swagger-ui/blob/master/.releaserc)
- [Commits](https://github.com/swagger-api/swagger-ui/compare/v5.18.2...v5.20.1)