### PR TITLE
feature: ensure stable order for sorted-parameters.enable=false

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -140,7 +140,7 @@ Set this boolean value to disable the merging of the deprecated `@Schema` `examp
 ----
 mp.openapi.extensions.smallrye.sorted-parameters.enable
 ----
-Set this boolean value to enable or disable the sorting of parameter array entries during annotation scanning. When enabled (set to `true`), parameters will be order either by their order within a `@Parameters` annotation on an operation method or (in the absence of that annotation) by their `$ref`, `in`, and `name` attributes. When disabled (set to `false`), parameters will be in the order they are encountered in the Java code. If not set, it will default to `true`.
+Set this boolean value to enable or disable the sorting of parameter array entries during annotation scanning. When enabled (set to `true`), parameters will be order either by their order within a `@Parameters` annotation on an operation method or (in the absence of that annotation) by their `$ref`, `in`, and `name` attributes. When disabled (set to `false`), parameters will be in the order they are encountered in the Java code, grouped - in no guaranteed order - by their `in` attribute. If not set, it will default to `true`.
 
 [#generic-response-use-default]
 ==== Generic Responses use `default` code

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/ResourceParameters.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/ResourceParameters.java
@@ -34,8 +34,7 @@ public class ResourceParameters {
         Comparator<Parameter> primaryComparator;
 
         if (preferredOrder != null) {
-            Comparator<Parameter> preferredComparator = (p1, p2) -> Integer.compare(position(preferredOrder, p1),
-                    position(preferredOrder, p2));
+            Comparator<Parameter> preferredComparator = Comparator.comparingInt(p -> position(preferredOrder, p));
 
             primaryComparator = preferredComparator
                     .thenComparing(Parameter::getRef, Comparator.nullsFirst(Comparator.naturalOrder()));
@@ -47,6 +46,11 @@ public class ResourceParameters {
         return primaryComparator
                 .thenComparing(Parameter::getIn, Comparator.nullsLast(Comparator.naturalOrder()))
                 .thenComparing(Parameter::getName, Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+
+    public static Comparator<Parameter> parameterInComparator() {
+
+        return Comparator.comparing(Parameter::getIn, Comparator.nullsLast(Comparator.naturalOrder()));
     }
 
     static final Pattern TEMPLATE_PARAM_PATTERN = Pattern.compile("\\{(\\w[\\w\\.-]*)\\}");

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -418,6 +418,8 @@ public abstract class AbstractParameterProcessor {
         // Re-sort (names of matrix parameters may have changed)
         if (scannerContext.getConfig().sortedParametersEnable()) {
             parameters.sort(ResourceParameters.parameterComparator(preferredOrder));
+        } else {
+            parameters.sort(ResourceParameters.parameterInComparator());
         }
 
         parameters.setFormBodyContent(getFormBodyContent());

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -18,9 +18,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
+import java.util.UUID;
+
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.Explode;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -808,22 +813,95 @@ class ParameterScanTests extends IndexScannerTestBase {
 
     @Test
     void testUnsortedParameters() throws IOException, JSONException {
-        @jakarta.ws.rs.Path("/status")
+        class ListOptions {
+            @jakarta.ws.rs.QueryParam("beanparam-field-1")
+            UUID field1;
+
+            @jakarta.ws.rs.HeaderParam("beanparam-field-2")
+            UUID field2;
+
+            @jakarta.ws.rs.PathParam("beanparam-field-3")
+            UUID field3;
+
+            @jakarta.ws.rs.QueryParam("beanparam-method-4")
+            public void field4(String field4) {
+            }
+
+            @jakarta.ws.rs.HeaderParam("beanparam-method-5")
+            public void field5(String field5) {
+            }
+
+            @jakarta.ws.rs.PathParam("beanparam-method-6")
+            public void field6(String field6) {
+            }
+
+            public void field7(@jakarta.ws.rs.QueryParam("beanparam-method-param-7") String field7) {
+            }
+
+            public void field8(@jakarta.ws.rs.HeaderParam("beanparam-method-param-8") String field8) {
+            }
+
+            public void field9(@jakarta.ws.rs.PathParam("beanparam-method-param-9") String field9) {
+            }
+
+            @jakarta.ws.rs.QueryParam("beanparam-field-10")
+            UUID field10;
+
+            @jakarta.ws.rs.HeaderParam("beanparam-field-11")
+            UUID field11;
+
+            @jakarta.ws.rs.PathParam("beanparam-field-12")
+            UUID field12;
+        }
+
+        @jakarta.ws.rs.Path("/status/{method-1-p1}/{field-3}/{method-6}/{field-9}/{beanparam-field-3}/{beanparam-field-6}/{beanparam-field-9}/{beanparam-field-12}")
         class Resource {
+            @jakarta.ws.rs.QueryParam("field-1")
+            UUID field1;
+
+            @jakarta.ws.rs.HeaderParam("field-2")
+            UUID field2;
+
+            @jakarta.ws.rs.PathParam("field-3")
+            UUID field3;
+
+            @Parameter(name = "method-additional-1", in = ParameterIn.QUERY)
+            @Parameter(name = "method-additional-2", in = ParameterIn.HEADER)
             @jakarta.ws.rs.GET
-            @jakarta.ws.rs.Path("/{resourceId}")
             public String get(
-                    @jakarta.ws.rs.QueryParam("q7") int q7,
-                    @jakarta.ws.rs.QueryParam("q9") int q9,
-                    @jakarta.ws.rs.HeaderParam("h6") int h8,
-                    @jakarta.ws.rs.PathParam("resourceId") String resourceId,
-                    @jakarta.ws.rs.QueryParam("q8") int q8) {
+                    @jakarta.ws.rs.QueryParam("method-1-q1") int q1,
+                    @jakarta.ws.rs.QueryParam("method-1-q2") int q2,
+                    @jakarta.ws.rs.HeaderParam("method-1-h1") int h3,
+                    @BeanParam ListOptions listOptions,
+                    @jakarta.ws.rs.PathParam("method-1-p1") String resourceId,
+                    @jakarta.ws.rs.QueryParam("method-1-q4") int q4) {
                 return null;
             }
+
+            @jakarta.ws.rs.QueryParam("method-4")
+            public void field4(String field4) {
+            }
+
+            @jakarta.ws.rs.HeaderParam("method-5")
+            public void field5(String field5) {
+            }
+
+            @jakarta.ws.rs.PathParam("method-6")
+            public void field6(String field6) {
+            }
+
+            @jakarta.ws.rs.QueryParam("field-7")
+            String field7;
+
+            @jakarta.ws.rs.HeaderParam("field-8")
+            String field8;
+
+            @jakarta.ws.rs.PathParam("field-9")
+            String field9;
         }
 
         test(dynamicConfig(SmallRyeOASConfig.SMALLRYE_SORTED_PARAMETERS_ENABLE, Boolean.FALSE),
-                "params.unsorted-scan-order.json", Resource.class);
+                "params.unsorted-scan-order.json", Resource.class, ListOptions.class);
     }
 
     @Test

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.unsorted-scan-order.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.unsorted-scan-order.json
@@ -1,43 +1,178 @@
 {
   "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "UUID" : {
+        "type" : "string",
+        "format" : "uuid",
+        "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+      }
+    }
+  },
   "paths" : {
-    "/status/{resourceId}" : {
+    "/status/{method-1-p1}/{field-3}/{method-6}/{field-9}/{beanparam-field-3}/{beanparam-field-6}/{beanparam-field-9}/{beanparam-field-12}" : {
+      "parameters" : [ {
+        "name" : "field-3",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "$ref" : "#/components/schemas/UUID"
+        }
+      }, {
+        "name" : "field-9",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "method-6",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "field-1",
+        "in" : "query",
+        "schema" : {
+          "$ref" : "#/components/schemas/UUID"
+        }
+      }, {
+        "name" : "field-7",
+        "in" : "query",
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "method-4",
+        "in" : "query",
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "field-2",
+        "in" : "header",
+        "schema" : {
+          "$ref" : "#/components/schemas/UUID"
+        }
+      }, {
+        "name" : "field-8",
+        "in" : "header",
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "method-5",
+        "in" : "header",
+        "schema" : {
+          "type" : "string"
+        }
+      } ],
       "get" : {
         "parameters" : [ {
-          "name" : "q7",
-          "in" : "query",
+          "name" : "beanparam-field-3",
+          "in" : "path",
+          "required" : true,
           "schema" : {
-            "type" : "integer",
-            "format" : "int32"
+            "$ref" : "#/components/schemas/UUID"
           }
         }, {
-          "name" : "q9",
-          "in" : "query",
+          "name" : "beanparam-field-12",
+          "in" : "path",
+          "required" : true,
           "schema" : {
-            "type" : "integer",
-            "format" : "int32"
+            "$ref" : "#/components/schemas/UUID"
           }
         }, {
-          "name" : "h6",
-          "in" : "header",
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "resourceId",
+          "name" : "method-1-p1",
           "in" : "path",
           "required" : true,
           "schema" : {
             "type" : "string"
           }
         }, {
-          "name" : "q8",
+          "name" : "method-1-q1",
           "in" : "query",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
           }
+        }, {
+          "name" : "method-1-q2",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "beanparam-field-1",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-field-10",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-method-4",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "beanparam-method-param-7",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "method-1-q4",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "in" : "query",
+          "name" : "method-additional-1"
+        }, {
+          "name" : "method-1-h1",
+          "in" : "header",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "beanparam-field-2",
+          "in" : "header",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-field-11",
+          "in" : "header",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-method-5",
+          "in" : "header",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "beanparam-method-param-8",
+          "in" : "header",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "in" : "header",
+          "name" : "method-additional-2"
         } ],
         "responses" : {
           "200" : {


### PR DESCRIPTION
`sorted-parameters.enable=false` allows to preserve definition order of parameters into the final openapi document.
Jandex first scans for annotations (our source of parameters) on fields, then on methods.
The output was therefore never in definition order.
Compare `org.jboss.jandex.Indexer.indexWithSummary`, which calls processFieldInfo before processMethodInfo.
(matchin jvms, which already sorts fields before methods https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html)

For openapi this means, we can add a test which makes sure this order stays stable with `sorted-parameters.enable=false`.

One hiccup was though, that the keys of ClassInfo.annotationsmap are not sorted in any particular way. The order changed mostly when adding a new kind of parameter type, e.g. adding header params on a resource where previously only query and path params where present

I therefore added an explicit sort on the In parameter in the `sorted-parameters.enable=false` case. This means though that we might break the currently existing order for existing apis.

Related to #2630. The next changeset basically requires that we agree upon a stable ordering.