### PR TITLE
Improve method/field property name match, fix delimited name strategies

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/PropertyNamingStrategyFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/PropertyNamingStrategyFactory.java
@@ -100,19 +100,15 @@ public class PropertyNamingStrategyFactory {
 
             for (int i = 0; i < propertyName.length(); i++) {
                 final char c = propertyName.charAt(i);
+                final char next = propertyName.length() > i + 1 ? propertyName.charAt(i + 1) : '\0';
+                final char transformed = converter.apply(c);
 
-                if (Character.isUpperCase(c)) {
-                    final char transformed = converter.apply(c);
-
-                    if (current.length() > 0) {
-                        global.append(current).append(separator);
-                        current.setLength(0);
-                    }
-
-                    current.append(transformed);
-                } else {
-                    current.append(c);
+                if (current.length() > 0 && Character.isUpperCase(c) && !Character.isUpperCase(next)) {
+                    global.append(current).append(separator);
+                    current.setLength(0);
                 }
+
+                current.append(transformed);
             }
 
             if (current.length() > 0) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -1029,11 +1029,28 @@ public class TypeResolver {
         }
 
         if (nameStart > 0) {
-            StringBuilder nameBuffer = new StringBuilder(methodName.length());
-            nameBuffer.append(methodName);
-            nameBuffer.setCharAt(nameStart, Character.toLowerCase(methodName.charAt(nameStart)));
+            String rawPropertyName = methodName.substring(nameStart);
+            if (Optional.ofNullable(properties.get(rawPropertyName)).map(p -> p.field).isPresent()) {
+                /*
+                 * The raw property name name matches the field name. Do not modify further.
+                 * E.g. field is URL and method is getURL.
+                 */
+                return rawPropertyName;
+            }
 
-            propertyName = nameBuffer.substring(nameStart);
+            /*
+             * If first two chars are upper-case, do nothing
+             * (following java.beans.Introspector.decapitalize(String))
+             */
+            if (rawPropertyName.length() > 1
+                    && Character.isUpperCase(rawPropertyName.charAt(1))
+                    && Character.isUpperCase(rawPropertyName.charAt(0))) {
+                propertyName = rawPropertyName;
+            } else {
+                StringBuilder nameBuffer = new StringBuilder(rawPropertyName);
+                nameBuffer.setCharAt(0, Character.toLowerCase(rawPropertyName.charAt(0)));
+                propertyName = nameBuffer.toString();
+            }
         } else {
             propertyName = methodName;
         }

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/PropertyNamingStrategyTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/PropertyNamingStrategyTest.java
@@ -50,21 +50,21 @@ class PropertyNamingStrategyTest extends IndexScannerTestBase {
     }
 
     @Test
-    void testInvalidNamingStrategyClass() throws Exception {
+    void testInvalidNamingStrategyClass() {
         Config config = config(SmallRyeOASConfig.SMALLRYE_PROPERTY_NAMING_STRATEGY,
                 "com.fasterxml.jackson.databind.PropertyNamingStrategies$InvalidStrategy");
         assertThrows(OpenApiRuntimeException.class, () -> scan(config, NameStrategyKebab.class));
     }
 
     @Test
-    void testNoValidTranslationMethods() throws Exception {
+    void testNoValidTranslationMethods() {
         Config config = config(SmallRyeOASConfig.SMALLRYE_PROPERTY_NAMING_STRATEGY,
                 NoValidTranslationMethods.class.getName());
         assertThrows(OpenApiRuntimeException.class, () -> scan(config, NameStrategyKebab.class));
     }
 
     @Test
-    void testInvalidPropertyNameTranslationAttempt() throws Exception {
+    void testInvalidPropertyNameTranslationAttempt() {
         Config config = config(SmallRyeOASConfig.SMALLRYE_PROPERTY_NAMING_STRATEGY,
                 TranslationThrowsException.class.getName());
         assertThrows(OpenApiRuntimeException.class, () -> scan(config, NameStrategyBean3.class));
@@ -79,7 +79,7 @@ class PropertyNamingStrategyTest extends IndexScannerTestBase {
             JsonbConstants.UPPER_CAMEL_CASE_WITH_SPACES + ", Simple String One|Another Field|Y|Z|SOME Value",
             JsonbConstants.CASE_INSENSITIVE + ", simpleStringOne|anotherField|Y|z|SOMEValue"
     })
-    void testJsonbConstantStrategy(String strategy, String expectedNames) throws Exception {
+    void testJsonbConstantStrategy(String strategy, String expectedNames) {
         OpenAPI result = scan(config(SmallRyeOASConfig.SMALLRYE_PROPERTY_NAMING_STRATEGY, strategy), NameStrategyBean3.class);
         List<String> expectedNameList = Arrays.asList(expectedNames.split("\\|"));
         Collections.sort(expectedNameList, String::compareToIgnoreCase);
@@ -90,6 +90,12 @@ class PropertyNamingStrategyTest extends IndexScannerTestBase {
         Collections.sort(actualNameList, String::compareToIgnoreCase);
 
         assertEquals(expectedNameList, actualNameList);
+    }
+
+    @Test
+    void testMethodNamePreserved() throws Exception {
+        OpenAPI result = scan(NameStrategyBean4.class);
+        assertJsonEquals("components.schemas.method-name-preserved.json", result);
     }
 
     @Schema
@@ -119,9 +125,9 @@ class PropertyNamingStrategyTest extends IndexScannerTestBase {
     static class NameStrategyBean3 {
         String simpleStringOne;
         Integer anotherField;
-        BigDecimal Y;
+        BigDecimal Y; // NOSONAR - naming intentional
         double z;
-        String SOMEValue;
+        String SOMEValue; // NOSONAR - naming intentional
 
         public String getSimpleStringOne() {
             return simpleStringOne;
@@ -144,14 +150,35 @@ class PropertyNamingStrategyTest extends IndexScannerTestBase {
         }
     }
 
-    public static class NoValidTranslationMethods {
-        public NoValidTranslationMethods() {
+    @Schema
+    static class NameStrategyBean4 {
+        @Schema(name = "TESTValue", title = "Test Value")
+        Integer TestValue; // NOSONAR - naming intentional
+
+        @Schema(name = "eValue", title = "e-Value")
+        String EValue; // NOSONAR - naming intentional
+
+        @Schema(description = "Property for TestValue")
+        public Integer getTESTValue() {
+            return TestValue;
         }
 
+        @Schema(description = "Property for e-Value")
+        public String geteValue() {
+            return EValue;
+        }
+
+    }
+
+    public static class NoValidTranslationMethods {
         public String translate() {
             return null;
         }
 
+        /**
+         * @param v1 unused, demonstrated unsuitable translate method signature
+         * @param v2 unused, demonstrated unsuitable translate method signature
+         */
         public String translate(String v1, String v2) {
             return null;
         }

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/PropertyNamingStrategyTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/PropertyNamingStrategyTest.java
@@ -4,10 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -71,20 +72,24 @@ class PropertyNamingStrategyTest extends IndexScannerTestBase {
 
     @ParameterizedTest(name = "testJsonbConstantStrategy-{0}")
     @CsvSource({
-            JsonbConstants.IDENTITY + ", simpleStringOne|anotherField|Y|z",
-            JsonbConstants.LOWER_CASE_WITH_DASHES + ", simple-string-one|another-field|y|z",
-            JsonbConstants.LOWER_CASE_WITH_UNDERSCORES + ", simple_string_one|another_field|y|z",
-            JsonbConstants.UPPER_CAMEL_CASE + ", SimpleStringOne|AnotherField|Y|Z",
-            JsonbConstants.UPPER_CAMEL_CASE_WITH_SPACES + ", Simple String One|Another Field|Y|Z",
-            JsonbConstants.CASE_INSENSITIVE + ", simpleStringOne|anotherField|Y|z"
+            JsonbConstants.IDENTITY + ", simpleStringOne|anotherField|Y|z|SOMEValue",
+            JsonbConstants.LOWER_CASE_WITH_DASHES + ", simple-string-one|another-field|y|z|some-value",
+            JsonbConstants.LOWER_CASE_WITH_UNDERSCORES + ", simple_string_one|another_field|y|z|some_value",
+            JsonbConstants.UPPER_CAMEL_CASE + ", SimpleStringOne|AnotherField|Y|Z|SOMEValue",
+            JsonbConstants.UPPER_CAMEL_CASE_WITH_SPACES + ", Simple String One|Another Field|Y|Z|SOME Value",
+            JsonbConstants.CASE_INSENSITIVE + ", simpleStringOne|anotherField|Y|z|SOMEValue"
     })
     void testJsonbConstantStrategy(String strategy, String expectedNames) throws Exception {
         OpenAPI result = scan(config(SmallRyeOASConfig.SMALLRYE_PROPERTY_NAMING_STRATEGY, strategy), NameStrategyBean3.class);
-        Set<String> expectedNameSet = new TreeSet<>(Arrays.asList(expectedNames.split("\\|")));
+        List<String> expectedNameList = Arrays.asList(expectedNames.split("\\|"));
+        Collections.sort(expectedNameList, String::compareToIgnoreCase);
+
         Map<String, org.eclipse.microprofile.openapi.models.media.Schema> schemas = result.getComponents().getSchemas();
         org.eclipse.microprofile.openapi.models.media.Schema schema = schemas.get(NameStrategyBean3.class.getSimpleName());
-        assertEquals(expectedNameSet.size(), schema.getProperties().size());
-        assertEquals(expectedNameSet, schema.getProperties().keySet());
+        List<String> actualNameList = new ArrayList<>(schema.getProperties().keySet());
+        Collections.sort(actualNameList, String::compareToIgnoreCase);
+
+        assertEquals(expectedNameList, actualNameList);
     }
 
     @Schema
@@ -116,6 +121,27 @@ class PropertyNamingStrategyTest extends IndexScannerTestBase {
         Integer anotherField;
         BigDecimal Y;
         double z;
+        String SOMEValue;
+
+        public String getSimpleStringOne() {
+            return simpleStringOne;
+        }
+
+        public Integer getAnotherField() {
+            return anotherField;
+        }
+
+        public BigDecimal getY() {
+            return Y;
+        }
+
+        public double getZ() {
+            return z;
+        }
+
+        public String getSOMEValue() {
+            return SOMEValue;
+        }
     }
 
     public static class NoValidTranslationMethods {

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.method-name-preserved.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.method-name-preserved.json
@@ -1,0 +1,23 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "NameStrategyBean4" : {
+        "type" : "object",
+        "properties" : {
+          "TESTValue" : {
+            "type" : "integer",
+            "format" : "int32",
+            "description" : "Property for TestValue",
+            "title" : "Test Value"
+          },
+          "eValue" : {
+            "type" : "string",
+            "description" : "Property for e-Value",
+            "title" : "e-Value"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2379 

- Improve method/field property name match. When a method name stripped of `get`/`set`/`is` matches a field name exactly, use the field name as the OpenAPI property name.
- Fix delimited name strategies. Account for scenarios where multiple upper-case characters should be preserved by the naming strategies. E.g. with the snake-case strategy, rather than converting `SOMEValue` to `s-o-m-e-value`, treat the leading upper-case chars as a unit and convert to `some-value`.