### PR TITLE
Enable YAML alias expansion for Jackson IO

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -123,3 +123,11 @@ Specify a strategy to be used globally for generating operation IDs when not spe
 ** `CLASS_METHOD` (may result in duplicate operation IDs in an application where REST endpoint simple class name + method names are not unique)
 ** `PACKAGE_CLASS_METHOD`
 ** A fully-qualified class name of an implementation of `io.smallrye.openapi.api.OperationIdGenerator` (as of 4.1.2, https://javadoc.io/doc/io.smallrye/smallrye-open-api-core/latest/io/smallrye/openapi/api/OperationIdGenerator.html[see JavaDoc])
+
+* YAML Alias Expansion (as of 4.1.2)
++
+[source%nowrap]
+----
+mp.openapi.extensions.smallrye.yaml-alias-expansion.enable
+----
+Set this boolean value to enable or disable the expansion of YAML aliases when loading a static OpenAPI file. When enabled (set to `true`), aliases encountered in the YAML will expand to the value of the YAML node having an anchor of the same name (see more about YAML https://yaml.org/spec/1.1/#id863390[anchors and aliases in the YAML 1.1 specification]). When disabled (set to `false`), aliases will not be expanded. If not set, it will default to `true`.

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -348,6 +348,10 @@ public interface OpenApiConfig {
         return getConfigValue(SmallRyeOASConfig.SMALLRYE_GENERIC_RESPONSE_USE_DEFAULT, Boolean.class, () -> Boolean.FALSE);
     }
 
+    default boolean yamlAliasExpansionEnable() {
+        return getConfigValue(SmallRyeOASConfig.SMALLRYE_YAML_ALIAS_EXPANSION_ENABLE, Boolean.class, () -> Boolean.TRUE);
+    }
+
     default Integer getMaximumStaticFileSize() {
         return getConfigValue(SmallRyeOASConfig.MAXIMUM_STATIC_FILE_SIZE, Integer.class,
                 () -> MAXIMUM_STATIC_FILE_SIZE_DEFAULT);

--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOASConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOASConfig.java
@@ -26,6 +26,7 @@ public final class SmallRyeOASConfig {
     private static final String SUFFIX_MERGE_SCHEMA_EXAMPLES = "merge-schema-examples";
     private static final String SUFFIX_SORTED_PARAMETERS_ENABLE = "sorted-parameters.enable";
     private static final String SUFFIX_GENERIC_RESPONSE_USE_DEFAULT = "generic-response-use-default";
+    private static final String SUFFIX_YAML_ALIAS_EXPANSION_ENABLE = "yaml-alias-expansion.enable";
     private static final String SMALLRYE_PREFIX = OASConfig.EXTENSIONS_PREFIX + VENDOR_NAME;
 
     public static final String SMALLRYE_SCAN_DEPENDENCIES_DISABLE = SMALLRYE_PREFIX + SUFFIX_SCAN_DEPENDENCIES_DISABLE;
@@ -58,6 +59,8 @@ public final class SmallRyeOASConfig {
 
     public static final String SMALLRYE_GENERIC_RESPONSE_USE_DEFAULT = SMALLRYE_PREFIX
             + SUFFIX_GENERIC_RESPONSE_USE_DEFAULT;
+
+    public static final String SMALLRYE_YAML_ALIAS_EXPANSION_ENABLE = SMALLRYE_PREFIX + SUFFIX_YAML_ALIAS_EXPANSION_ENABLE;
 
     public static final String SCAN_PROFILES = SMALLRYE_PREFIX + "scan.profiles";
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/JacksonJsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/JacksonJsonIO.java
@@ -60,7 +60,9 @@ class JacksonJsonIO implements JsonIO<JsonNode, ArrayNode, ObjectNode, ArrayNode
          * YAML to be in-lined as if the elements were repeated throughout a
          * source document.
          */
-        yamlFactory = new YAMLAnchorReplayingFactory(yamlFactory, null);
+        if (this.config.yamlAliasExpansionEnable()) {
+            yamlFactory = new YAMLAnchorReplayingFactory(yamlFactory, null);
+        }
 
         this.yamlMapper = jsonMapper.copyWith(yamlFactory);
         this.yamlWriter = yamlMapper.writer().with(yamlFactory);

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/JacksonJsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/JacksonJsonIOTest.java
@@ -1,6 +1,10 @@
 package io.smallrye.openapi.runtime.io;
 
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -10,10 +14,27 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class JacksonJsonIOTest extends JsonIOTest<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
 
+    private Properties originalSystemProperties;
+
     @BeforeEach
-    void setup() {
+    void setup(TestInfo testInfo) {
+        originalSystemProperties = System.getProperties();
+        Properties testSystemProperties = new Properties();
+        originalSystemProperties.forEach(testSystemProperties::put);
+        System.setProperties(testSystemProperties);
+
+        testInfo.getTags().stream()
+                .filter(tag -> tag.startsWith("property:"))
+                .map(tag -> tag.substring("property:".length()))
+                .map(tag -> tag.split("="))
+                .forEach(tag -> System.setProperty(tag[0], tag[1]));
+
         super.target = new JacksonJsonIO(new ObjectMapper()
                 .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS));
     }
 
+    @AfterEach
+    void teardown() {
+        System.setProperties(originalSystemProperties);
+    }
 }

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/JsonIOTest.java
@@ -1,9 +1,16 @@
 package io.smallrye.openapi.runtime.io;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.math.BigDecimal;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -33,5 +40,61 @@ abstract class JsonIOTest<V, A extends V, O extends V, AB, OB> {
         V jsonValue = target.getValue(value, "key");
         Object javaValue = target.fromJson(jsonValue);
         assertEquals(new BigDecimal(expected), javaValue);
+    }
+
+    @Test
+    void testSimpleAliasExpansion() {
+        String input = ""
+                + "---\n"
+                + "openapi: 3.1.0\n"
+                + "info:\n"
+                + "  title: &info_title Cool API Title\n"
+                + "  description: *info_title"; // description points to title's value
+
+        @SuppressWarnings("unchecked")
+        O value = (O) target.fromString(input, Format.YAML);
+        String title = target.getObject(value, "info")
+                .map(info -> target.getString(info, "title"))
+                .orElseThrow();
+        String description = target.getObject(value, "info")
+                .map(info -> target.getString(info, "description"))
+                .orElseThrow();
+
+        assertEquals("Cool API Title", title);
+        assertEquals(title, description);
+    }
+
+    @Test
+    void testAliasedPathItemExpansion() throws IOException {
+        O resource1;
+        O resource2;
+
+        try (InputStream source = getClass().getResourceAsStream("openapi-aliased-pathitem.yaml");
+                Reader reader = new InputStreamReader(source)) {
+            @SuppressWarnings("unchecked")
+            O value = (O) target.fromReader(reader);
+            resource1 = target.getObject(value, "paths")
+                    .flatMap(paths -> target.getObject(paths, "/api/resource1"))
+                    .orElseThrow();
+            resource2 = target.getObject(value, "paths")
+                    .flatMap(paths -> target.getObject(paths, "/api/resource2"))
+                    .orElseThrow();
+        }
+
+        assertTrue(target.isObject(resource1));
+
+        O r1get = target.getObject(resource1, "get").orElseThrow();
+        O r2get = target.getObject(resource2, "get").orElseThrow();
+
+        assertTrue(target.isObject(r1get));
+        assertEquals(r1get, r2get);
+
+        O r1post = target.getObject(resource1, "post").orElse(null);
+        O r2post = target.getObject(resource2, "post").orElse(null);
+
+        assertNull(r1post);
+        assertTrue(target.isObject(r2post));
+        assertEquals("putResource2", target.getString(r2post, "operationId"));
+
     }
 }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/io/openapi-aliased-pathitem.yaml
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/io/openapi-aliased-pathitem.yaml
@@ -1,0 +1,33 @@
+---
+openapi: 3.1.0
+info:
+  title: Simple API with Anchors and Aliases
+  description: An API definition that demonstrates the use of YAML anchors and aliases for data reuse
+  termsOfService: http://example.com/terms/
+  contact:
+    name: API Support
+    url: http://www.example.com/support
+    email: support@example.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+paths:
+  /api/resource1: &resource1
+    get:
+      content:
+        application/json:
+          schema:
+            property:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+              description:
+                type: string
+  # resource2 has the same layout as resource1
+  /api/resource2:
+    <<: *resource1
+    post:
+      operationId: putResource2


### PR DESCRIPTION
Fixes #1237 

TBD if this should be either opt-in (default disabled) or opt-out (default enabled). Currently, it is enabled and cannot be disabled.