### PR TITLE
Skip defaulting schema type to `object` when `implementation` is void

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/schema/SchemaFactory.java
@@ -521,7 +521,7 @@ public class SchemaFactory {
      * @param schemaReferenceSupported
      */
     static Schema readClassSchema(final AnnotationScannerContext context, Type type, boolean schemaReferenceSupported) {
-        if (type == null) {
+        if (type == null || TypeUtil.isVoid(type)) {
             return null;
         }
         Schema schema;

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -113,6 +113,7 @@ public class TypeUtil {
     // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#dataTypeFormat
     static {
         TYPE_MAP.put(DOTNAME_OBJECT, ANY);
+        TYPE_MAP.put(DOTNAME_VOID, ANY);
 
         // String
         TYPE_MAP.put(DotName.createSimple(String.class.getName()), STRING_FORMAT);

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/StandaloneSchemaScanTest.java
@@ -1084,4 +1084,31 @@ class StandaloneSchemaScanTest extends IndexScannerTestBase {
         assertJsonEquals("components.schemas.resolved-mapped-generic-ptype.json",
                 Bean.class, GenericRoot.class, GenericListRoot.class, Data.class, DataList.class);
     }
+
+    static final class TestVoidImplementationNoType {
+        @Schema(oneOf = { Implementation.class, String.class }, implementation = Void.class)
+        interface IFace1 {
+        }
+
+        interface IFace2 {
+        }
+
+        @Schema(additionalProperties = Schema.False.class)
+        static class Implementation implements IFace1 {
+            @Schema(required = true, description = "Identifier")
+            String id;
+            @Schema(defaultValue = "1", minimum = "1", description = "Sequence of this implemenatation instance")
+            long sequence;
+            @Schema(oneOf = { Implementation.class, String.class }, implementation = Void.class)
+            IFace2 oneOfIface2;
+            @Schema(implementation = String.class)
+            IFace2 stringIface2;
+        }
+    }
+
+    @Test
+    void testVoidImplementationNoType() throws IOException, JSONException {
+        assertJsonEquals("components.schemas.void-implementation-no-type.json",
+                TestVoidImplementationNoType.IFace1.class, TestVoidImplementationNoType.Implementation.class);
+    }
 }

--- a/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.void-implementation-no-type.json
+++ b/core/src/test/resources/io/smallrye/openapi/runtime/scanner/components.schemas.void-implementation-no-type.json
@@ -1,0 +1,42 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "IFace1" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/Implementation"
+        }, {
+          "type" : "string"
+        } ]
+      },
+      "Implementation" : {
+        "additionalProperties" : false,
+        "type" : "object",
+        "required" : [ "id" ],
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "Identifier"
+          },
+          "sequence" : {
+            "type" : "integer",
+            "format" : "int64",
+            "minimum" : 1,
+            "description" : "Sequence of this implemenatation instance",
+            "default" : 1
+          },
+          "oneOfIface2" : {
+            "oneOf" : [ {
+              "$ref" : "#/components/schemas/Implementation"
+            }, {
+              "type" : "string"
+            } ]
+          },
+          "stringIface2" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/refsEnabled.kitchenSink.expected.json
@@ -502,7 +502,6 @@
             }
           },
           "voidField": {
-            "type": "object"
           },
           "writeOnlyInteger": {
             "format": "int32",


### PR DESCRIPTION
Fixes #2432 