### PR TITLE
Include content and media types w/o schema for opaque response types

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -310,6 +310,10 @@ public interface OpenApiConfig {
         return getConfigValue(SmallRyeOASConfig.SMALLRYE_SORTED_PARAMETERS_ENABLE, Boolean.class, () -> Boolean.TRUE);
     }
 
+    default boolean defaultWithInternalResponse() {
+        return getConfigValue(SmallRyeOASConfig.SMALLRYE_DEFAULT_WITH_INTERNAL_RESPONSE, Boolean.class, () -> Boolean.FALSE);
+    }
+
     default Integer getMaximumStaticFileSize() {
         return getConfigValue(SmallRyeOASConfig.MAXIMUM_STATIC_FILE_SIZE, Integer.class,
                 () -> MAXIMUM_STATIC_FILE_SIZE_DEFAULT);

--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOASConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOASConfig.java
@@ -25,6 +25,7 @@ public final class SmallRyeOASConfig {
     private static final String SUFFIX_REMOVE_UNUSED_SCHEMAS_ENABLE = "remove-unused-schemas.enable";
     private static final String SUFFIX_MERGE_SCHEMA_EXAMPLES = "merge-schema-examples";
     private static final String SUFFIX_SORTED_PARAMETERS_ENABLE = "sorted-parameters.enable";
+    private static final String SUFFIX_DEFAULT_WITH_INTERNAL_RESPONSE = "default-with-internal-response";
     private static final String SMALLRYE_PREFIX = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME;
 
     public static final String SMALLRYE_SCAN_DEPENDENCIES_DISABLE = SMALLRYE_PREFIX + SUFFIX_SCAN_DEPENDENCIES_DISABLE;
@@ -54,6 +55,9 @@ public final class SmallRyeOASConfig {
     public static final String SMALLRYE_MERGE_SCHEMA_EXAMPLES = SMALLRYE_PREFIX + SUFFIX_MERGE_SCHEMA_EXAMPLES;
 
     public static final String SMALLRYE_SORTED_PARAMETERS_ENABLE = SMALLRYE_PREFIX + SUFFIX_SORTED_PARAMETERS_ENABLE;
+
+    public static final String SMALLRYE_DEFAULT_WITH_INTERNAL_RESPONSE = SMALLRYE_PREFIX
+            + SUFFIX_DEFAULT_WITH_INTERNAL_RESPONSE;
 
     public static final String SCAN_PROFILES = SMALLRYE_PREFIX + "scan.profiles";
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ApiResponseTests.java
@@ -13,6 +13,10 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.smallrye.openapi.api.SmallRyeOASConfig;
 
 /**
  * @author Michael Edgar {@literal <michael@xlate.io>} and Scott Curtis {@literal <Scott.Curtis@ibm.com>}
@@ -414,5 +418,40 @@ class ApiResponseTests extends IndexScannerTestBase {
                 HttpTreeApi.class,
                 Reference.class,
                 ReferencesResponse.class);
+    }
+
+    /*
+     * Test case for Smallrye OpenAPI issue #2315.
+     *
+     * https://github.com/smallrye/smallrye-open-api/issues/2315
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "true,  responses.multivariant-internal-with-default.json",
+            "false, responses.multivariant-internal-with-code.json"
+    })
+    void testMultiVariantDefaultResponseType(Boolean defaultResponse, String expectedResource)
+            throws IOException, JSONException {
+        @jakarta.ws.rs.Path("data")
+        class DataApi {
+            @jakarta.ws.rs.GET
+            @jakarta.ws.rs.PUT
+            @jakarta.ws.rs.POST
+            @jakarta.ws.rs.DELETE
+            @jakarta.ws.rs.Path("endpoint")
+            @jakarta.ws.rs.Produces({
+                    jakarta.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM,
+                    jakarta.ws.rs.core.MediaType.APPLICATION_JSON,
+                    jakarta.ws.rs.core.MediaType.APPLICATION_XML,
+            })
+            public jakarta.ws.rs.core.Response handle() {
+                return null;
+            }
+        }
+
+        assertJsonEquals(expectedResource, scan(
+                config(SmallRyeOASConfig.SMALLRYE_DEFAULT_WITH_INTERNAL_RESPONSE, defaultResponse),
+                (java.io.InputStream) null,
+                DataApi.class));
     }
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/examples.parameters.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/examples.parameters.json
@@ -63,7 +63,10 @@
       "get" : {
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.beanparam-multipartform-inherited.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.beanparam-multipartform-inherited.json
@@ -21,7 +21,10 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       }
@@ -53,7 +56,10 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       }
@@ -84,7 +90,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       }
@@ -115,7 +124,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.request-body-annotation-on-arg.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.request-body-annotation-on-arg.json
@@ -25,7 +25,10 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.request-body-items-ref.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.request-body-items-ref.json
@@ -34,7 +34,10 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-reactive-missing-restpath.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.resteasy-reactive-missing-restpath.json
@@ -14,11 +14,14 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
-    },    
+    },
     "/movies/{id}" : {
       "get" : {
         "parameters" : [ {

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types-wo-array-refs.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types-wo-array-refs.json
@@ -118,7 +118,10 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -245,7 +248,10 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -356,7 +362,10 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.generic-model-types.json
@@ -127,7 +127,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -259,7 +262,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -375,7 +381,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.string-implementation-wrapped.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.parameters.string-implementation-wrapped.json
@@ -15,7 +15,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.kotlin-continuation-opaque.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.kotlin-continuation-opaque.json
@@ -15,7 +15,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {}
+            }
           }
         }
       }
@@ -34,7 +37,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {}
+            }
           }
         }
       }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.multivariant-internal-with-code.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.multivariant-internal-with-code.json
@@ -1,0 +1,55 @@
+{
+  "openapi" : "3.1.0",
+  "paths" : {
+    "/data/endpoint" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/octet-stream" : { },
+              "application/json" : { },
+              "application/xml" : { }
+            }
+          }
+        }
+      },
+      "put" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/octet-stream" : { },
+              "application/json" : { },
+              "application/xml" : { }
+            }
+          }
+        }
+      },
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/octet-stream" : { },
+              "application/json" : { },
+              "application/xml" : { }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/octet-stream" : { },
+              "application/json" : { },
+              "application/xml" : { }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.multivariant-internal-with-default.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/responses.multivariant-internal-with-default.json
@@ -1,0 +1,55 @@
+{
+  "openapi" : "3.1.0",
+  "paths" : {
+    "/data/endpoint" : {
+      "get" : {
+        "responses" : {
+          "default" : {
+            "description" : "Default Response",
+            "content" : {
+              "application/octet-stream" : { },
+              "application/json" : { },
+              "application/xml" : { }
+            }
+          }
+        }
+      },
+      "put" : {
+        "responses" : {
+          "default" : {
+            "description" : "Default Response",
+            "content" : {
+              "application/octet-stream" : { },
+              "application/json" : { },
+              "application/xml" : { }
+            }
+          }
+        }
+      },
+      "post" : {
+        "responses" : {
+          "default" : {
+            "description" : "Default Response",
+            "content" : {
+              "application/octet-stream" : { },
+              "application/json" : { },
+              "application/xml" : { }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "responses" : {
+          "default" : {
+            "description" : "Default Response",
+            "content" : {
+              "application/octet-stream" : { },
+              "application/json" : { },
+              "application/xml" : { }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-with-ignored.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/special.jsonview-with-ignored.json
@@ -146,7 +146,10 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       },
@@ -179,7 +182,10 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       },
@@ -212,7 +218,10 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       },


### PR DESCRIPTION
Also add new configuration property `mp.openapi.extensions.smallrye.default-with-internal-response` (name up for discussion) to use `default` response entry in these cases.

To-do:
- add docs to README for new property
- resolve TCK failure due to (incorrect?) assumption by TCK that a media type always has a schema. This does not appear to be required by the OAS spec.

Fixes #2315 