### PR TITLE
Restore SmallRyeOpenAPI.Builder binary compatibility (buildFinalize)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,15 @@ jobs:
             !**/target/surefire-reports/**/*
             !**/target/maven-it/**/*
 
+      - name: Archive Failed Tests Results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: artifacts-${{ matrix.os }}-java${{matrix.java}} 
+          path: |
+            **/target/failsafe-reports/
+            **/target/surefire-reports/
+            
   tck-reporting:
     runs-on: ubuntu-latest
     strategy:

--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
@@ -654,6 +654,10 @@ public class SmallRyeOpenAPI {
             return new SmallRyeOpenAPI(model, ctx.modelIO.write(model).orElse(null), toString, unmodifiable);
         }
 
+        protected <V> SmallRyeOpenAPI buildFinalize(BuildContext<V, ?, ?, ?, ?> ctx) {
+            return buildFinalize(ctx, false);
+        }
+
         protected static class BuildContext<V, A extends V, O extends V, AB, OB> {
             ClassLoader appClassLoader;
             OpenApiConfig buildConfig;

--- a/testsuite/data/pom.xml
+++ b/testsuite/data/pom.xml
@@ -115,6 +115,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <version>1.5.3</version>
@@ -308,6 +312,7 @@
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>
                         <maven.home>${maven.home}</maven.home>
+                        <quarkus.test.arg-line>${jacocoArgLine}</quarkus.test.arg-line>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -354,6 +359,29 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                           <execution>
+                                <id>default-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
+                                    <destFile>${project.build.directory}/jacoco.exec</destFile>
+                                    <append>true</append>
+                                </configuration>
+                           </execution>
+                           <execution>
+                                <id>default-prepare-agent-integration</id>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${project.build.directory}/jacoco.exec</destFile>
+                                    <append>true</append>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/testsuite/data/src/test/java/io/smallrye/openapi/testdata/QuarkusOpenAPIEndpointIT.java
+++ b/testsuite/data/src/test/java/io/smallrye/openapi/testdata/QuarkusOpenAPIEndpointIT.java
@@ -1,0 +1,27 @@
+package io.smallrye.openapi.testdata;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.greaterThan;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = """
+        dev services uses testcontainers, not supported on Windows
+        WARN  [org.tes.doc.DockerClientProviderStrategy] (build-26) windows is currently not supported
+        """)
+class QuarkusOpenAPIEndpointIT {
+
+    @Test
+    void testOpenAPIEndpointResponds() {
+        given()
+                .when().get("/q/openapi.json")
+                .then()
+                .body("paths", aMapWithSize(greaterThan(0)));
+    }
+}


### PR DESCRIPTION
Fixes #2344

As noted in the issue, restoring the original `buildFinalize` as a proxy to the new `buildFinalize` using `false` for new `unmodifiable` option restores compatibility with current Quarkus versions for those wishing to use smallrye-open-api 4.1.x versions.

Also added is a small smoke test in the Quarkus test application used to help verify the builder is executing the newly restored method.