### PR TITLE
perf: Reduce ancestry calls in isResourceMethod

### DIFF
--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
@@ -286,14 +286,26 @@ public class JaxRsParameterProcessor extends AbstractParameterProcessor {
 
     @Override
     protected boolean isResourceMethod(MethodInfo method) {
+        // avoid the expensive ancestry call if possible by first checking the method itself
+        if (hasMethodHTTPMethodAnnotation(method)) {
+            return true;
+        }
+
+        // check if any of the parent methods has a http method annotation
         for (MethodInfo overriddenMethod : scannerContext.getAugmentedIndex().ancestry(method).values()) {
-            if (overriddenMethod != null) {
-                for (AnnotationInstance a : overriddenMethod.declaredAnnotations()) {
-                    for (AnnotationInstance httpMethod : JaxRsConstants.HTTP_METHOD_INSTANCES) {
-                        if (a.equivalentTo(httpMethod)) {
-                            return true;
-                        }
-                    }
+            if (overriddenMethod != null && hasMethodHTTPMethodAnnotation(overriddenMethod)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean hasMethodHTTPMethodAnnotation(MethodInfo method) {
+        for (AnnotationInstance a : method.declaredAnnotations()) {
+            for (AnnotationInstance httpMethod : JaxRsConstants.HTTP_METHOD_INSTANCES) {
+                if (a.equivalentTo(httpMethod)) {
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
ancestry determines the parent methods the given method is overriden. Which in turn are checked if they are a resource method.

However, often the resource methods are not overriding any parent methods. so the ancestry call would be wasted.

ancestry() is slow (relativly speaking) because of the interfaces() calls.

Introduce a fast path for first checking if the given method is already resource method, before falling back to checking ancestry.


This saves about 100ms when doing a quarkus:build.

Related to #2630