### PR TITLE
fix: support duplicateOperationIdBehavior in Gradle plugin (#2231)

### DIFF
--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
@@ -191,6 +191,7 @@ class Configs implements SmallryeOpenApiProperties {
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_LICENSE_NAME, infoLicenseName);
         addToPropertyMap(cp, SmallRyeOASConfig.INFO_LICENSE_URL, infoLicenseUrl);
         addToPropertyMap(cp, SmallRyeOASConfig.OPERATION_ID_STRAGEGY, operationIdStrategy);
+        addToPropertyMap(cp, SmallRyeOASConfig.DUPLICATE_OPERATION_ID_BEHAVIOR, duplicateOperationIdBehavior);
         addToPropertyMap(cp, SmallRyeOASConfig.SCAN_PROFILES, scanProfiles);
         addToPropertyMap(cp, SmallRyeOASConfig.SCAN_EXCLUDE_PROFILES, scanExcludeProfiles);
         addToPropertyMap(cp, SmallRyeOASConfig.SCAN_RESOURCE_CLASS_PREFIX, scanResourceClasses);


### PR DESCRIPTION
Backport for 4.0.9