### PR TITLE
Handle JsonView on getter-only properties

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -76,6 +76,8 @@ public class TypeResolver {
     private boolean exposed = false;
     private boolean readOnly = false;
     private boolean writeOnly = false;
+    private MethodInfo ignoredReadMethod;
+    private MethodInfo ignoredWriteMethod;
     private final List<AnnotationTarget> constraintTargets = new ArrayList<>();
     private String propertyNamePrefix;
     private String propertyNameSuffix;
@@ -372,7 +374,17 @@ public class TypeResolver {
 
     public boolean isIgnored() {
         return ignored || (readOnly && readMethod == null && field == null)
-                || (writeOnly && writeMethod == null && field == null);
+                || (writeOnly && writeMethod == null && field == null)
+                || (ignoredReadMethod != null && readMethod == ignoredReadMethod && writeMethod == null
+                        && !isFieldExplicitlyVisible())
+                || (ignoredWriteMethod != null && writeMethod == ignoredWriteMethod && readMethod == null
+                        && !isFieldExplicitlyVisible());
+    }
+
+    private boolean isFieldExplicitlyVisible() {
+        return field != null && (context.annotations().getAnnotation(field, JacksonConstants.JSON_VIEW) != null
+                || isUnhidden(field)
+                || context.annotations().getAnnotation(field, JacksonConstants.JSON_PROPERTY) != null);
     }
 
     public boolean isReadOnly() {
@@ -692,8 +704,10 @@ public class TypeResolver {
                 if (target.kind() == Kind.METHOD) {
                     if (isAccessor(context, target.asMethod())) {
                         this.writeOnly = true;
+                        this.ignoredReadMethod = target.asMethod();
                     } else {
                         this.readOnly = true;
+                        this.ignoredWriteMethod = target.asMethod();
                     }
 
                     if (this.readOnly && this.writeOnly) {

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import io.smallrye.openapi.api.OpenApiConfig;
@@ -900,6 +901,13 @@ class TypeResolverTests extends IndexScannerTestBase {
         class Bean {
             private String field0;
             private String field1;
+            private String field2;
+            @JsonView(Views.Public.class)
+            private String field3;
+            @Schema
+            private String field4;
+            @JsonProperty
+            private String field5;
 
             public String getField0() {
                 return field0;
@@ -913,6 +921,26 @@ class TypeResolverTests extends IndexScannerTestBase {
             public String getField1() {
                 return field1;
             }
+
+            @JsonView(Views.Private.class)
+            public void setField2(String field2) {
+                this.field2 = field2;
+            }
+
+            @JsonView(Views.Private.class)
+            public String getField3() {
+                return field3;
+            }
+
+            @JsonView(Views.Private.class)
+            public String getField4() {
+                return field4;
+            }
+
+            @JsonView(Views.Private.class)
+            public String getField5() {
+                return field5;
+            }
         }
 
         AnnotationScannerContext context = buildContext(emptyConfig(), Bean.class, Views.Private.class, Views.Public.class);
@@ -921,6 +949,10 @@ class TypeResolverTests extends IndexScannerTestBase {
         Map<String, TypeResolver> properties = getProperties(context, Bean.class);
         assertFalse(properties.get("field0").isIgnored());
         assertTrue(properties.get("field1").isIgnored());
+        assertTrue(properties.get("field2").isIgnored());
+        assertFalse(properties.get("field3").isIgnored());
+        assertFalse(properties.get("field4").isIgnored());
+        assertFalse(properties.get("field5").isIgnored());
     }
 
     /*

--- a/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolverTests.java
@@ -883,6 +883,46 @@ class TypeResolverTests extends IndexScannerTestBase {
         Stream.of("field0", "field1", "field2", "field3").forEach(f -> assertFalse(p3.get(f).isIgnored()));
     }
 
+    @Test
+    /*
+     * Issue: https://github.com/smallrye/smallrye-open-api/issues/2412
+     */
+    void testJsonViewExcludesGetterOnlyProperty() {
+        class Views {
+            class Public {
+            }
+
+            class Private {
+            }
+        }
+
+        @SuppressWarnings("unused")
+        class Bean {
+            private String field0;
+            private String field1;
+
+            public String getField0() {
+                return field0;
+            }
+
+            public void setField0(String field0) {
+                this.field0 = field0;
+            }
+
+            @JsonView(Views.Private.class)
+            public String getField1() {
+                return field1;
+            }
+        }
+
+        AnnotationScannerContext context = buildContext(emptyConfig(), Bean.class, Views.Private.class, Views.Public.class);
+        context.getJsonViews().put(Type.create(DotName.createSimple(Views.Public.class), Type.Kind.CLASS), true);
+
+        Map<String, TypeResolver> properties = getProperties(context, Bean.class);
+        assertFalse(properties.get("field0").isIgnored());
+        assertTrue(properties.get("field1").isIgnored());
+    }
+
     /*
      * Issue: https://github.com/smallrye/smallrye-open-api/issues/1817
      */


### PR DESCRIPTION
Fixes #2412.

## Summary
- Track when a property accessor/mutator is ignored by visibility rules such as an inactive `@JsonView`.
- Avoid keeping a getter-only property solely because of its backing field when that getter is excluded from the active view.
- Add a regression test for a getter-only property annotated with a different view.

## Testing
- `mvn -pl core -am -Dtest=io.smallrye.openapi.runtime.scanner.dataobject.TypeResolverTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl core -am test`
