### PR TITLE
feat: support spring controllers that don't use the @RestController annotation

### DIFF
--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -1,13 +1,6 @@
 package io.smallrye.openapi.spring;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -152,13 +145,25 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
         // Get all Spring controllers and convert them to OpenAPI models (and merge them into a single one)
         Collection<AnnotationInstance> controllerAnnotations = context.getIndex()
                 .getAnnotations(SpringConstants.REST_CONTROLLER);
-        List<ClassInfo> applications = new ArrayList<>();
+        Collection<AnnotationInstance> requestMappingAnnotations = context.getIndex()
+                .getAnnotations(SpringConstants.REQUEST_MAPPING);
+
+        Set<ClassInfo> applications = new LinkedHashSet<>();
         for (AnnotationInstance annotationInstance : controllerAnnotations) {
             if (annotationInstance.target().kind().equals(AnnotationTarget.Kind.CLASS)) {
                 ClassInfo classInfo = annotationInstance.target().asClass();
                 applications.add(classInfo);
             } else {
                 SpringLogging.log.ignoringAnnotation(SpringConstants.REST_CONTROLLER.withoutPackagePrefix());
+            }
+        }
+
+        for (AnnotationInstance annotationInstance : requestMappingAnnotations) {
+            if (annotationInstance.target().kind().equals(AnnotationTarget.Kind.CLASS)) {
+                ClassInfo classInfo = annotationInstance.target().asClass();
+                applications.add(classInfo);
+            } else {
+                SpringLogging.log.ignoringAnnotation(SpringConstants.REQUEST_MAPPING.withoutPackagePrefix());
             }
         }
 

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringAnnotationScanner.java
@@ -1,6 +1,13 @@
 package io.smallrye.openapi.spring;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -163,7 +170,7 @@ public class SpringAnnotationScanner extends AbstractAnnotationScanner {
                 ClassInfo classInfo = annotationInstance.target().asClass();
                 applications.add(classInfo);
             } else {
-                SpringLogging.log.ignoringAnnotation(SpringConstants.REQUEST_MAPPING.withoutPackagePrefix());
+                SpringLogging.log.ignoringMultiTargetAnnotation(SpringConstants.REQUEST_MAPPING.withoutPackagePrefix());
             }
         }
 

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringLogging.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringLogging.java
@@ -31,7 +31,6 @@ interface SpringLogging {
     @Message(id = 11004, value = "Value '%s' is not a valid %s default")
     void invalidDefault(String segment, String primitive);
 
-
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 11005, value = "Ignoring %s annotation (multi-target) that is not on a class")
     void ignoringMultiTargetAnnotation(String className);

--- a/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringLogging.java
+++ b/extension-spring/src/main/java/io/smallrye/openapi/spring/SpringLogging.java
@@ -31,4 +31,8 @@ interface SpringLogging {
     @Message(id = 11004, value = "Value '%s' is not a valid %s default")
     void invalidDefault(String segment, String primitive);
 
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 11005, value = "Ignoring %s annotation (multi-target) that is not on a class")
+    void ignoringMultiTargetAnnotation(String className);
 }

--- a/extension-spring/src/test/java/io/smallrye/openapi/runtime/scanner/SpringAnnotationScannerTest.java
+++ b/extension-spring/src/test/java/io/smallrye/openapi/runtime/scanner/SpringAnnotationScannerTest.java
@@ -8,7 +8,18 @@ import org.junit.jupiter.api.Test;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
 import test.io.smallrye.openapi.runtime.scanner.entities.GreetingParam;
-import test.io.smallrye.openapi.runtime.scanner.resources.*;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingDeleteController;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingDeleteControllerAlt;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetController;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetControllerAlt;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetControllerAlt2;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetControllerNoRestController;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPostController;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPostControllerAlt;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPostControllerMultiplePaths;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPutController;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPutControllerAlt;
+import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPutControllerMultiplePaths;
 
 /**
  * Basic Spring annotation scanning

--- a/extension-spring/src/test/java/io/smallrye/openapi/runtime/scanner/SpringAnnotationScannerTest.java
+++ b/extension-spring/src/test/java/io/smallrye/openapi/runtime/scanner/SpringAnnotationScannerTest.java
@@ -8,17 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
 import test.io.smallrye.openapi.runtime.scanner.entities.GreetingParam;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingDeleteController;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingDeleteControllerAlt;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetController;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetControllerAlt;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingGetControllerAlt2;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPostController;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPostControllerAlt;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPostControllerMultiplePaths;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPutController;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPutControllerAlt;
-import test.io.smallrye.openapi.runtime.scanner.resources.GreetingPutControllerMultiplePaths;
+import test.io.smallrye.openapi.runtime.scanner.resources.*;
 
 /**
  * Basic Spring annotation scanning
@@ -65,6 +55,20 @@ class SpringAnnotationScannerTest extends IndexScannerTestBase {
     void testBasicSpringDefinitionScanningAlt2() throws IOException, JSONException {
         OpenAPI result = scan(GreetingGetControllerAlt2.class, Greeting.class, GreetingParam.class);
         assertJsonEquals("resource.testBasicSpringGetDefinitionScanning.json", result);
+    }
+
+    /**
+     * This test a basic, no OpenApi annotations, hello world service
+     *
+     * Here we don't use @RestController
+     *
+     * @throws IOException
+     * @throws JSONException
+     */
+    @Test
+    void testNoRestControllerSpringDefinitionScanning() throws IOException, JSONException {
+        OpenAPI result = scan(GreetingGetControllerNoRestController.class, Greeting.class, GreetingParam.class);
+        assertJsonEquals("resource.testNoRestControllerSpringGetDefinitionScanning.json", result);
     }
 
     /**

--- a/extension-spring/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingGetControllerNoRestController.java
+++ b/extension-spring/src/test/java/test/io/smallrye/openapi/runtime/scanner/resources/GreetingGetControllerNoRestController.java
@@ -1,0 +1,28 @@
+package test.io.smallrye.openapi.runtime.scanner.resources;
+
+import java.security.Principal;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import test.io.smallrye.openapi.runtime.scanner.entities.Greeting;
+
+@Service
+@RequestMapping(value = "/restless-greetings")
+public class GreetingGetControllerNoRestController {
+
+    @RequestMapping(value = "/howdy", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Greeting> hello(HttpServletRequest request_,
+            HttpServletResponse response_,
+            Principal principal_) {
+        return new ResponseEntity<>(new Greeting("Howdy!"), HttpStatus.OK);
+    }
+
+}

--- a/extension-spring/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testNoRestControllerSpringGetDefinitionScanning.json
+++ b/extension-spring/src/test/resources/io/smallrye/openapi/runtime/scanner/resource.testNoRestControllerSpringGetDefinitionScanning.json
@@ -1,0 +1,33 @@
+{
+  "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "Greeting" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  },
+  "paths" : {
+    "/restless-greetings/howdy" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I was integrating smallrye into my project and found that virtually no endpoints were showing up.  Discovered it's because our codebase doesn't use the `@RestController` helper utility.  This change will allow detecting any beans that use `@RequestMapping`, which I believe is the true common denominator for spring-web-mvc.

In theory I think the RestController detection is redundant with this, but didn't want to fully swap it out just in case.  I changed to using a LinkedHashSet to avoid double counting beans with both annotations.