### PR TITLE
Use jdk11 profile for CI with older dependencies, update build matrices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,9 @@ jobs:
         - 11
         - 17
         - 21
+        tck-version:
+        - "4.0.2"
+        - "4.1"
 
         include:
         # Disable older TCK jobs prior to 4.0 GA release 
@@ -149,5 +152,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         name: tck-report
         with:
-          name: "tck-report-${{ matrix.tck-version }}"
+          name: "tck-report-${{ matrix.tck-version }}-jdk${{ matrix.java }}"
           path: "testsuite/tck/target/surefire-reports/microprofile-openapi-tck-report.html"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
         java:
         - 17
         - 21
+        - 25
     runs-on: ${{ matrix.os }}
     name: build with jdk ${{matrix.java}} (${{ matrix.os }}) 
 
@@ -101,6 +102,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java:
+        - 11
+        - 17
+        - 21
+        - 25
+
         include:
         # Disable older TCK jobs prior to 4.0 GA release 
         #- tck-version: "2.0.1"
@@ -111,7 +118,7 @@ jobs:
         - title: "4.1.x"
           tck-version: "4.1"
 
-    name: MicroProfile OpenAPI TCK ${{ matrix.title }}
+    name: MicroProfile OpenAPI TCK ${{ matrix.title }} with jdk ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v5
         name: checkout
@@ -136,7 +143,7 @@ jobs:
         name: set up jdk
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: ${{ matrix.java }}
 
       - name: execute tck ${{ matrix.tck-version }}
         run: mvn -B test -f testsuite/tck/pom.xml -Dsmallrye.commit=$(git rev-parse HEAD) -Dversion.eclipse.microprofile.openapi=${{ matrix.tck-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
           java-version: 17
 
       - name: build with maven
-        run: mvn -B install -pl '!testsuite/coverage,!testsuite/data,!testsuite/extra,!tools,!tools/gradle-plugin,!tools/maven-plugin,!ui,!ui/open-api-ui,!ui/open-api-ui-forms' -DskipTests
+        run: mvn -B install -pl 'testsuite/tck' -am -DskipTests
 
       - uses: actions/setup-java@v5
         name: set up jdk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
         java:
         - 17
         - 21
-        - 25
     runs-on: ${{ matrix.os }}
     name: build with jdk ${{matrix.java}} (${{ matrix.os }}) 
 
@@ -106,7 +105,6 @@ jobs:
         - 11
         - 17
         - 21
-        - 25
 
         include:
         # Disable older TCK jobs prior to 4.0 GA release 

--- a/.github/workflows/publish-tck.yml
+++ b/.github/workflows/publish-tck.yml
@@ -14,15 +14,15 @@ jobs:
 
     strategy:
       matrix:
-        include:
-        # Disable older TCK jobs prior to 4.0 GA release
-        #- tck-version: "2.0.1"
-        #- tck-version: "3.0"
-        #- tck-version: "3.1.1"
-        - tck-version: "4.0.2"
-        - tck-version: "4.1"
+        java:
+        - 11
+        - 17
+        - 21
+        tck-version:
+        - "4.0.2"
+        - "4.1"
 
-    name: MicroProfile OpenAPI TCK ${{ matrix.tck-version }}
+    name: MicroProfile OpenAPI TCK ${{ matrix.tck-version }} with jdk ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v5
         name: checkout ${{inputs.version}}
@@ -49,16 +49,16 @@ jobs:
         name: set up jdk
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: ${{ matrix.java }}
 
       - name: execute tck ${{ matrix.tck-version }}
         run: mvn -B test -f testsuite/tck/pom.xml -Dsmallrye.commit=$(git rev-parse HEAD) -Dversion.eclipse.microprofile.openapi=${{ matrix.tck-version }}
 
       - name: stage tck report
-        run: mv testsuite/tck/target/surefire-reports/microprofile-openapi-tck-report.html ./microprofile-openapi-tck-report-${{ matrix.tck-version }}.html
+        run: mv testsuite/tck/target/surefire-reports/microprofile-openapi-tck-report.html ./microprofile-openapi-tck-report-${{ matrix.tck-version }}-jdk${{ matrix.java }}.html
 
       - name: upload tck report to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ inputs.version }} microprofile-openapi-tck-report-${{ matrix.tck-version }}.html
+          gh release upload ${{ inputs.version }} microprofile-openapi-tck-report-${{ matrix.tck-version }}-jdk${{ matrix.java }}.html

--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
         <profile>
             <id>jdk11</id>
             <activation>
-                <jdk>11</jdk>
+                <jdk>[11,17)</jdk>
             </activation>
             <properties>
                 <jboss.extra.opts>--add-modules java.se</jboss.extra.opts>
@@ -446,9 +446,9 @@
         </profile>
 
         <profile>
-            <id>jdk12plus</id>
+            <id>jdk17plus</id>
             <activation>
-                <jdk>[12,)</jdk>
+                <jdk>[17,)</jdk>
             </activation>
             <properties>
                 <jboss.extra.opts>--add-modules java.se</jboss.extra.opts>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
         <jackson-bom.version>2.20.0</jackson-bom.version>
         <version.eclipse.microprofile.config>3.0.3</version.eclipse.microprofile.config>
         <version.io.smallrye.jandex>3.5.0</version.io.smallrye.jandex>
-        <version.io.smallrye.smallrye-config>3.10.2</version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-config>3.14.0</version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-common-classloader>2.13.9</version.io.smallrye.smallrye-common-classloader>
         <version.eclipse.microprofile.openapi>4.1</version.eclipse.microprofile.openapi>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
@@ -32,9 +33,7 @@
         <version.testng>7.11.0</version.testng>
         <version.arquillian.jetty>2.0.0.Final</version.arquillian.jetty>
         <version.jetty>11.0.24</version.jetty>
-
-        <!-- Use Jakarta EE 10 versions -->
-        <version.resteasy>6.2.3.Final</version.resteasy>
+        <version.resteasy>7.0.0.Final</version.resteasy>
         <version.weld.core>5.1.2.Final</version.weld.core>
 
         <!--
@@ -129,7 +128,7 @@
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-classloader</artifactId>
-                <version>2.8.0</version>
+                <version>${version.io.smallrye.smallrye-common-classloader}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.config</groupId>
@@ -370,24 +369,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.asciidoctor</groupId>
-                    <artifactId>asciidoctor-maven-plugin</artifactId>
-                    <configuration>
-                        <sourceHighlighter>coderay</sourceHighlighter>
-                        <attributes>
-                            <icons>font</icons>
-                            <pagenums />
-                            <version>${project.version}</version>
-                            <idprefix />
-                            <idseparator>-</idseparator>
-                            <allow-uri-read>true</allow-uri-read>
-                            <revnumber>${project.version}</revnumber>
-                            <revdate>${maven.build.timestamp}</revdate>
-                            <organization>${project.organization.name}</organization>
-                        </attributes>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${version.buildhelper.plugin}</version>
@@ -428,7 +409,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${version.maven-resources-plugin}</version>
             </plugin>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -452,9 +432,23 @@
         </profile>
 
         <profile>
-            <id>jdk11plus</id>
+            <id>jdk11</id>
             <activation>
-                <jdk>[11,)</jdk>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <jboss.extra.opts>--add-modules java.se</jboss.extra.opts>
+                <maven.compiler.release>11</maven.compiler.release>
+                <version.io.smallrye.smallrye-common-classloader>2.8.0</version.io.smallrye.smallrye-common-classloader>
+                <version.io.smallrye.smallrye-config>3.10.2</version.io.smallrye.smallrye-config>
+                <version.resteasy>6.2.3.Final</version.resteasy>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>jdk12plus</id>
+            <activation>
+                <jdk>[12,)</jdk>
             </activation>
             <properties>
                 <jboss.extra.opts>--add-modules java.se</jboss.extra.opts>


### PR DESCRIPTION
- Update JDK 11 Maven profile to use older Java 11 compatible library versions. As libraries are upgraded to new versions supporting Java 17 and beyond, they will be added here so that we can still run the TCK in a Java 11 environment.
- Run each supported version of the TCK with Java 11, 17, and 21 and attach/publish reports to releases.
- Delete plugin management for unused `asciidoctor-maven-plugin`