### PR TITLE
feat: don't error out with duplicate key when there's no actual conflict

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/io/ModelIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/ModelIO.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -160,7 +161,7 @@ public abstract class ModelIO<T, V, A extends V, O extends V, AB, OB> implements
     /**
      * Creates a Collector for a stream of Map.Entry where the entry keys are Strings.
      *
-     * Null map entry values are allowed, but duplicate keys will result in an
+     * Null map entry values are allowed, but duplicate keys with different values will result in an
      * IllegalStateException being thrown.
      *
      * This method is the equivalent of
@@ -176,7 +177,7 @@ public abstract class ModelIO<T, V, A extends V, O extends V, AB, OB> implements
             String k = entry.getKey();
             T v = entry.getValue();
 
-            if (map.containsKey(k)) {
+            if (map.containsKey(k) && !Objects.equals(map.get(k), v)) {
                 throw new IllegalStateException(String.format(
                         "Duplicate key %s (attempted merging values %s and %s)",
                         k, map.get(k), v));

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/ModelIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/ModelIOTest.java
@@ -1,5 +1,6 @@
 package io.smallrye.openapi.runtime.io;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -17,9 +18,17 @@ class ModelIOTest {
     @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
     void testToLinkedMapDuplicateKeyThrowsException() {
-        Stream<Map.Entry<String, String>> stream = Stream.of("k1", "k1").map(k -> new SimpleEntry(k, ""));
+        Stream<Map.Entry<String, String>> stream = Stream.of(new SimpleEntry("k1", "v1"), new SimpleEntry("k1", "v2"));
         Collector<Map.Entry<String, String>, ?, Map<String, String>> collector = ModelIO.toLinkedMap();
         assertThrows(IllegalStateException.class, () -> stream.collect(collector));
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void testToLinkedMapDuplicateKeyWithSameValueDoesntThrowException() {
+        Stream<Map.Entry<String, String>> stream = Stream.of(new SimpleEntry("k1", "v1"), new SimpleEntry("k1", "v1"));
+        Collector<Map.Entry<String, String>, ?, Map<String, String>> collector = ModelIO.toLinkedMap();
+        assertDoesNotThrow(() -> stream.collect(collector));
     }
 
     @Test


### PR DESCRIPTION
A small tweak to be more forgiving.  Ran into this when using meta-annotations to add `x-smallrye-profile-blah` `@Extension`. If you end up with multiple of them on the same endpoint, currently your build errors out.  Given there's no actual problem with that, and its convenient to allow overlaps when you have multiple annotations at play to control documentation builds, I made this tweak