### PR TITLE
Remove unnecessary CDI annotations from several tests

### DIFF
--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/MethodTargetParametersResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/jakarta/MethodTargetParametersResource.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.enterprise.context.RequestScoped;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -25,7 +24,6 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 @Path(value = "/policies")
 @Produces(value = "application/json")
 @Consumes(value = "application/json")
-@RequestScoped
 public class MethodTargetParametersResource {
 
     public static class PagedResponse<T> {

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/javax/MethodTargetParametersResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/javax/MethodTargetParametersResource.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -25,7 +24,6 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 @Path(value = "/policies")
 @Produces(value = "application/json")
 @Consumes(value = "application/json")
-@RequestScoped
 public class MethodTargetParametersResource {
 
     public static class PagedResponse<T> {

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/jakarta/NestedSchemaOnParameterResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/jakarta/NestedSchemaOnParameterResource.java
@@ -3,7 +3,6 @@ package test.io.smallrye.openapi.runtime.scanner.resources.jakarta;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.enterprise.context.Dependent;
 import jakarta.json.bind.annotation.JsonbProperty;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -46,7 +45,6 @@ public class NestedSchemaOnParameterResource {
         String name;
     }
 
-    @Dependent
     @Schema(name = "another_nested", description = "The name of this child is not 'AnotherNestedChildWithSchemaName'")
     public static class AnotherNestedChildWithSchemaName {
         @Schema(required = true)

--- a/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/javax/NestedSchemaOnParameterResource.java
+++ b/extension-jaxrs/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/javax/NestedSchemaOnParameterResource.java
@@ -3,7 +3,6 @@ package test.io.smallrye.openapi.runtime.scanner.resources.javax;
 import java.util.List;
 import java.util.Map;
 
-import javax.enterprise.context.Dependent;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -46,7 +45,6 @@ public class NestedSchemaOnParameterResource {
         String name;
     }
 
-    @Dependent
     @Schema(name = "another_nested", description = "The name of this child is not 'AnotherNestedChildWithSchemaName'")
     public static class AnotherNestedChildWithSchemaName {
         @Schema(required = true)

--- a/pom.xml
+++ b/pom.xml
@@ -151,12 +151,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <!-- CDI -->
-            <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>2.0</version>
-            </dependency>
             <!-- JaxRS -->
             <dependency>
                 <groupId>javax.ws.rs</groupId>
@@ -286,17 +280,6 @@
              This allows us to create both javax.* and jakarta.* namespace tests.
              The implementation itself does not depend on any Jakarta EE libraries -->
 
-        <!-- CDI -->
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!-- JaxRS -->
         <dependency>
             <groupId>jakarta.ws.rs</groupId>


### PR DESCRIPTION
The CDI annotations don't add any value to the test modified in the PR and introduce unnecessary dependencies.