### PR TITLE
fix: preserve Schema annotation `nullable` after setting type

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -113,6 +113,12 @@
             <version>1.1.7</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>26.0.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/io/smallrye/openapi/internal/models/media/SchemaSupport.java
+++ b/core/src/main/java/io/smallrye/openapi/internal/models/media/SchemaSupport.java
@@ -167,7 +167,8 @@ public final class SchemaSupport {
     private static void setTypeList(Schema schema, List<SchemaType> types) {
         if (schema instanceof io.smallrye.openapi.internal.models.media.Schema) {
             ((io.smallrye.openapi.internal.models.media.Schema) schema).setTypeList(types);
+        } else {
+            schema.setType(types);
         }
-        schema.setType(types);
     }
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -198,6 +198,7 @@ public class SchemaFactory {
         schema.setRequired(readAttr(context, annotation, SchemaConstant.PROP_REQUIRED_PROPERTIES, defaults));
         schema.setDescription(readAttr(context, annotation, SchemaConstant.PROP_DESCRIPTION, defaults));
         schema.setFormat(readAttr(context, annotation, SchemaConstant.PROP_FORMAT, defaults));
+        SchemaSupport.setNullable(schema, readAttr(context, annotation, SchemaConstant.PROP_NULLABLE, defaults));
         schema.setReadOnly(readAttr(context, annotation, SchemaConstant.PROP_READ_ONLY, defaults));
         schema.setWriteOnly(readAttr(context, annotation, SchemaConstant.PROP_WRITE_ONLY, defaults));
         schema.setExternalDocs(context.io().extDocIO().read(annotation.value(SchemaConstant.PROP_EXTERNAL_DOCS)));
@@ -205,7 +206,6 @@ public class SchemaFactory {
 
         final SchemaType type = readSchemaType(context, annotation, schema, defaults);
         SchemaSupport.setType(schema, readSchemaType(context, annotation, schema, defaults));
-        SchemaSupport.setNullable(schema, readAttr(context, annotation, SchemaConstant.PROP_NULLABLE, defaults));
 
         Object example = parseSchemaAttr(context, annotation, SchemaConstant.PROP_EXAMPLE, defaults, type);
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -198,7 +198,6 @@ public class SchemaFactory {
         schema.setRequired(readAttr(context, annotation, SchemaConstant.PROP_REQUIRED_PROPERTIES, defaults));
         schema.setDescription(readAttr(context, annotation, SchemaConstant.PROP_DESCRIPTION, defaults));
         schema.setFormat(readAttr(context, annotation, SchemaConstant.PROP_FORMAT, defaults));
-        SchemaSupport.setNullable(schema, readAttr(context, annotation, SchemaConstant.PROP_NULLABLE, defaults));
         schema.setReadOnly(readAttr(context, annotation, SchemaConstant.PROP_READ_ONLY, defaults));
         schema.setWriteOnly(readAttr(context, annotation, SchemaConstant.PROP_WRITE_ONLY, defaults));
         schema.setExternalDocs(context.io().extDocIO().read(annotation.value(SchemaConstant.PROP_EXTERNAL_DOCS)));
@@ -206,6 +205,7 @@ public class SchemaFactory {
 
         final SchemaType type = readSchemaType(context, annotation, schema, defaults);
         SchemaSupport.setType(schema, readSchemaType(context, annotation, schema, defaults));
+        SchemaSupport.setNullable(schema, readAttr(context, annotation, SchemaConstant.PROP_NULLABLE, defaults));
 
         Object example = parseSchemaAttr(context, annotation, SchemaConstant.PROP_EXAMPLE, defaults, type);
 

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -903,7 +903,7 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         @Schema
         final class Bean {
-            @Schema(required = false, description = "Any description", nullable = false, example = "3072")
+            @Schema(required = false, description = "Any description", nullable = false, examples = "3072")
             @org.jetbrains.annotations.Nullable
             private final Long amount;
 

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -35,6 +35,7 @@ import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -895,6 +896,29 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
 
         assertJsonEquals("components.schemas.example-not-merged.json",
                 scan(config(SmallRyeOASConfig.SMALLRYE_MERGE_SCHEMA_EXAMPLES, "false"), null, new Class[] { DTO.class }));
+    }
+
+    @Test
+    void testKotlinNullableSetNonNullable() throws IOException, JSONException {
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @Schema
+        final class Bean {
+            @Schema(required = false, description = "Any description", nullable = false, example = "3072")
+            @org.jetbrains.annotations.Nullable
+            private final Long amount;
+
+            @SuppressWarnings("unused")
+            public Bean(@org.jetbrains.annotations.Nullable Long amount) {
+                this.amount = amount;
+            }
+
+            @org.jetbrains.annotations.Nullable
+            public final Long getAmount() {
+                return this.amount;
+            }
+        }
+
+        assertJsonEquals("components.schemas.nonnullable-kotlin-nullable.json", Bean.class);
     }
 
     @Test

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.nonnullable-kotlin-nullable.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.nonnullable-kotlin-nullable.json
@@ -1,0 +1,18 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "8Bean" : {
+        "type" : "object",
+        "properties" : {
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "Any description",
+            "examples" : [ 3072 ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2254

This will also be cherry-picked for 4.0.11