### PR TITLE
fix: preserve unresolved parameter references

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -565,12 +565,18 @@ public abstract class AbstractParameterProcessor {
                      * post-processed later and renamed with a "Matrix" suffix, if needed.
                      *
                      * https://spec.openapis.org/oas/v3.1.0.html#parameter-object
-                     */
-                    ScannerSPILogging.log.duplicateParameter(
-                            param.getName(),
-                            String.valueOf(param.getIn()),
-                            String.valueOf(param.getStyle()),
-                            String.valueOf(context.target));
+                    */
+                    if (param.getRef() != null) {
+                        ScannerSPILogging.log.duplicateParameterReference(
+                                param.getRef(),
+                                String.valueOf(context.target));
+                    } else {
+                        ScannerSPILogging.log.duplicateParameter(
+                                param.getName(),
+                                String.valueOf(param.getIn()),
+                                String.valueOf(param.getStyle()),
+                                String.valueOf(context.target));
+                    }
                 }
             }
         }

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -549,12 +549,17 @@ public abstract class AbstractParameterProcessor {
             Parameter param = mapParameter(resourceMethod, context);
 
             if (param != null) {
-                if (paramKeys.add(Arrays.asList(param.getName(), param.getIn(), param.getStyle()))) {
+                List<?> paramKey = param.getRef() != null
+                        ? Collections.singletonList(param.getRef())
+                        : Arrays.asList(param.getName(), param.getIn(), param.getStyle());
+
+                if (paramKeys.add(paramKey)) {
                     parameters.add(param);
                 } else {
                     /*
-                     * Parameters are unique by name and location - filter out any
-                     * duplicates seen earlier in the stream. We also consider the parameter's
+                     * Referenced parameters are unique by reference. Inline parameters are
+                     * unique by name and location - filter out any duplicates seen earlier in
+                     * the stream. We also consider the parameter's
                      * style to account for matrix parameters having the same name as an
                      * associated path parameter. The matrix parameter name will be
                      * post-processed later and renamed with a "Matrix" suffix, if needed.

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -565,7 +565,7 @@ public abstract class AbstractParameterProcessor {
                      * post-processed later and renamed with a "Matrix" suffix, if needed.
                      *
                      * https://spec.openapis.org/oas/v3.1.0.html#parameter-object
-                    */
+                     */
                     if (param.getRef() != null) {
                         ScannerSPILogging.log.duplicateParameterReference(
                                 param.getRef(),

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/ScannerSPILogging.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/ScannerSPILogging.java
@@ -33,4 +33,8 @@ interface ScannerSPILogging { // NOSONAR (use of constants in an interface)
     @Message(id = 7904, value = "Ignoring duplicate parameter named '%s' in location '%s' with style '%s', specified on %s")
     void duplicateParameter(String name, String location, String style, String target);
 
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 7905, value = "Ignoring duplicate parameter reference '%s', specified on %s")
+    void duplicateParameterReference(String reference, String target);
+
 }

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.Explode;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
@@ -26,6 +28,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -547,6 +550,52 @@ class ParameterScanTests extends IndexScannerTestBase {
         test("params.parameter-ref-property.json",
                 test.io.smallrye.openapi.runtime.scanner.jakarta.ParameterRefTestApplication.class,
                 test.io.smallrye.openapi.runtime.scanner.jakarta.ParameterRefTestResource.class);
+    }
+
+    @Test
+    void testMultipleUnresolvedParameterRefs() {
+        @jakarta.ws.rs.Path("/parameters")
+        class Resource {
+            @jakarta.ws.rs.GET
+            @jakarta.ws.rs.Path("/repeatable")
+            @Parameter(ref = "#/components/parameters/XHeader2")
+            @Parameter(ref = "#/components/parameters/XHeader1")
+            public void repeatable() {
+            }
+
+            @jakarta.ws.rs.GET
+            @jakarta.ws.rs.Path("/container")
+            @Parameters({
+                    @Parameter(ref = "#/components/parameters/XHeader2"),
+                    @Parameter(ref = "#/components/parameters/XHeader1")
+            })
+            public void container() {
+            }
+        }
+
+        OpenAPI result = scan(Resource.class);
+        new OASFilter() {
+            @Override
+            public void filterOpenAPI(OpenAPI openAPI) {
+                openAPI.setComponents(OASFactory.createComponents()
+                        .addParameter("XHeader1", OASFactory.createParameter()
+                                .name("XHeader1")
+                                .in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.HEADER))
+                        .addParameter("XHeader2", OASFactory.createParameter()
+                                .name("XHeader2")
+                                .in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.HEADER)));
+            }
+        }.filterOpenAPI(result);
+
+        for (String path : List.of("/parameters/repeatable", "/parameters/container")) {
+            List<org.eclipse.microprofile.openapi.models.parameters.Parameter> parameters = result.getPaths()
+                    .getPathItem(path)
+                    .getGET()
+                    .getParameters();
+            Assertions.assertEquals(2, parameters.size());
+            Assertions.assertEquals("#/components/parameters/XHeader2", parameters.get(0).getRef());
+            Assertions.assertEquals("#/components/parameters/XHeader1", parameters.get(1).getRef());
+        }
     }
 
     @Test

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -19,8 +19,6 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 
-import org.eclipse.microprofile.openapi.OASFactory;
-import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.Explode;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
@@ -561,32 +559,22 @@ class ParameterScanTests extends IndexScannerTestBase {
             @Parameter(ref = "#/components/parameters/XHeader2")
             @Parameter(ref = "#/components/parameters/XHeader1")
             public void repeatable() {
+                // No-op endpoint used for annotation scanning
             }
 
             @jakarta.ws.rs.GET
             @jakarta.ws.rs.Path("/container")
+            @SuppressWarnings("java:S1710") // The explicit container form is under test
             @Parameters({
                     @Parameter(ref = "#/components/parameters/XHeader2"),
                     @Parameter(ref = "#/components/parameters/XHeader1")
             })
             public void container() {
+                // No-op endpoint used for annotation scanning
             }
         }
 
         OpenAPI result = scan(Resource.class);
-        new OASFilter() {
-            @Override
-            public void filterOpenAPI(OpenAPI openAPI) {
-                openAPI.setComponents(OASFactory.createComponents()
-                        .addParameter("XHeader1", OASFactory.createParameter()
-                                .name("XHeader1")
-                                .in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.HEADER))
-                        .addParameter("XHeader2", OASFactory.createParameter()
-                                .name("XHeader2")
-                                .in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.HEADER)));
-            }
-        }.filterOpenAPI(result);
-
         for (String path : List.of("/parameters/repeatable", "/parameters/container")) {
             List<org.eclipse.microprofile.openapi.models.parameters.Parameter> parameters = result.getPaths()
                     .getPathItem(path)


### PR DESCRIPTION
## Description

Fixes #2643.

Multiple unresolved parameter references were treated as duplicates because their `name`, `in`, and `style` values were all `null` during annotation scanning.

Referenced parameters now use their `$ref` as the duplicate key. Inline parameters continue to use `name`, `in`, and `style`.

## Changes

- Preserve distinct unresolved parameter references.
- Retain existing duplicate handling for inline parameters.
- Add regression coverage for:
  - Repeated `@Parameter` annotations.
  - Explicit `@Parameters` containers.
  - Referenced components supplied after scanning by a filter.

## Testing

```bash
./mvnw -pl extension-jaxrs -am -Dtest=ParameterScanTests#testMultipleUnresolvedParameterRefs test
```