### PR TITLE
Remove unused frontend-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.skyscreamer>1.5.3</version.org.skyscreamer>
         <version.maven-resources-plugin>3.3.1</version.maven-resources-plugin>
-        <version.com.github.eirslett.frontend-maven-plugin>2.0.0</version.com.github.eirslett.frontend-maven-plugin>
         <version.quarkus>3.36.2</version.quarkus>
         <version.testng>7.12.0</version.testng>
         <version.arquillian.jetty>2.0.0.Final</version.arquillian.jetty>
@@ -404,11 +403,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>${version.com.github.eirslett.frontend-maven-plugin}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This was used by the ui-forms module that was removed in #2497