### PR TITLE
Add support for Jackson v3 and JSON provider selection via builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,11 @@ jobs:
       - name: build with maven
         run: mvn -B formatter:validate impsort:check install javadoc:javadoc -Pcoverage -Pgradle-smoke-test
 
+        # Test Jackson 3 and collect coverage information only for analysis
+      - name: test Jackson 3 processing
+        if: ${{ matrix.java == '17' && matrix.os == 'ubuntu-latest' }}
+        run: mvn -B verify -Pcoverage,jackson3
+
       ## Store information about the build context for Sonar scan in separate job
       - name: Save Build Context
         run: echo "$GITHUB_CONTEXT" > target/build-context.json

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Third Party Libraries -->
+        <!-- Jackson 2 Libraries -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -54,6 +54,25 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+
+        <!-- Jackson 3 Libraries -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Third Party Libraries -->
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Third Party Libraries -->
+        <!-- Jackson 2 Libraries -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -54,6 +54,22 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+
+        <!-- Jackson 3 Libraries -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+
+        <!-- Third Party Libraries -->
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,8 +13,15 @@
     <name>SmallRye: OpenAPI Core</name>
 
     <properties>
-        <!-- Excluded model classes for duplication checks (getters/setters treated as duplicates by Sonar) -->
-        <sonar.cpd.exclusions>src/main/java/io/smallrye/openapi/api/models/**/*.java</sonar.cpd.exclusions>
+        <!--
+          * Excluded model classes for duplication checks (getters/setters treated as duplicates by Sonar)
+          * Ignore duplication in Jackson IO classes. Nearly identical besides packages
+        -->
+        <sonar.cpd.exclusions>
+            src/main/java/io/smallrye/openapi/api/models/**/*.java,
+            src/main/java/io/smallrye/openapi/runtime/io/Jackson2JsonIO.java,
+            src/main/java/io/smallrye/openapi/runtime/io/Jackson3JsonIO.java
+        </sonar.cpd.exclusions>
     </properties>
 
     <dependencies>

--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -50,6 +51,31 @@ import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerFactory;
 
 @SuppressWarnings("deprecation")
 public class SmallRyeOpenAPI {
+
+    public enum JsonProvider {
+        JACKSON2("Jackson 2.x"),
+        JACKSON3("Jackson 3.x"),
+        JAKARTA_JSON("Jakarta JSON"),
+        AUTO(null);
+
+        private final String title;
+
+        private JsonProvider(String title) {
+            this.title = title;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public static List<JsonProvider> providers() {
+            return List.of(JACKSON2, JACKSON3, JAKARTA_JSON);
+        }
+
+        public static List<String> providerNames() {
+            return List.of(JACKSON2.title, JACKSON3.title, JAKARTA_JSON.title);
+        }
+    }
 
     private final OpenAPI model;
     private final Object jsonModel;
@@ -101,6 +127,8 @@ public class SmallRyeOpenAPI {
         private Config config;
         private ClassLoader applicationClassLoader;
         private OpenAPI initialModel;
+
+        private JsonProvider jsonProvider = JsonProvider.AUTO;
 
         private boolean enableModelReader = true;
 
@@ -155,6 +183,20 @@ public class SmallRyeOpenAPI {
         public Builder withConfig(Config config) {
             removeContext();
             this.config = Objects.requireNonNull(config);
+            return this;
+        }
+
+        /**
+         * Set the JSON provider to use when building the OpenAPI model. If not
+         * set, the provider will be auto-detected from the classpath.
+         *
+         * @param jsonProvider
+         *        the JSON provider to use, nulls not allowed
+         * @return this builder
+         */
+        public Builder withJsonProvider(JsonProvider jsonProvider) {
+            removeContext();
+            this.jsonProvider = Objects.requireNonNull(jsonProvider);
             return this;
         }
 
@@ -710,7 +752,7 @@ public class SmallRyeOpenAPI {
 
                 this.buildConfig = OpenApiConfig.fromConfig(Optional.ofNullable(builder.config)
                         .orElseGet(() -> ConfigProvider.getConfig(this.appClassLoader)));
-                IOContext<V, A, O, AB, OB> io = IOContext.forJson(JsonIO.newInstance(this.buildConfig));
+                IOContext<V, A, O, AB, OB> io = IOContext.forJson(JsonIO.newInstance(builder.jsonProvider, this.buildConfig));
                 this.modelIO = new OpenAPIDefinitionIO<>(io);
                 this.filteredIndex = new FilteredIndexView(builder.index, this.buildConfig);
                 this.initialModel = builder.initialModel;

--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -50,6 +51,31 @@ import io.smallrye.openapi.runtime.scanner.spi.AnnotationScannerFactory;
 
 @SuppressWarnings("deprecation")
 public class SmallRyeOpenAPI {
+
+    public enum JsonProvider {
+        JACKSON3("Jackson 3.x"),
+        JACKSON2("Jackson 2.x"),
+        JAKARTA_JSON("Jakarta JSON"),
+        AUTO(null);
+
+        private final String title;
+
+        private JsonProvider(String title) {
+            this.title = title;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public static List<JsonProvider> providers() {
+            return List.of(JACKSON3, JACKSON2, JAKARTA_JSON);
+        }
+
+        public static List<String> providerNames() {
+            return List.of(JACKSON3.title, JACKSON2.title, JAKARTA_JSON.title);
+        }
+    }
 
     private final OpenAPI model;
     private final Object jsonModel;
@@ -101,6 +127,8 @@ public class SmallRyeOpenAPI {
         private Config config;
         private ClassLoader applicationClassLoader;
         private OpenAPI initialModel;
+
+        private JsonProvider jsonProvider = JsonProvider.AUTO;
 
         private boolean enableModelReader = true;
 
@@ -155,6 +183,20 @@ public class SmallRyeOpenAPI {
         public Builder withConfig(Config config) {
             removeContext();
             this.config = Objects.requireNonNull(config);
+            return this;
+        }
+
+        /**
+         * Set the JSON provider to use when building the OpenAPI model. If not
+         * set, the provider will be auto-detected from the classpath.
+         *
+         * @param jsonProvider
+         *        the JSON provider to use, nulls not allowed
+         * @return this builder
+         */
+        public Builder withJsonProvider(JsonProvider jsonProvider) {
+            removeContext();
+            this.jsonProvider = Objects.requireNonNull(jsonProvider);
             return this;
         }
 
@@ -710,7 +752,7 @@ public class SmallRyeOpenAPI {
 
                 this.buildConfig = OpenApiConfig.fromConfig(Optional.ofNullable(builder.config)
                         .orElseGet(() -> ConfigProvider.getConfig(this.appClassLoader)));
-                IOContext<V, A, O, AB, OB> io = IOContext.forJson(JsonIO.newInstance(this.buildConfig));
+                IOContext<V, A, O, AB, OB> io = IOContext.forJson(JsonIO.newInstance(builder.jsonProvider, this.buildConfig));
                 this.modelIO = new OpenAPIDefinitionIO<>(io);
                 this.filteredIndex = new FilteredIndexView(builder.index, this.buildConfig);
                 this.initialModel = builder.initialModel;

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/IoLogging.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/IoLogging.java
@@ -81,4 +81,8 @@ public interface IoLogging extends BasicLogger {
     @Message(id = 2017, value = "JSON/YAML value could not be read as type %s: %s")
     void invalidJsonType(String targetType, String nodeText);
 
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 2018, value = "Attempt to auto-load JSON provider %s failed: %s")
+    void jsonProviderAutoLoadFailure(String providerName, String exceptionMessage);
+
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/IoMessages.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/IoMessages.java
@@ -3,10 +3,13 @@ package io.smallrye.openapi.runtime.io;
 import static java.lang.invoke.MethodHandles.lookup;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
+
+import io.smallrye.openapi.runtime.OpenApiRuntimeException;
 
 @MessageBundle(projectCode = "SROAP", length = 5)
 interface IoMessages {
@@ -20,4 +23,7 @@ interface IoMessages {
 
     @Message(id = 3002, value = "Invalid file extension for URL (expected json, yaml, or yml): %s")
     IOException invalidFileExtension(String url);
+
+    @Message(id = 3003, value = "No JSON provider found. Supported providers: %s")
+    OpenApiRuntimeException noJsonProviderFound(List<String> providers);
 }

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/Jackson2JsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/Jackson2JsonIO.java
@@ -12,7 +12,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.yaml.snakeyaml.LoaderOptions;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -30,23 +29,21 @@ import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.model.BaseModel;
 import io.smallrye.openapi.runtime.OpenApiRuntimeException;
 
-class JacksonJsonIO implements JsonIO<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
+class Jackson2JsonIO implements JsonIO<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
 
     private static final JsonNodeFactory factory = JsonNodeFactory.instance;
 
-    private final OpenApiConfig config;
     private final ObjectMapper jsonMapper;
     private final ObjectMapper yamlMapper;
     private final ObjectWriter jsonWriter;
     private final ObjectWriter yamlWriter;
 
-    public JacksonJsonIO(OpenApiConfig config, ObjectMapper objectMapper) {
-        this.config = config != null ? config : OpenApiConfig.fromConfig(ConfigProvider.getConfig());
+    public Jackson2JsonIO(OpenApiConfig config, ObjectMapper objectMapper) {
         this.jsonMapper = objectMapper;
         this.jsonWriter = objectMapper.writerWithDefaultPrettyPrinter();
 
         LoaderOptions loaderOptions = new LoaderOptions();
-        Optional.ofNullable(this.config.getMaximumStaticFileSize()).ifPresent(loaderOptions::setCodePointLimit);
+        Optional.ofNullable(config.getMaximumStaticFileSize()).ifPresent(loaderOptions::setCodePointLimit);
 
         YAMLFactory yamlFactory = new YAMLFactoryBuilder(new YAMLFactory())
                 .loaderOptions(loaderOptions)
@@ -60,7 +57,7 @@ class JacksonJsonIO implements JsonIO<JsonNode, ArrayNode, ObjectNode, ArrayNode
          * YAML to be in-lined as if the elements were repeated throughout a
          * source document.
          */
-        if (this.config.yamlAliasExpansionEnable()) {
+        if (config.yamlAliasExpansionEnable()) {
             yamlFactory = new YAMLAnchorReplayingFactory(yamlFactory, null);
         }
 
@@ -68,16 +65,8 @@ class JacksonJsonIO implements JsonIO<JsonNode, ArrayNode, ObjectNode, ArrayNode
         this.yamlWriter = yamlMapper.writer().with(yamlFactory);
     }
 
-    public JacksonJsonIO(OpenApiConfig config) {
+    public Jackson2JsonIO(OpenApiConfig config) {
         this(config, new ObjectMapper());
-    }
-
-    public JacksonJsonIO(ObjectMapper objectMapper) {
-        this(null, objectMapper);
-    }
-
-    public JacksonJsonIO() {
-        this(null, new ObjectMapper());
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/Jackson3JsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/Jackson3JsonIO.java
@@ -1,0 +1,391 @@
+package io.smallrye.openapi.runtime.io;
+
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+
+import org.snakeyaml.engine.v2.api.LoadSettings;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.model.BaseModel;
+import io.smallrye.openapi.runtime.OpenApiRuntimeException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.dataformat.yaml.YAMLAnchorReplayingFactory;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLFactoryBuilder;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
+
+class Jackson3JsonIO implements JsonIO<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
+
+    private static final JsonNodeFactory factory = JsonNodeFactory.instance;
+
+    private final ObjectMapper jsonMapper;
+    private final ObjectMapper yamlMapper;
+    private final ObjectWriter jsonWriter;
+    private final ObjectWriter yamlWriter;
+
+    public Jackson3JsonIO(OpenApiConfig config, ObjectMapper objectMapper) {
+        this.jsonMapper = objectMapper;
+        this.jsonWriter = objectMapper.writerWithDefaultPrettyPrinter();
+
+        var settingsBuilder = LoadSettings.builder();
+        Optional.ofNullable(config.getMaximumStaticFileSize()).ifPresent(settingsBuilder::setCodePointLimit);
+
+        YAMLFactory yamlFactory = new YAMLFactoryBuilder(new YAMLFactory())
+                .loadSettings(settingsBuilder.build())
+                .enable(YAMLWriteFeature.MINIMIZE_QUOTES)
+                .enable(YAMLWriteFeature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
+                .enable(YAMLWriteFeature.ALLOW_LONG_KEYS)
+                .build();
+
+        /*
+         * The anchor replaying factory allows aliases of anchors values in the
+         * YAML to be in-lined as if the elements were repeated throughout a
+         * source document.
+         */
+        if (config.yamlAliasExpansionEnable()) {
+            yamlFactory = new YAMLAnchorReplayingFactory(yamlFactory);
+        }
+
+        this.yamlMapper = new YAMLMapper(yamlFactory);
+        this.yamlWriter = yamlMapper.writer();
+    }
+
+    public Jackson3JsonIO(OpenApiConfig config) {
+        this(config, new ObjectMapper());
+    }
+
+    @Override
+    public boolean isArray(JsonNode value) {
+        return value instanceof ArrayNode;
+    }
+
+    @Override
+    public ArrayNode asArray(JsonNode value) {
+        return (ArrayNode) value;
+    }
+
+    @Override
+    public List<JsonNode> entries(ArrayNode array) {
+        List<JsonNode> entries = new ArrayList<>(array.size());
+        array.forEach(entries::add);
+        return entries;
+    }
+
+    @Override
+    public boolean isObject(JsonNode value) {
+        return value instanceof ObjectNode;
+    }
+
+    @Override
+    public ObjectNode asObject(JsonNode value) {
+        return (ObjectNode) value;
+    }
+
+    @Override
+    public boolean hasKey(ObjectNode object, String key) {
+        return object.has(key);
+    }
+
+    @Override
+    public Set<Entry<String, JsonNode>> properties(ObjectNode object) {
+        return object.properties();
+    }
+
+    @Override
+    public boolean isString(JsonNode value) {
+        return value != null && value.isString();
+    }
+
+    @Override
+    public String asString(JsonNode value) {
+        return value != null && value.isValueNode() ? value.asString() : null;
+    }
+
+    @Override
+    public boolean isBoolean(JsonNode value) {
+        return value != null && value.isBoolean();
+    }
+
+    @Override
+    public Boolean asBoolean(JsonNode value) {
+        return value != null && value.isBoolean() ? value.asBoolean() : null;
+    }
+
+    @Override
+    public boolean isNull(JsonNode value) {
+        return value != null && value.isNull();
+    }
+
+    @Override
+    public Integer getJsonInt(ObjectNode object, String key) {
+        JsonNode value = object.get(key);
+        return value != null && value.isInt() ? value.asInt() : null;
+    }
+
+    @Override
+    public String getJsonString(ObjectNode object, String key) {
+        return asString(object.get(key));
+    }
+
+    @Override
+    public Boolean getJsonBoolean(ObjectNode object, String key) {
+        JsonNode value = object.get(key);
+        return value != null && value.isBoolean() ? value.asBoolean() : null;
+    }
+
+    @Override
+    public BigDecimal getJsonBigDecimal(ObjectNode object, String key) {
+        JsonNode value = object.get(key);
+        return value != null && value.isNumber() ? value.decimalValue() : null;
+    }
+
+    @Override
+    public JsonNode getValue(ObjectNode object, String key) {
+        return object.get(key);
+    }
+
+    @Override
+    public Optional<ArrayNode> getArray(ObjectNode object, String key) {
+        JsonNode value = object.get(key);
+        return value != null && value.isArray() ? Optional.of((ArrayNode) value) : Optional.empty();
+    }
+
+    @Override
+    public Optional<ObjectNode> getObject(ObjectNode object, String key) {
+        JsonNode value = object.get(key);
+        return value != null && value.isObject() ? Optional.of((ObjectNode) value) : Optional.empty();
+    }
+
+    @Override
+    public ArrayNode createArray() {
+        return factory.arrayNode();
+    }
+
+    @Override
+    public void add(ArrayNode array, JsonNode value) {
+        array.add(value);
+    }
+
+    @Override
+    public ArrayNode buildArray(ArrayNode array) {
+        return array;
+    }
+
+    @Override
+    public ObjectNode createObject() {
+        return factory.objectNode();
+    }
+
+    @Override
+    public void set(ObjectNode object, String key, JsonNode value) {
+        object.set(key, value);
+    }
+
+    @Override
+    public void setAll(ObjectNode object, ObjectNode valueSource) {
+        object.setAll(valueSource);
+    }
+
+    @Override
+    public ObjectNode buildObject(ObjectNode object) {
+        return object;
+    }
+
+    @Override
+    public JsonNode toJson(Object value, JsonNode defaultValue, PropertyMapper<JsonNode, ObjectNode> propertyMapper) {
+        if (value instanceof String) {
+            return factory.stringNode((String) value);
+        } else if (value instanceof List) {
+            return toJson((List<?>) value, propertyMapper);
+        } else if (value instanceof Map) {
+            return toJson((Map<?, ?>) value, propertyMapper);
+        } else if (value instanceof Enum) {
+            return factory.stringNode(value.toString());
+        } else if (value instanceof BaseModel) {
+            return toJson((BaseModel<?>) value, propertyMapper);
+        } else if (value instanceof JsonNode) {
+            return (JsonNode) value;
+        } else if (value instanceof BigDecimal) {
+            return factory.numberNode((BigDecimal) value);
+        } else if (value instanceof BigInteger) {
+            return factory.numberNode((BigInteger) value);
+        } else if (value instanceof Boolean) {
+            return factory.booleanNode((Boolean) value);
+        } else if (value instanceof Double) {
+            return factory.numberNode((Double) value);
+        } else if (value instanceof Float) {
+            return factory.numberNode((Float) value);
+        } else if (value instanceof Short) {
+            return factory.numberNode((short) value);
+        } else if (value instanceof Integer) {
+            return factory.numberNode((Integer) value);
+        } else if (value instanceof Long) {
+            return factory.numberNode((Long) value);
+        } else if (value instanceof Character) {
+            return factory.stringNode(((Character) value).toString());
+        } else {
+            return defaultValue;
+        }
+    }
+
+    private JsonNode toJson(List<?> value, PropertyMapper<JsonNode, ObjectNode> propertyMapper) {
+        ArrayNode array = createArray();
+        for (var entry : (List<?>) value) {
+            JsonNode node = toJson(entry, factory.nullNode(), propertyMapper);
+            array.add(node);
+        }
+        return array;
+    }
+
+    private JsonNode toJson(Map<?, ?> value, PropertyMapper<JsonNode, ObjectNode> propertyMapper) {
+        ObjectNode object = createObject();
+        for (var entry : ((Map<?, ?>) value).entrySet()) {
+            JsonNode node = toJson(entry.getValue(), factory.nullNode(), propertyMapper);
+            object.set(String.valueOf(entry.getKey()), node);
+        }
+        return object;
+    }
+
+    private JsonNode toJson(BaseModel<?> value, PropertyMapper<JsonNode, ObjectNode> propertyMapper) {
+        Optional<JsonNode> override = propertyMapper.mapObject(value);
+
+        if (override.isPresent()) {
+            return override.get();
+        }
+
+        ObjectNode object = createObject();
+
+        for (var entry : value.getAllProperties().entrySet()) {
+            String propertyName = String.valueOf(entry.getKey());
+            Object propertyValue = entry.getValue();
+            Optional<JsonNode> propertyOverride = propertyMapper.mapProperty(value, propertyName, propertyValue);
+
+            JsonNode node;
+
+            if (propertyOverride.isPresent()) {
+                node = propertyOverride.get();
+            } else {
+                node = toJson(propertyValue, factory.nullNode(), propertyMapper);
+            }
+
+            if (!node.isNull()) {
+                object.set(propertyName, node);
+            }
+        }
+
+        propertyMapper.mapObject(value, object);
+        return object;
+    }
+
+    @Override
+    public Object fromJson(JsonNode value) {
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        if (value.isBigDecimal()) {
+            return value.decimalValue();
+        }
+        if (value.isBigInteger()) {
+            return value.bigIntegerValue();
+        }
+        if (value.isBoolean()) {
+            return value.asBoolean();
+        }
+        if (value.isDouble()) {
+            return value.asDouble();
+        }
+        if (value.isFloat()) {
+            return value.asDouble();
+        }
+        if (value.isInt()) {
+            return value.asInt();
+        }
+        if (value.isLong()) {
+            return value.asLong();
+        }
+        if (value.isString()) {
+            return value.asString();
+        }
+        if (value.isArray()) {
+            List<Object> items = new ArrayList<>();
+            value.asArray().elements().forEach(entry -> items.add(fromJson(entry)));
+            return items;
+        }
+        if (value.isObject()) {
+            Map<String, Object> items = new LinkedHashMap<>();
+            value.properties().forEach(field -> items.put(field.getKey(), fromJson(field.getValue())));
+            return items;
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T fromJson(JsonNode object, Class<T> desiredType) {
+        if (desiredType == String.class && object.isValueNode()) {
+            return (T) object.asString();
+        }
+        if (desiredType == Integer.class && object.canConvertToInt()) {
+            return (T) Integer.valueOf(object.asInt());
+        }
+        if (desiredType == BigInteger.class && object.canConvertToExactIntegral()) {
+            return (T) object.bigIntegerValue();
+        }
+        if (desiredType == Long.class && object.canConvertToLong()) {
+            return (T) Long.valueOf(object.asLong());
+        }
+        if (desiredType == BigDecimal.class && object.isNumber()) {
+            return (T) object.decimalValue();
+        }
+        if (desiredType == Boolean.class && object.isBoolean()) {
+            return (T) Boolean.valueOf(object.booleanValue());
+        }
+        return null;
+    }
+
+    @Override
+    public String toString(JsonNode value, Format format) {
+        try {
+            if (format == Format.JSON) {
+                return jsonWriter.writeValueAsString(value);
+            } else {
+                return yamlWriter.writeValueAsString(value);
+            }
+        } catch (JacksonException e) {
+            throw new OpenApiRuntimeException(e);
+        }
+    }
+
+    @Override
+    public JsonNode fromReader(Reader reader, Format format) {
+        try {
+            if (format == Format.JSON) {
+                return jsonMapper.readTree(reader);
+            } else {
+                return yamlMapper.readTree(reader);
+            }
+        } catch (JacksonException e) {
+            throw new OpenApiRuntimeException("Failed to read " + format + " stream", e);
+        }
+    }
+
+    @Override
+    public JsonNode nullValue() {
+        return factory.nullNode();
+    }
+}

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/JakartaJsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/JakartaJsonIO.java
@@ -30,7 +30,6 @@ import jakarta.json.JsonWriter;
 import jakarta.json.JsonWriterFactory;
 import jakarta.json.spi.JsonProvider;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 
@@ -40,7 +39,6 @@ import io.xlate.yamljson.Yaml;
 
 class JakartaJsonIO implements JsonIO<JsonValue, JsonArray, JsonObject, JsonArrayBuilder, JsonObjectBuilder> {
 
-    private final OpenApiConfig config;
     private final JsonProvider json;
     private final JsonReaderFactory jsonReaderFactory;
     private final JsonWriterFactory jsonWriterFactory;
@@ -49,13 +47,12 @@ class JakartaJsonIO implements JsonIO<JsonValue, JsonArray, JsonObject, JsonArra
     private final JsonWriterFactory yamlWriterFactory;
 
     public JakartaJsonIO(OpenApiConfig config, JsonProvider jsonProvider, JsonProvider yamlProvider) {
-        this.config = config;
         this.json = jsonProvider;
         this.jsonReaderFactory = jsonProvider.createReaderFactory(Collections.emptyMap());
         this.jsonWriterFactory = jsonProvider.createWriterFactory(Collections.emptyMap());
 
         LoaderOptions loaderOptions = new LoaderOptions();
-        Optional.ofNullable(this.config.getMaximumStaticFileSize()).ifPresent(loaderOptions::setCodePointLimit);
+        Optional.ofNullable(config.getMaximumStaticFileSize()).ifPresent(loaderOptions::setCodePointLimit);
         Map<String, Object> yamlReaderConfig = new HashMap<>();
         yamlReaderConfig.put(Yaml.Settings.LOAD_CONFIG, loaderOptions);
         this.yamlReaderFactory = yamlProvider.createReaderFactory(yamlReaderConfig);
@@ -70,10 +67,6 @@ class JakartaJsonIO implements JsonIO<JsonValue, JsonArray, JsonObject, JsonArra
 
     public JakartaJsonIO(OpenApiConfig config) {
         this(config, JsonProvider.provider(), Yaml.provider());
-    }
-
-    public JakartaJsonIO() {
-        this(OpenApiConfig.fromConfig(ConfigProvider.getConfig()), JsonProvider.provider(), Yaml.provider());
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/JsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/JsonIO.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
 import io.smallrye.openapi.model.BaseModel;
 
 /**
@@ -61,10 +62,32 @@ public interface JsonIO<V, A extends V, O extends V, AB, OB> {
         }
     }
 
-    public static <V, A extends V, O extends V, AB, OB> JsonIO<V, A, O, AB, OB> newInstance(OpenApiConfig config) {
-        @SuppressWarnings("unchecked")
-        JsonIO<V, A, O, AB, OB> jackson = (JsonIO<V, A, O, AB, OB>) new JacksonJsonIO(config);
-        return jackson;
+    @SuppressWarnings("unchecked")
+    public static <V, A extends V, O extends V, AB, OB> JsonIO<V, A, O, AB, OB> newInstance(
+            SmallRyeOpenAPI.JsonProvider jsonProvider, OpenApiConfig config) {
+        return (JsonIO<V, A, O, AB, OB>) newInstanceRaw(jsonProvider, config);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static JsonIO newInstanceRaw(SmallRyeOpenAPI.JsonProvider jsonProvider, OpenApiConfig config) {
+        switch (jsonProvider) {
+            case JACKSON2:
+                return new Jackson2JsonIO(config);
+            case JACKSON3:
+                return new Jackson3JsonIO(config);
+            case JAKARTA_JSON:
+                return new JakartaJsonIO(config);
+            case AUTO:
+            default:
+                for (var provider : SmallRyeOpenAPI.JsonProvider.providers()) {
+                    try {
+                        return newInstanceRaw(provider, config);
+                    } catch (Exception | LinkageError e) {
+                        IoLogging.logger.jsonProviderAutoLoadFailure(provider.name(), e.getMessage());
+                    }
+                }
+                throw IoMessages.msg.noJsonProviderFound(SmallRyeOpenAPI.JsonProvider.providerNames());
+        }
     }
 
     private boolean wrapped(String value, String prefix, String suffix) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/JsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/JsonIO.java
@@ -65,7 +65,7 @@ public interface JsonIO<V, A extends V, O extends V, AB, OB> {
     @SuppressWarnings("unchecked")
     public static <V, A extends V, O extends V, AB, OB> JsonIO<V, A, O, AB, OB> newInstance(
             SmallRyeOpenAPI.JsonProvider jsonProvider, OpenApiConfig config) {
-        return (JsonIO<V, A, O, AB, OB>) newInstanceRaw(jsonProvider, config);
+        return newInstanceRaw(jsonProvider, config);
     }
 
     @SuppressWarnings("rawtypes")

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/JsonIO.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/JsonIO.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
 import io.smallrye.openapi.model.BaseModel;
 
 /**
@@ -61,10 +62,32 @@ public interface JsonIO<V, A extends V, O extends V, AB, OB> {
         }
     }
 
-    public static <V, A extends V, O extends V, AB, OB> JsonIO<V, A, O, AB, OB> newInstance(OpenApiConfig config) {
-        @SuppressWarnings("unchecked")
-        JsonIO<V, A, O, AB, OB> jackson = (JsonIO<V, A, O, AB, OB>) new JacksonJsonIO(config);
-        return jackson;
+    @SuppressWarnings("unchecked")
+    public static <V, A extends V, O extends V, AB, OB> JsonIO<V, A, O, AB, OB> newInstance(
+            SmallRyeOpenAPI.JsonProvider jsonProvider, OpenApiConfig config) {
+        return newInstanceRaw(jsonProvider, config);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static JsonIO newInstanceRaw(SmallRyeOpenAPI.JsonProvider jsonProvider, OpenApiConfig config) {
+        switch (jsonProvider) {
+            case JACKSON2:
+                return new Jackson2JsonIO(config);
+            case JACKSON3:
+                return new Jackson3JsonIO(config);
+            case JAKARTA_JSON:
+                return new JakartaJsonIO(config);
+            case AUTO:
+            default:
+                for (var provider : SmallRyeOpenAPI.JsonProvider.providers()) {
+                    try {
+                        return newInstanceRaw(provider, config);
+                    } catch (Exception | LinkageError e) {
+                        IoLogging.logger.jsonProviderAutoLoadFailure(provider.name(), e.getMessage());
+                    }
+                }
+                throw IoMessages.msg.noJsonProviderFound(SmallRyeOpenAPI.JsonProvider.providerNames());
+        }
     }
 
     private boolean wrapped(String value, String prefix, String suffix) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiParser.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 
 import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
 import io.smallrye.openapi.runtime.OpenApiRuntimeException;
 
 /**
@@ -54,7 +55,9 @@ public class OpenApiParser {
             }
 
             try (InputStream stream = url.openStream()) {
-                return parse(stream, isJson ? Format.JSON : Format.YAML, OpenApiConfig.fromConfig(ConfigProvider.getConfig()));
+                return parse(stream, isJson ? Format.JSON : Format.YAML,
+                        JsonIO.newInstance(SmallRyeOpenAPI.JsonProvider.AUTO,
+                                OpenApiConfig.fromConfig(ConfigProvider.getConfig())));
             }
         } catch (URISyntaxException e) {
             throw new IOException(e);
@@ -70,7 +73,8 @@ public class OpenApiParser {
      * @return OpenAPIImpl parsed from the stream
      */
     public static OpenAPI parse(InputStream stream, Format format, OpenApiConfig config) {
-        return parse(stream, format, JsonIO.newInstance(config));
+        config = config != null ? config : OpenApiConfig.fromConfig(ConfigProvider.getConfig());
+        return parse(stream, format, JsonIO.newInstance(SmallRyeOpenAPI.JsonProvider.AUTO, config));
     }
 
     private static <V, A extends V, O extends V, AB, OB> OpenAPI parse(InputStream stream, Format format,
@@ -89,7 +93,8 @@ public class OpenApiParser {
      * @throws OpenApiRuntimeException Errors in reading the String
      */
     public static Schema parseSchema(String schemaJson) {
-        return parseSchema(schemaJson, JsonIO.newInstance(null));
+        return parseSchema(schemaJson, JsonIO.newInstance(SmallRyeOpenAPI.JsonProvider.AUTO,
+                OpenApiConfig.fromConfig(ConfigProvider.getConfig())));
     }
 
     /**

--- a/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiSerializer.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/io/OpenApiSerializer.java
@@ -2,9 +2,13 @@ package io.smallrye.openapi.runtime.io;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
 
 /**
  * Class used to serialize an OpenAPI
@@ -30,7 +34,8 @@ public class OpenApiSerializer {
      * @throws IOException Errors in processing the JSON
      */
     public static String serialize(OpenAPI openApi, Format format) throws IOException {
-        return serialize(openApi, format, JsonIO.newInstance(null));
+        return serialize(openApi, format, JsonIO.newInstance(SmallRyeOpenAPI.JsonProvider.AUTO,
+                OpenApiConfig.fromConfig(ConfigProvider.getConfig())));
     }
 
     /**
@@ -43,7 +48,8 @@ public class OpenApiSerializer {
      * @throws IOException Errors in processing the JSON
      */
     public static String serialize(OpenAPI openApi, ObjectMapper objectMapper, Format format) throws IOException {
-        return serialize(openApi, format, JsonIO.newInstance(null));
+        return serialize(openApi, format, JsonIO.newInstance(SmallRyeOpenAPI.JsonProvider.AUTO,
+                OpenApiConfig.fromConfig(ConfigProvider.getConfig())));
     }
 
     private static <V, A extends V, O extends V, AB, OB> String serialize(OpenAPI openApi, Format format,

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/AnnotationScannerExtension.java
@@ -9,6 +9,7 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.Type;
 
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
 import io.smallrye.openapi.runtime.io.Format;
 import io.smallrye.openapi.runtime.io.JsonIO;
 import io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner;
@@ -37,7 +38,7 @@ public interface AnnotationScannerExtension {
             this.scannerContext = scannerContext;
 
             if (scannerContext.io().jsonIO() == null) {
-                scannerContext.io().jsonIO(JsonIO.newInstance(scannerContext.getConfig()));
+                scannerContext.io().jsonIO(JsonIO.newInstance(SmallRyeOpenAPI.JsonProvider.AUTO, scannerContext.getConfig()));
             }
 
             jsonIO = scannerContext.io().jsonIO();

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson2JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson2JsonIOTest.java
@@ -1,0 +1,35 @@
+package io.smallrye.openapi.runtime.io;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+
+@EnabledIf("jackson2Present")
+class Jackson2JsonIOTest extends JacksonJsonIOTest<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
+    static boolean jackson2Present() {
+        try {
+            Class.forName("com.fasterxml.jackson.databind.ObjectMapper");
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    @BeforeEach
+    void setup(TestInfo testInfo) {
+        super.setup(testInfo);
+        super.target = new Jackson2JsonIO(
+                OpenApiConfig.fromConfig(ConfigProvider.getConfig()),
+                new ObjectMapper()
+                        .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS));
+    }
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson2JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson2JsonIOTest.java
@@ -24,6 +24,7 @@ class Jackson2JsonIOTest extends JacksonJsonIOTest<JsonNode, ArrayNode, ObjectNo
         }
     }
 
+    @Override
     @BeforeEach
     void setup(TestInfo testInfo) {
         super.setup(testInfo);

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson2JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson2JsonIOTest.java
@@ -1,0 +1,36 @@
+package io.smallrye.openapi.runtime.io;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+
+@EnabledIf("jackson2Present")
+class Jackson2JsonIOTest extends JacksonJsonIOTest<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
+    static boolean jackson2Present() {
+        try {
+            Class.forName("com.fasterxml.jackson.databind.ObjectMapper");
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    @Override
+    @BeforeEach
+    void setup(TestInfo testInfo) {
+        super.setup(testInfo);
+        super.target = new Jackson2JsonIO(
+                OpenApiConfig.fromConfig(ConfigProvider.getConfig()),
+                new ObjectMapper()
+                        .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS));
+    }
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson3JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson3JsonIOTest.java
@@ -23,6 +23,7 @@ class Jackson3JsonIOTest extends JacksonJsonIOTest<JsonNode, ArrayNode, ObjectNo
         }
     }
 
+    @Override
     @BeforeEach
     void setup(TestInfo testInfo) {
         super.setup(testInfo);

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson3JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson3JsonIOTest.java
@@ -1,0 +1,35 @@
+package io.smallrye.openapi.runtime.io;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+@EnabledIf("jackson3Present")
+class Jackson3JsonIOTest extends JacksonJsonIOTest<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
+    static boolean jackson3Present() {
+        try {
+            Class.forName("tools.jackson.databind.ObjectMapper");
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    @BeforeEach
+    void setup(TestInfo testInfo) {
+        super.setup(testInfo);
+        super.target = new Jackson3JsonIO(
+                OpenApiConfig.fromConfig(ConfigProvider.getConfig()),
+                JsonMapper.builder()
+                        .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                        .build());
+    }
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson3JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/Jackson3JsonIOTest.java
@@ -1,0 +1,36 @@
+package io.smallrye.openapi.runtime.io;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+@EnabledIf("jackson3Present")
+class Jackson3JsonIOTest extends JacksonJsonIOTest<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
+    static boolean jackson3Present() {
+        try {
+            Class.forName("tools.jackson.databind.ObjectMapper");
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    @Override
+    @BeforeEach
+    void setup(TestInfo testInfo) {
+        super.setup(testInfo);
+        super.target = new Jackson3JsonIO(
+                OpenApiConfig.fromConfig(ConfigProvider.getConfig()),
+                JsonMapper.builder()
+                        .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                        .build());
+    }
+}

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/JacksonJsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/JacksonJsonIOTest.java
@@ -6,13 +6,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-class JacksonJsonIOTest extends JsonIOTest<JsonNode, ArrayNode, ObjectNode, ArrayNode, ObjectNode> {
+abstract class JacksonJsonIOTest<V, A extends V, O extends V, AB, OB> extends JsonIOTest<V, A, O, AB, OB> {
 
     private Properties originalSystemProperties;
 
@@ -28,9 +22,6 @@ class JacksonJsonIOTest extends JsonIOTest<JsonNode, ArrayNode, ObjectNode, Arra
                 .map(tag -> tag.substring("property:".length()))
                 .map(tag -> tag.split("="))
                 .forEach(tag -> System.setProperty(tag[0], tag[1]));
-
-        super.target = new JacksonJsonIO(new ObjectMapper()
-                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS));
     }
 
     @AfterEach

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/JakartaJsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/JakartaJsonIOTest.java
@@ -6,13 +6,16 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
+
+import io.smallrye.openapi.api.OpenApiConfig;
 
 class JakartaJsonIOTest extends JsonIOTest<JsonValue, JsonArray, JsonObject, JsonArrayBuilder, JsonObjectBuilder> {
 
     @BeforeEach
     void setup() {
-        super.target = new JakartaJsonIO();
+        super.target = new JakartaJsonIO(OpenApiConfig.fromConfig(ConfigProvider.getConfig()));
     }
 
 }

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/JsonIOTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/JsonIOTest.java
@@ -71,7 +71,7 @@ abstract class JsonIOTest<V, A extends V, O extends V, AB, OB> {
     @Test
     @Tag("property:" + SmallRyeOASConfig.SMALLRYE_YAML_ALIAS_EXPANSION_ENABLE + "=false")
     void testSimpleAliasExpansionDisabled() {
-        assumeTrue(getClass().equals(JacksonJsonIOTest.class), "Disabling alias expansion only supported for JacksonJsonIO");
+        assumeTrue(this instanceof JacksonJsonIOTest, "Disabling alias expansion only supported for Jackson");
 
         String input = ""
                 + "---\n"

--- a/core/src/test/java/io/smallrye/openapi/runtime/io/OpenApiParserAndSerializerTest.java
+++ b/core/src/test/java/io/smallrye/openapi/runtime/io/OpenApiParserAndSerializerTest.java
@@ -20,6 +20,7 @@ import org.jboss.logging.Logger;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.error.YAMLException;
 
@@ -661,7 +662,8 @@ class OpenApiParserAndSerializerTest {
         Exception thrown = assertThrows(OpenApiRuntimeException.class, () -> doTest(tempFileLoc, Format.YAML));
         assertNotNull(thrown.getCause());
         Throwable rootCause = thrown.getCause().getCause();
-        assertTrue(rootCause instanceof YAMLException);
+        assertTrue(rootCause instanceof YAMLException // Jackson 2
+                || rootCause instanceof YamlEngineException); // Jackson 3
 
         // now let's set a higher limit
         final Integer maximumFileSize = 8 * 1024 * 1024;

--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -137,6 +137,9 @@
                                 <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-core</classpathDependencyExclude>
                                 <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
                                 <classpathDependencyExclude>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</classpathDependencyExclude>
+                                <classpathDependencyExclude>tools.jackson.core:jackson-core</classpathDependencyExclude>
+                                <classpathDependencyExclude>tools.jackson.core:jackson-databind</classpathDependencyExclude>
+                                <classpathDependencyExclude>tools.jackson.dataformat:jackson-dataformat-yaml</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                         </configuration>
                     </execution>

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/CustomExtensionParsingTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/CustomExtensionParsingTests.java
@@ -43,8 +43,9 @@ class CustomExtensionParsingTests {
 
     void testDefaultExtensionParseThrowsJacksonNotFound(Index index) {
         OpenApiConfig config = IndexScannerTestBase.emptyConfig();
-        NoClassDefFoundError err = assertThrows(NoClassDefFoundError.class, () -> new OpenApiAnnotationScanner(config, index));
-        assertTrue(err.getMessage().contains("jackson"));
+        var err = assertThrows(io.smallrye.openapi.runtime.OpenApiRuntimeException.class,
+                () -> new OpenApiAnnotationScanner(config, index));
+        assertTrue(err.getMessage().contains("No JSON provider found"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,8 @@
 
     <properties>
         <version.buildhelper.plugin>3.6.1</version.buildhelper.plugin>
-        <jackson-bom.version>2.22.1</jackson-bom.version>
+        <version.jackson2-bom>2.22.1</version.jackson2-bom>
+        <version.jackson3-bom>3.2.0</version.jackson3-bom>
         <version.eclipse.microprofile.config>3.0.3</version.eclipse.microprofile.config>
         <version.io.smallrye.jandex>3.6.0</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-config>3.18.1</version.io.smallrye.smallrye-config>
@@ -115,7 +116,14 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson-bom.version}</version>
+                <version>${version.jackson2-bom}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${version.jackson3-bom}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -476,6 +484,45 @@
                 <jboss.extra.opts>--add-modules java.se</jboss.extra.opts>
                 <maven.compiler.release>11</maven.compiler.release>
             </properties>
+        </profile>
+
+        <profile>
+            <id>jackson3</id>
+            <dependencies>
+                <!-- Jackson 2 Libraries -->
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+
+                <!-- Jackson 3 Libraries -->
+                <dependency>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <optional>false</optional>
+                </dependency>
+                <dependency>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                    <optional>false</optional>
+                </dependency>
+                <dependency>
+                    <groupId>tools.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                    <optional>false</optional>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         </sonar.coverage.exclusions>
         <!-- Ignore duplication in Jackson IO classes. Nearly identical besides packages. -->
         <sonar.cpd.exclusions>
-          core/src/main/java/io/smallrye/openapi/runtime/io/Jackson2JsonIO.java,
-          core/src/main/java/io/smallrye/openapi/runtime/io/Jackson3JsonIO.java
+          **/Jackson2JsonIO.java,
+          **/Jackson3JsonIO.java
         </sonar.cpd.exclusions>
         <!--
           Ignore rule java:S119 the checks type parameter names. The generic types in the

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,8 @@
 
     <properties>
         <version.buildhelper.plugin>3.6.1</version.buildhelper.plugin>
-        <jackson-bom.version>2.22.2</jackson-bom.version>
+        <version.jackson2>2.22.2</version.jackson2>
+        <version.jackson3>3.2.0</version.jackson3>
         <version.eclipse.microprofile.config>3.0.3</version.eclipse.microprofile.config>
         <version.io.smallrye.jandex>3.6.0</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-config>3.18.2</version.io.smallrye.smallrye-config>
@@ -49,6 +50,10 @@
           testsuite/data/**/*.java,
           tools/model-apt/**/*.java
         </sonar.coverage.exclusions>
+        <!-- Ignore duplication in Jackson IO classes. Nearly identical besides packages. -->
+        <sonar.cpd.exclusions>
+          core/src/main/java/io/smallrye/openapi/runtime/io/Jackson*JsonIO.java
+        </sonar.cpd.exclusions>
         <!--
           Ignore rule java:S119 the checks type parameter names. The generic types in the
           io.smallrye.openapi.runtime.io package use two-character type parameter names for the
@@ -112,13 +117,35 @@
             </dependency>
 
             <!-- Third Party Libraries -->
+
+            <!-- Jackson 2 -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson-bom.version}</version>
+                <version>${version.jackson2}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- Jackson 3 Libraries -->
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${version.jackson3}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.jackson3}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${version.jackson3}</version>
+                <scope>provided</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-metadata-jvm</artifactId>
@@ -476,6 +503,33 @@
                 <jboss.extra.opts>--add-modules java.se</jboss.extra.opts>
                 <maven.compiler.release>11</maven.compiler.release>
             </properties>
+        </profile>
+
+        <profile>
+            <id>jackson3</id>
+            <dependencyManagement>
+                <dependencies>
+                    <!-- Jackson 3 Libraries -->
+                    <dependency>
+                        <groupId>tools.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>${version.jackson3}</version>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>tools.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                        <version>${version.jackson3}</version>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>tools.jackson.dataformat</groupId>
+                        <artifactId>jackson-dataformat-yaml</artifactId>
+                        <version>${version.jackson3}</version>
+                        <scope>compile</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,6 @@
           testsuite/data/**/*.java,
           tools/model-apt/**/*.java
         </sonar.coverage.exclusions>
-        <!-- Ignore duplication in Jackson IO classes. Nearly identical besides packages. -->
-        <sonar.cpd.exclusions>
-          **/Jackson2JsonIO.java,
-          **/Jackson3JsonIO.java
-        </sonar.cpd.exclusions>
         <!--
           Ignore rule java:S119 the checks type parameter names. The generic types in the
           io.smallrye.openapi.runtime.io package use two-character type parameter names for the

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,8 @@
         </sonar.coverage.exclusions>
         <!-- Ignore duplication in Jackson IO classes. Nearly identical besides packages. -->
         <sonar.cpd.exclusions>
-          core/src/main/java/io/smallrye/openapi/runtime/io/Jackson*JsonIO.java
+          core/src/main/java/io/smallrye/openapi/runtime/io/Jackson2JsonIO.java,
+          core/src/main/java/io/smallrye/openapi/runtime/io/Jackson3JsonIO.java
         </sonar.cpd.exclusions>
         <!--
           Ignore rule java:S119 the checks type parameter names. The generic types in the


### PR DESCRIPTION
- Add JSON provider for Jackson v3
- Enable provider selection using the SmallRyeOpenAPI.Builder
- Auto-select JSON provider when not chosen with the builder. Order of preference is Jackson3, Jackson2, Jakarta JSON.
- Adjust CI to test Jackson 3 separately and collect coverage statistics