### PR TITLE
fix: recursively resolve parameterized types from type variables

### DIFF
--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -1056,4 +1056,32 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
         assertJsonEquals("components.schemas.implementation-no-introspection.json", UseSchemaImplementationImpl.class,
                 UseSchemaImplementationType.class, UseSchemaImplementationType2.class);
     }
+
+    @Test
+    @SuppressWarnings("unused")
+    void testParameterizedGenericTypeResolution() throws IOException, JSONException {
+        @Schema(name = "Bean")
+        class Bean {
+            String name;
+            int age;
+        }
+
+        class GenericRoot<T> {
+            T data;
+        }
+
+        class GenericListRoot<T> extends GenericRoot<List<T>> {
+        }
+
+        @Schema(name = "Data")
+        class Data extends GenericRoot<Bean> {
+        }
+
+        @Schema(name = "DataList")
+        class DataList extends GenericListRoot<Bean> {
+        }
+
+        assertJsonEquals("components.schemas.resolved-mapped-generic-ptype.json",
+                Bean.class, GenericRoot.class, GenericListRoot.class, Data.class, DataList.class);
+    }
 }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.resolved-mapped-generic-ptype.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.resolved-mapped-generic-ptype.json
@@ -1,0 +1,38 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "Bean" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "age" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "Data" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Bean"
+          }
+        }
+      },
+      "DataList" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Bean"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2311 

This change refactors how generic type resolution handles variables that resolve to a parameterized type that itself contains a type variable. For example `MyType<T> extends AnotherType<List<T>>`. 

Previously, the resolved type of `T` would have been "stuck" as `List<T>` which then makes the schema of `T` simply `type: object` in the resulting OpenAPI. The fix here will allow `List<T>`  or any of a parameterized type's arguments to further be resolved using the type resolution variable mappings.

Also for backport to `4.0.x`