### PR TITLE
Revert "Refine profile include/exclude logic"

### DIFF
--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ProfileSelectionWithStaticModelTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ProfileSelectionWithStaticModelTest.java
@@ -49,20 +49,12 @@ class ProfileSelectionWithStaticModelTest {
             public List<String> listUsers() {
                 return Collections.emptyList();
             }
-
-            @Path("/other-users")
-            @GET
-            @Extension(name = "x-smallrye-profile-other", value = "")
-            public List<String> listOtherUsers() {
-                return Collections.emptyList();
-            }
         }
 
         SmallRyeOpenAPI result;
 
         try {
             System.setProperty(SmallRyeOASConfig.SCAN_PROFILES, "public");
-            System.setProperty(SmallRyeOASConfig.SCAN_EXCLUDE_PROFILES, "public"); // ignored if the same profile is also included
             System.setProperty(OASConfig.MODEL_READER, MyReader.class.getName());
 
             result = SmallRyeOpenAPI.builder()
@@ -78,7 +70,6 @@ class ProfileSelectionWithStaticModelTest {
                     .withIndex(Index.of(MyResource.class))
                     .build();
         } finally {
-            System.clearProperty(SmallRyeOASConfig.SCAN_EXCLUDE_PROFILES);
             System.clearProperty(SmallRyeOASConfig.SCAN_PROFILES);
             System.clearProperty(OASConfig.MODEL_READER);
         }

--- a/model/src/main/java/io/smallrye/openapi/model/Extensions.java
+++ b/model/src/main/java/io/smallrye/openapi/model/Extensions.java
@@ -100,24 +100,15 @@ public final class Extensions {
     public static boolean includedProfile(Extensible<?> extensible, Set<String> included, Set<String> excluded) {
         Set<String> profiles = getProfiles(extensible);
 
-        if (profiles.isEmpty()) {
-            // Include an extensible without any profiles attached when none
-            // are explicitly included via configuration.
-            return included.isEmpty();
+        if (!excluded.isEmpty()) {
+            return excluded.stream().noneMatch(profiles::contains);
         }
 
-        if (included.stream().anyMatch(profiles::contains)) {
+        if (included.isEmpty()) {
             return true;
         }
 
-        if (excluded.stream().anyMatch(profiles::contains)) {
-            // Exclude the extensible if it has configured exclusions and also
-            // does not have any configured inclusions. This also means that
-            // inclusion overrides exclusion if a profile is configured for both.
-            return false;
-        }
-
-        return included.isEmpty();
+        return included.stream().anyMatch(profiles::contains);
     }
 
     public static void removeProfiles(Extensible<?> extensible) {


### PR DESCRIPTION
Reverts logic change to profile include/exclude processing in #2548

The change conflicts with Quarkus tests and documentation.