### PR TITLE
ISSUE-2560: Fix broken OAuth2 login flow

### DIFF
--- a/ui/open-api-ui/README.adoc
+++ b/ui/open-api-ui/README.adoc
@@ -1,6 +1,6 @@
 = SmallRye OpenAPI UI
 
-This allows you you add Swagger UI with your project. 
+This allows you to add a Swagger UI to your project.
 
 The UI will be available under `/openapi-ui`.
 

--- a/ui/open-api-ui/pom.xml
+++ b/ui/open-api-ui/pom.xml
@@ -103,7 +103,8 @@
                                                 **/swagger-ui-bundle.js.map,
                                                 **/swagger-ui-standalone-preset.js,
                                                 **/swagger-ui-standalone-preset.js.map,
-                                                **/oauth2-redirect.html</includes>
+                                                **/oauth2-redirect.html,
+                                                **/oauth2-redirect.js</includes>
                                     <fileMappers>
                                         <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper />
                                     </fileMappers>


### PR DESCRIPTION
What:
+ Add oauth2-redirect.js to smallrye-open-api-ui.jar.  See #2560 

Why:
+ Currently OAuth2 workflow fails with a HTTP 404 attempting to load oauth2-redirect.js, which is not included in the .jar.