### PR TITLE
fix: ignore duplicated parameters on paths and operations

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/ScannerSPILogging.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/ScannerSPILogging.java
@@ -25,4 +25,9 @@ interface ScannerSPILogging { // NOSONAR (use of constants in an interface)
     @Message(id = 7903, value = "Duplicate operationId: %s produced by Class: %s, Method: %s and Class: %s, Method: %s")
     void duplicateOperationId(String operationId, String className, String method, String conflictingClassName,
             String conflictingMethod);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 7904, value = "Ignoring duplicate parameter named '%s' in location '%s' with style '%s', specified on %s")
+    void duplicateParameter(String name, String location, String style, String target);
+
 }

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.ignored-name-type-duplicates.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.ignored-name-type-duplicates.json
@@ -1,0 +1,29 @@
+{
+  "openapi" : "3.1.0",
+  "paths" : {
+    "/resource" : {
+      "get" : {
+        "parameters" : [ {
+          "description" : "Hi",
+          "name" : "qparam",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Get a message",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2325

Also re-factor several occurrences of stream processing to simple loops to improve ease of debugging.