### PR TITLE
Add support for custom OperationIdStrategy implementations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -111,3 +111,15 @@ Set this boolean value to enable or disable the sorting of parameter array entri
 mp.openapi.extensions.smallrye.generic-response-use-default
 ----
 Set this boolean value to enable the automatic use of the https://spec.openapis.org/oas/v3.1.0.html#responses-object[`default` response code] for framework response types (e.g. Jakarta REST's `Response` type) when no `@APIResponse` annotations have been used and the HTTP response code for an operation cannot be determined. When unset or `false`, the response code will be set to `200`.
+
+* Operation ID Strategy
++
+[source%nowrap]
+----
+mp.openapi.extensions.smallrye.operationIdStrategy
+----
+Specify a strategy to be used globally for generating operation IDs when not specified via an annotation or static OpenAPI input. If not set, operation IDs will not be generated. Set to one of the following:
+** `METHOD` (may result in duplicate operation IDs in an application where REST endpoint method names are not unique)
+** `CLASS_METHOD` (may result in duplicate operation IDs in an application where REST endpoint simple class name + method names are not unique)
+** `PACKAGE_CLASS_METHOD`
+** A fully-qualified class name of an implementation of `io.smallrye.openapi.api.OperationIdGenerator` (as of 4.1.2, https://javadoc.io/doc/io.smallrye/smallrye-open-api-core/latest/io/smallrye/openapi/api/OperationIdGenerator.html[see JavaDoc])

--- a/core/src/main/java/io/smallrye/openapi/api/ApiMessages.java
+++ b/core/src/main/java/io/smallrye/openapi/api/ApiMessages.java
@@ -1,8 +1,11 @@
 package io.smallrye.openapi.api;
 
 import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
+
+import io.smallrye.openapi.runtime.OpenApiRuntimeException;
 
 @MessageBundle(projectCode = "SROAP", length = 5)
 interface ApiMessages {
@@ -16,4 +19,7 @@ interface ApiMessages {
 
     @Message(id = 2, value = "OpenApiConfig must be set before init")
     IllegalStateException configMustBeSet();
+
+    @Message(id = 3, value = "Exception accessing operationIdStrategy: %s")
+    OpenApiRuntimeException invalidOperationIdStrategyWithCause(String strategyName, @Cause Throwable cause);
 }

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -60,10 +60,44 @@ public interface OpenApiConfig {
                     "org.eclipse.microprofile.openapi",
                     "org.jetbrains.annotations")));
 
-    enum OperationIdStrategy {
-        METHOD,
-        CLASS_METHOD,
-        PACKAGE_CLASS_METHOD
+    class OperationIdStrategy {
+        private OperationIdStrategy() {
+        }
+
+        /**
+         * Strategy name to generate an operationId with the resource method's
+         * name
+         */
+        public static final String METHOD = "METHOD";
+        /**
+         * Strategy name to generate an operationId with the resource class's
+         * simple name and the resource method's name
+         */
+        public static final String CLASS_METHOD = "CLASS_METHOD";
+        /**
+         * Strategy name to generate an operationId with the resource class's
+         * fully-qualified name and the resource method's name
+         */
+        public static final String PACKAGE_CLASS_METHOD = "PACKAGE_CLASS_METHOD";
+
+        /**
+         * Support compatibility with Quarkus configuration mapping. May be
+         * removed once Quarkus is updated to no longer treat the
+         * operation-id-strategy as an enum.
+         *
+         * @deprecated not for general purpose use. See
+         *             {@link OperationIdGenerator#load(String, ClassLoader)}
+         *             instead
+         */
+        @Deprecated(since = "4.1.2")
+        public static OperationIdStrategy valueOf(String value) { // NOSONAR
+            return new OperationIdStrategy() {
+                @Override
+                public String toString() {
+                    return value;
+                }
+            };
+        }
     }
 
     enum DuplicateOperationIdBehavior {
@@ -241,8 +275,8 @@ public interface OpenApiConfig {
         return getConfigValue(SmallRyeOASConfig.INFO_LICENSE_URL, String.class, () -> null);
     }
 
-    default OperationIdStrategy getOperationIdStrategy() {
-        return getConfigValue(SmallRyeOASConfig.OPERATION_ID_STRAGEGY, String.class, OperationIdStrategy::valueOf, () -> null);
+    default String getOperationIdStrategy() {
+        return getConfigValue(SmallRyeOASConfig.OPERATION_ID_STRAGEGY, String.class, () -> null);
     }
 
     default DuplicateOperationIdBehavior getDuplicateOperationIdBehavior() {

--- a/core/src/main/java/io/smallrye/openapi/api/OperationIdGenerator.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OperationIdGenerator.java
@@ -1,0 +1,73 @@
+package io.smallrye.openapi.api;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+
+import io.smallrye.openapi.api.OpenApiConfig.OperationIdStrategy;
+
+/**
+ * Interface that may be implemented to generate custom operationId values.
+ *
+ * Three built-in generators may be used by specifying an operationIdStrategy
+ * configuration property value of METHOD, CLASS_METHOD, or
+ * PACKAGE_CLASS_METHOD. Otherwise, an fully-qualified implementation name may
+ * be given for a custom generator.
+ *
+ * @since 4.1.2
+ */
+@FunctionalInterface
+public interface OperationIdGenerator {
+
+    /**
+     * Derive an operationId given the Jandex resource ClassInfo and MethodInfo.
+     *
+     * @param resourceClass
+     *        the resource class. E.g. a Jakarta REST end-point class
+     * @param method
+     *        the resource method. E.g. a Jakarta REST end-point method.
+     *        This may be declared in a class other than the resourceClass
+     *        such as a parent class or interface.
+     * @return value to be used for the OpenAPI operationId
+     */
+    String generateOperationId(ClassInfo resourceClass, MethodInfo method);
+
+    /**
+     * Loads an OperationIdGenerator instance by name. If providing a
+     * fully-qualified implementation class name, the class must be loadable
+     * using the provided ClassLoader. The loader is not required or used
+     * when one of the built-in strategy names is provided.
+     *
+     * @param strategyName
+     *        name of the OperationIdGenerator to load
+     * @param loader
+     *        ClassLoader to load a custom implementation, if necessary
+     * @return the requested OperationIdGenerator
+     */
+    public static OperationIdGenerator load(String strategyName, ClassLoader loader) {
+        final OperationIdGenerator strategy;
+
+        switch (strategyName) {
+            case OperationIdStrategy.METHOD:
+                strategy = (c, m) -> m.name();
+                break;
+            case OperationIdStrategy.CLASS_METHOD:
+                strategy = (c, m) -> c.name().withoutPackagePrefix() + "_" + m.name();
+                break;
+            case OperationIdStrategy.PACKAGE_CLASS_METHOD:
+                strategy = (c, m) -> c.name() + "_" + m.name();
+                break;
+            default:
+                final Class<?> strategyType;
+
+                try {
+                    strategyType = loader.loadClass(strategyName);
+                    strategy = (OperationIdGenerator) strategyType.getConstructor().newInstance();
+                } catch (Exception e) {
+                    throw ApiMessages.msg.invalidOperationIdStrategyWithCause(strategyName, e);
+                }
+                break;
+        }
+
+        return strategy;
+    }
+}

--- a/testsuite/data/src/main/resources/application.properties
+++ b/testsuite/data/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+mp.openapi.extensions.smallrye.operationIdStrategy=METHOD

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/Configs.java
@@ -57,7 +57,7 @@ class Configs implements SmallryeOpenApiProperties {
     final Property<String> infoContactUrl;
     final Property<String> infoLicenseName;
     final Property<String> infoLicenseUrl;
-    final Property<OpenApiConfig.OperationIdStrategy> operationIdStrategy;
+    final Property<String> operationIdStrategy;
     final Property<OpenApiConfig.DuplicateOperationIdBehavior> duplicateOperationIdBehavior;
     final ListProperty<String> scanProfiles;
     final ListProperty<String> scanExcludeProfiles;
@@ -93,7 +93,7 @@ class Configs implements SmallryeOpenApiProperties {
         infoContactUrl = objects.property(String.class);
         infoLicenseName = objects.property(String.class);
         infoLicenseUrl = objects.property(String.class);
-        operationIdStrategy = objects.property(OpenApiConfig.OperationIdStrategy.class);
+        operationIdStrategy = objects.property(String.class);
         duplicateOperationIdBehavior = objects.property(OpenApiConfig.DuplicateOperationIdBehavior.class);
         scanProfiles = objects.listProperty(String.class);
         scanExcludeProfiles = objects.listProperty(String.class);
@@ -130,7 +130,7 @@ class Configs implements SmallryeOpenApiProperties {
         infoContactUrl = objects.property(String.class).convention(ext.getInfoContactUrl());
         infoLicenseName = objects.property(String.class).convention(ext.getInfoLicenseName());
         infoLicenseUrl = objects.property(String.class).convention(ext.getInfoLicenseUrl());
-        operationIdStrategy = objects.property(OpenApiConfig.OperationIdStrategy.class)
+        operationIdStrategy = objects.property(String.class)
                 .convention(ext.getOperationIdStrategy());
         duplicateOperationIdBehavior = objects.property(OpenApiConfig.DuplicateOperationIdBehavior.class)
                 .convention(ext.getDuplicateOperationIdBehavior());
@@ -325,7 +325,7 @@ class Configs implements SmallryeOpenApiProperties {
         return infoLicenseUrl;
     }
 
-    public Property<OpenApiConfig.OperationIdStrategy> getOperationIdStrategy() {
+    public Property<String> getOperationIdStrategy() {
         return operationIdStrategy;
     }
 

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiProperties.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiProperties.java
@@ -121,7 +121,7 @@ public interface SmallryeOpenApiProperties {
      * Configuration property to specify how the operationid is generated. Can be used to minimize
      * risk of collisions between operations.
      */
-    Property<OpenApiConfig.OperationIdStrategy> getOperationIdStrategy();
+    Property<String> getOperationIdStrategy();
 
     /**
      * Configuration property to specify what should happen if duplicate operationIds occur.

--- a/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
+++ b/tools/gradle-plugin/src/main/java/io/smallrye/openapi/gradleplugin/SmallryeOpenApiTask.java
@@ -418,7 +418,7 @@ public class SmallryeOpenApiTask extends DefaultTask implements SmallryeOpenApiP
     @Input
     @Optional
     @Override
-    public Property<OpenApiConfig.OperationIdStrategy> getOperationIdStrategy() {
+    public Property<String> getOperationIdStrategy() {
         return properties.operationIdStrategy;
     }
 


### PR DESCRIPTION
Closes #2243 

~~Depends on #2345 (included until other PR is merged and this is re-based).~~