### PR TITLE
feat: add APPEND_NUMBER behavior for duplicate operationIds

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ Configures handling of schema inheritance. Allowed values include `NONE` (defaul
 ----
 mp.openapi.extensions.smallrye.duplicateOperationIdBehavior
 ----
-Set to `FAIL` to abort in case of duplicate operationIds, set to `WARN` to log warnings when the build encounters duplicate operationIds. Default value is `WARN`.
+Set to `FAIL` to abort in case of duplicate operationIds, set to `WARN` to log warnings, or set to `APPEND_NUMBER` to resolve duplicates by automatically appending numeric suffixes (e.g. `_1`, `_2`). Default value is `WARN`.
 
 [#maximumStaticFileSize]
 ==== Maximum Static File Size

--- a/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
+++ b/core/src/main/java/io/smallrye/openapi/api/OpenApiConfig.java
@@ -104,7 +104,8 @@ public interface OpenApiConfig {
 
     enum DuplicateOperationIdBehavior {
         FAIL,
-        WARN
+        WARN,
+        APPEND_NUMBER
     }
 
     enum AutoInheritance {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -311,7 +311,10 @@ public interface AnnotationScanner {
         String operationId = operation.getOperationId();
 
         if (operationId != null) {
-            saveOperationId(context, resourceClass, method, operationId);
+            String resolvedId = saveOperationId(context, resourceClass, method, operationId);
+            if (!resolvedId.equals(operationId)) {
+                operation.setOperationId(resolvedId);
+            }
         }
 
         ExternalDocumentation externalDocs = context.io().extDocIO().read(method);
@@ -322,7 +325,7 @@ public interface AnnotationScanner {
         return Optional.of(operation);
     }
 
-    private void saveOperationId(AnnotationScannerContext context, ClassInfo resourceClass, MethodInfo method,
+    private String saveOperationId(AnnotationScannerContext context, ClassInfo resourceClass, MethodInfo method,
             String operationId) {
         final MethodInfo conflictingMethod = context.getOperationIdMap().putIfAbsent(operationId, method);
 
@@ -330,6 +333,13 @@ public interface AnnotationScanner {
             if (context.getAugmentedIndex().ancestry(method).values().contains(conflictingMethod)) {
                 // The conflict was a method from a parent class, replace it
                 context.getOperationIdMap().put(operationId, method);
+            } else if (context.getConfig().getDuplicateOperationIdBehavior() == DuplicateOperationIdBehavior.APPEND_NUMBER) {
+                int counter = 1;
+                String numberedId;
+                do {
+                    numberedId = operationId + "_" + counter++;
+                } while (context.getOperationIdMap().putIfAbsent(numberedId, method) != null);
+                return numberedId;
             } else {
                 final ClassInfo conflictingClass = conflictingMethod.declaringClass();
                 final String className = resourceClass.name().toString();
@@ -345,6 +355,8 @@ public interface AnnotationScanner {
                 }
             }
         }
+
+        return operationId;
     }
 
     default void setJsonViewContext(AnnotationScannerContext context, Type[] views) {

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationIdTest.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/OperationIdTest.java
@@ -1,8 +1,15 @@
 package io.smallrye.openapi.runtime.scanner;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
 import org.jboss.jandex.Index;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -49,6 +56,42 @@ class OperationIdTest extends JaxRsDataObjectScannerTestBase {
             assertJsonEquals(expectedResultResourceName, result);
         } finally {
             System.clearProperty(SmallRyeOASConfig.OPERATION_ID_STRAGEGY);
+        }
+    }
+
+    @Test
+    void testAppendNumberOnDuplicateOperationIds() throws Exception {
+        Map<String, String> config = new HashMap<>();
+        config.put(SmallRyeOASConfig.OPERATION_ID_STRAGEGY, "METHOD");
+        config.put(SmallRyeOASConfig.DUPLICATE_OPERATION_ID_BEHAVIOR,
+                OpenApiConfig.DuplicateOperationIdBehavior.APPEND_NUMBER.name());
+
+        Index index = indexOf(AppendNumberTestResource.class);
+        OpenAPI result = OpenApiProcessor.bootstrap(dynamicConfig(config), index);
+        printToConsole(result);
+
+        List<String> operationIds = result.getPaths().getPathItems().values().stream()
+                .map(PathItem::getOperations)
+                .flatMap(ops -> ops.values().stream())
+                .map(Operation::getOperationId)
+                .sorted()
+                .collect(Collectors.toList());
+
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("create", "create_1"), operationIds);
+    }
+
+    @jakarta.ws.rs.Path("/append-number-test")
+    static class AppendNumberTestResource {
+        @jakarta.ws.rs.GET
+        @jakarta.ws.rs.Path("/one")
+        public String create() {
+            return "one";
+        }
+
+        @jakarta.ws.rs.GET
+        @jakarta.ws.rs.Path("/two")
+        public String create(@jakarta.ws.rs.QueryParam("q") String param) {
+            return "two";
         }
     }
 


### PR DESCRIPTION
Implement a new `DuplicateOperationIdBehavior.APPEND_NUMBER` strategy that auto-resolves
duplicate operationIds by appending `_1`, `_2`, etc. instead of failing or warning. Enables
viable use of `METHOD/CLASS_METHOD` strategies even when overloaded methods produce identical
operation IDs.

- Add `APPEND_NUMBER` enum value to `DuplicateOperationIdBehavior`
- Modify `saveOperationId()` to return the resolved ID
- Loop through `_1`, `_2`, ... until `putIfAbsent()` succeeds
- Update `processOperation()` to apply the renumbered ID
- Add test with inline resource containing duplicate method names

Fixes duplicate operationId conflicts without requiring explicit `@Operation(operationId="...")`
annotations on every overload.