### PR TITLE
Adding a test to validate processing rules (@ExternalDocumentation ATM)

### DIFF
--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/ProcessingRulesTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/ProcessingRulesTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.openapi.tck.extra;
+
+import org.eclipse.microprofile.openapi.tck.AppTestBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import io.restassured.response.ValidatableResponse;
+import test.io.smallrye.openapi.tck.ExtraSuiteTestBase;
+
+/**
+ * NOTE: It's not a TCK test, it only leverages the TCK test setup
+ */
+public class ProcessingRulesTest extends ExtraSuiteTestBase<ProcessingRulesTest.ProcessingRulesTestArquillian> {
+
+    public static class ProcessingRulesTestArquillian extends AppTestBase {
+        @Deployment(name = "processing-rules")
+        public static WebArchive createDeployment() {
+            return ShrinkWrap.create(WebArchive.class, "ProcessingRules.war")
+                    .addPackages(true, new String[] { "io.smallrye.openapi.tck.extra.procrules" })
+                    .addAsManifestResource("set-model-reader.properties", "microprofile-config.properties");
+        }
+
+        @RunAsClient
+        @Test(dataProvider = "formatProvider")
+        public void testPathItems(String type) {
+            ValidatableResponse vr = this.callEndpoint(type);
+            vr.body("externalDocs.url", org.hamcrest.Matchers.notNullValue());
+            vr.body("externalDocs.url", org.hamcrest.Matchers.is("http://widget-external-docs.org"));
+            vr.body("externalDocs.description", org.hamcrest.Matchers.notNullValue());
+            vr.body("externalDocs.description", org.hamcrest.Matchers.is("Widget resource external documentation"));
+        }
+
+    }
+}

--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/procrules/OpenApiModelReader.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/procrules/OpenApiModelReader.java
@@ -1,0 +1,26 @@
+package io.smallrye.openapi.tck.extra.procrules;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASModelReader;
+import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+/**
+ * Generates a base model to be used by the OpenAPI.
+ */
+public class OpenApiModelReader implements OASModelReader {
+    /**
+     * Creates a new {@link ExternalDocumentation} instance, modifying the output OpenAPI document.
+     *
+     * @return A new {@link OpenAPI} instance that will serve as base for generation
+     */
+    @Override
+    public OpenAPI buildModel() {
+        OpenAPI api = OASFactory.createObject(OpenAPI.class);
+        ExternalDocumentation externalDocumentation = OASFactory.createExternalDocumentation();
+        externalDocumentation.setUrl("http://oas-model-reader-based-external-docs.org");
+        externalDocumentation.setDescription("Could be overridden by static files and/or annotations");
+        api.setExternalDocs(externalDocumentation);
+        return api;
+    }
+}

--- a/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/procrules/WidgetResourceWithAnnotations.java
+++ b/testsuite/extra/src/test/java/io/smallrye/openapi/tck/extra/procrules/WidgetResourceWithAnnotations.java
@@ -1,0 +1,9 @@
+package io.smallrye.openapi.tck.extra.procrules;
+
+import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
+
+import io.smallrye.openapi.tck.extra.jaxrs.WidgetResource;
+
+@ExternalDocumentation(url = "http://widget-external-docs.org", description = "Widget resource external documentation")
+public class WidgetResourceWithAnnotations extends WidgetResource {
+}

--- a/testsuite/extra/src/test/resources/set-model-reader.properties
+++ b/testsuite/extra/src/test/resources/set-model-reader.properties
@@ -1,0 +1,1 @@
+mp.openapi.model.reader=io.smallrye.openapi.tck.extra.procrules.OpenApiModelReader


### PR DESCRIPTION
This test aims at validating processing rules, see https://download.eclipse.org/microprofile/microprofile-open-api-4.1/microprofile-openapi-spec-4.1.html#_processing_rules
It is about an application which includes a resources that is annotated with `@ExternalDocumentation`.

According to the MicroProfile OpenAPI Javadoc, the generated OpenAPI documentation should include an `externalDocs` element at root level, but it does not, and the test is failing.

_Note_: 
The test logic uses a custom `OASModelReader` instance in order to generate the OpenAPI model with an initial value for the `externalDocs` element, which should be overridden by the annotation. The test would fail even when such initial step is not executed, i.e. when line 39 is commented out.