### PR TITLE
Fix bogus absolute paths in smallrye-open-api-ui sources JAR

### DIFF
--- a/ui/open-api-ui/pom.xml
+++ b/ui/open-api-ui/pom.xml
@@ -50,7 +50,7 @@
             <!-- Make sure the template is available for external usage -->
             <resource>
                 <directory>${basedir}/src/main/resources/template</directory>
-                <targetPath>${project.build.directory}/classes/META-INF/resources/template</targetPath>
+                <targetPath>META-INF/resources/template</targetPath>
                 <filtering>false</filtering>
                 <includes>
                     <include>*.html</include>
@@ -59,7 +59,7 @@
             <!-- Also included index.html in case a template is not used -->
             <resource>
                 <directory>${basedir}/src/main/webapp</directory>
-                <targetPath>${project.build.directory}/classes/META-INF/resources/${path.swagger-ui}</targetPath>
+                <targetPath>META-INF/resources/${path.swagger-ui}</targetPath>
                 <filtering>true</filtering>
                 <includes>
                     <include>**/*.html</include>
@@ -67,7 +67,7 @@
             </resource>
             <resource>
                 <directory>${basedir}/src/main/webapp</directory>
-                <targetPath>${project.build.directory}/classes/META-INF/resources/${path.swagger-ui}</targetPath>
+                <targetPath>META-INF/resources/${path.swagger-ui}</targetPath>
                 <filtering>false</filtering>
                 <excludes>
                     <exclude>**/*.html</exclude>


### PR DESCRIPTION
## Problem

The `-sources.jar` published for `smallrye-open-api-ui` contains bogus
absolute-path entries derived from the CI build environment, e.g.:

```
/home/runner/work/smallrye-open-api/smallrye-open-api/ui/open-api-ui/target/classes/...
```

## Root cause

`maven-4.0.0.xsd` documents `<targetPath>` as relative to
`${project.build.outputDirectory}` (`target/classes`). The pom.xml for
this module set it to an absolute path
(`${project.build.directory}/classes/META-INF/resources/...`), which
the resources plugin re-nested under `target/classes`, embedding the
whole absolute build path in the produced JAR/sources JAR.

## Fix

Change `targetPath` values to be relative, as intended
(`META-INF/resources/...`).

## Verification

Built the module locally (`mvn -pl ui/open-api-ui package source:jar`)
and confirmed the resulting `-sources.jar` no longer contains any
absolute-path entries.