### PR TITLE
perf: optimize AbstractParameterProcessor.readParameters

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -140,7 +140,7 @@ Set this boolean value to disable the merging of the deprecated `@Schema` `examp
 ----
 mp.openapi.extensions.smallrye.sorted-parameters.enable
 ----
-Set this boolean value to enable or disable the sorting of parameter array entries during annotation scanning. When enabled (set to `true`), parameters will be order either by their order within a `@Parameters` annotation on an operation method or (in the absence of that annotation) by their `$ref`, `in`, and `name` attributes. When disabled (set to `false`), parameters will be in the order they are encountered in the Java code. If not set, it will default to `true`.
+Set this boolean value to enable or disable the sorting of parameter array entries during annotation scanning. When enabled (set to `true`), parameters will be order either by their order within a `@Parameters` annotation on an operation method or (in the absence of that annotation) by their `$ref`, `in`, and `name` attributes. When disabled (set to `false`), parameters will be in the order they are encountered in the Java code. Within a class, fields are encountered before methods and constructors, each in declaration order. If not set, it will default to `true`.
 
 [#generic-response-use-default]
 ==== Generic Responses use `default` code

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AbstractParameterProcessor.java
@@ -43,7 +43,6 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.PrimitiveType.Primitive;
 import org.jboss.jandex.Type;
 
@@ -138,6 +137,20 @@ public abstract class AbstractParameterProcessor {
     }
 
     private final Comparator<AnnotationInstance> frameworkParametersFirst = new FrameworkParamsFirstComparator();
+
+    /**
+     * Jandex sorts method arguments alphabetically. This comparator ensures they are sorted by their declaration order instead.
+     */
+    private static final Comparator<AnnotationInstance> COMPARATOR_METHOD_PARAMETER_ORDER = Comparator
+            .comparingInt(an -> {
+                AnnotationTarget target = an.target();
+                if (target.kind() != Kind.METHOD_PARAMETER) {
+                    // order method level parameters before method argument level parameters
+                    return -1;
+                }
+
+                return target.asMethodParameter().position();
+            });
 
     protected AbstractParameterProcessor(AnnotationScannerContext scannerContext,
             String contextPath,
@@ -1596,73 +1609,51 @@ public abstract class AbstractParameterProcessor {
     protected void readParameters(ClassInfo clazz, AnnotationInstance beanParamAnnotation, boolean overriddenParametersOnly) {
         List<AnnotationInstance> paramAnnotations = new ArrayList<>();
 
-        for (Map.Entry<DotName, List<AnnotationInstance>> entry : clazz.annotationsMap().entrySet()) {
-            DotName name = entry.getKey();
-
-            if (Names.PARAMETER.equals(name) || isParameter(name)) {
-                for (AnnotationInstance annotation : entry.getValue()) {
-                    if (isBeanPropertyParam(annotation)) {
-                        paramAnnotations.add(annotation);
-                    }
+        for (FieldInfo fieldInfo : clazz.fieldsInDeclarationOrder()) {
+            for (AnnotationInstance annotation : fieldInfo.annotations()) {
+                if (annotation.target().kind() == Kind.FIELD && isParameter(annotation.name())) {
+                    paramAnnotations.add(annotation);
                 }
             }
         }
 
-        Collections.sort(paramAnnotations, frameworkParametersFirst);
+        for (MethodInfo method : clazz.methodsInDeclarationOrder()) {
+            if (!isBeanPropertyMethod(method)) {
+                continue;
+            }
+
+            int methodOffset = paramAnnotations.size();
+
+            for (AnnotationInstance annotation : method.annotations()) {
+                AnnotationTarget target = annotation.target();
+                if (target.kind() == Kind.METHOD_PARAMETER) {
+                    if (isParameter(annotation.name())) {
+                        paramAnnotations.add(annotation);
+                    }
+                } else if (target.kind() == Kind.METHOD) {
+                    if (getType(target) != null && isParameter(annotation.name())) {
+                        paramAnnotations.add(annotation);
+                    }
+                }
+            }
+
+            if (paramAnnotations.size() - methodOffset > 1) {
+                paramAnnotations.subList(methodOffset, paramAnnotations.size()).sort(COMPARATOR_METHOD_PARAMETER_ORDER);
+            }
+        }
+
+        paramAnnotations.sort(frameworkParametersFirst);
 
         for (AnnotationInstance annotation : paramAnnotations) {
             readAnnotatedType(annotation, beanParamAnnotation, overriddenParametersOnly);
         }
     }
 
-    /**
-     * Determines if the annotation is a property parameter. Annotation targets
-     * must be annotated with a framework-specific parameter annotation or
-     * {@link org.eclipse.microprofile.openapi.annotations.parameters.Parameter @Parameter}.
-     *
-     * Method targets must not be annotated with one of the framework-specific HTTP method annotations and
-     * the method must have a single argument.
-     *
-     * @param annotation
-     * @return
-     */
-    boolean isBeanPropertyParam(AnnotationInstance annotation) {
-        AnnotationTarget target = annotation.target();
-        boolean relevant = false;
-
-        switch (target.kind()) {
-            case FIELD: {
-                FieldInfo field = target.asField();
-                relevant = hasParameters(field.annotations());
-                break;
-            }
-
-            case METHOD_PARAMETER: {
-                MethodParameterInfo param = target.asMethodParameter();
-                MethodInfo method = param.method();
-                relevant = nonSyntheticParameterMethod(method,
-                        scannerContext.annotations().getMethodParameterAnnotations(method, param.position()));
-                break;
-            }
-
-            case METHOD: {
-                MethodInfo method = target.asMethod();
-                relevant = nonSyntheticParameterMethod(method, method.annotations()) &&
-                        getType(target) != null;
-                break;
-            }
-
-            default:
-                break;
-        }
-
-        return relevant;
-    }
-
-    boolean nonSyntheticParameterMethod(MethodInfo method, Collection<AnnotationInstance> annotations) {
-        return !method.isSynthetic() &&
+    boolean isBeanPropertyMethod(MethodInfo method) {
+        // A method without parameters is neither a "setter" nor a source of parameters
+        return method.parametersCount() > 0 &&
+                !method.isSynthetic() &&
                 !isResourceMethod(method) &&
-                hasParameters(annotations) &&
                 !isSubResourceLocator(method);
     }
 
@@ -1684,18 +1675,6 @@ public abstract class AbstractParameterProcessor {
      * @return true if the method is annotated with a framework-specific HTTP method annotation, false otherwise
      */
     protected abstract boolean isResourceMethod(MethodInfo method);
-
-    /**
-     * Check for the existence relevant parameter annotations in the collection.
-     *
-     * @param annotations collection of annotations
-     * @return true if any of the annotations is a relevant parameter annotation.
-     */
-    protected boolean hasParameters(Collection<AnnotationInstance> annotations) {
-        return annotations.stream()
-                .map(AnnotationInstance::name)
-                .anyMatch(this::isParameter);
-    }
 
     protected abstract boolean isParameter(DotName annotationName);
 

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsConstants.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsConstants.java
@@ -12,8 +12,6 @@ import java.util.stream.Stream;
 
 import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.PathItem.HttpMethod;
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
 
 /**
@@ -124,12 +122,6 @@ public class JaxRsConstants {
 
     public static final Set<DotName> HTTP_METHODS = Collections
             .unmodifiableSet(methods);
-
-    private static final AnnotationValue[] EMPTY_VALUES = new AnnotationValue[0];
-    public static final Set<AnnotationInstance> HTTP_METHOD_INSTANCES = methods
-            .stream()
-            .map(name -> AnnotationInstance.create(name, null, EMPTY_VALUES))
-            .collect(Collectors.toUnmodifiableSet());
 
     public static final Map<PathItem.HttpMethod, Set<DotName>> HTTP_METHOD_ANNOTATIONS;
     static {

--- a/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
+++ b/extension-jaxrs/src/main/java/io/smallrye/openapi/jaxrs/JaxRsParameterProcessor.java
@@ -302,14 +302,11 @@ public class JaxRsParameterProcessor extends AbstractParameterProcessor {
     }
 
     private boolean hasMethodHTTPMethodAnnotation(MethodInfo method) {
-        for (AnnotationInstance a : method.declaredAnnotations()) {
-            for (AnnotationInstance httpMethod : JaxRsConstants.HTTP_METHOD_INSTANCES) {
-                if (a.equivalentTo(httpMethod)) {
-                    return true;
-                }
+        for (AnnotationInstance a : method.annotations()) {
+            if (a.target().kind() == AnnotationTarget.Kind.METHOD && JaxRsConstants.HTTP_METHODS.contains(a.name())) {
+                return true;
             }
         }
-
         return false;
     }
 

--- a/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
+++ b/extension-jaxrs/src/test/java/io/smallrye/openapi/runtime/scanner/ParameterScanTests.java
@@ -18,9 +18,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
+import java.util.UUID;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.Explode;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -808,22 +810,97 @@ class ParameterScanTests extends IndexScannerTestBase {
 
     @Test
     void testUnsortedParameters() throws IOException, JSONException {
-        @jakarta.ws.rs.Path("/status")
+        class ListOptions {
+
+            @jakarta.ws.rs.QueryParam("beanparam-field-1")
+            UUID field1;
+
+            @jakarta.ws.rs.HeaderParam("beanparam-field-2")
+            UUID field2;
+
+            @jakarta.ws.rs.PathParam("beanparam-field-3")
+            UUID field3;
+
+            @jakarta.ws.rs.QueryParam("beanparam-method-4")
+            public void field4(String field4) {
+            }
+
+            @jakarta.ws.rs.HeaderParam("beanparam-method-5")
+            public void field5(String field5) {
+            }
+
+            @jakarta.ws.rs.PathParam("beanparam-method-6")
+            public void field6(String field6) {
+            }
+
+            public ListOptions(@jakarta.ws.rs.QueryParam("beanparam-constructor-c-10") String constructor10,
+                    @jakarta.ws.rs.HeaderParam("beanparam-constructor-d-11") String constructor11,
+                    @jakarta.ws.rs.PathParam("beanparam-constructor-a-12") String constructor12) {
+
+            }
+
+            @Parameter(name = "beanparam-method-42", in = ParameterIn.QUERY)
+            public void field41(@jakarta.ws.rs.QueryParam("beanparam-method-41") String field41) {
+            }
+
+            @jakarta.ws.rs.QueryParam("beanparam-field-7")
+            UUID field7;
+
+            @jakarta.ws.rs.HeaderParam("beanparam-field-8")
+            UUID field8;
+
+            @jakarta.ws.rs.PathParam("beanparam-field-9")
+            UUID field9;
+        }
+
+        @jakarta.ws.rs.Path("/status/{method-1-p1}/{field-3}/{method-6}/{field-9}/{beanparam-field-3}/{beanparam-method-6}/{beanparam-field-9}/{beanparam-constructor-a-12}")
         class Resource {
+            @jakarta.ws.rs.QueryParam("field-1")
+            UUID field1;
+
+            @jakarta.ws.rs.HeaderParam("field-2")
+            UUID field2;
+
+            @jakarta.ws.rs.PathParam("field-3")
+            UUID field3;
+
+            @Parameter(name = "method-additional-1", in = ParameterIn.QUERY)
+            @Parameter(name = "method-additional-2", in = ParameterIn.HEADER)
             @jakarta.ws.rs.GET
-            @jakarta.ws.rs.Path("/{resourceId}")
             public String get(
-                    @jakarta.ws.rs.QueryParam("q7") int q7,
-                    @jakarta.ws.rs.QueryParam("q9") int q9,
-                    @jakarta.ws.rs.HeaderParam("h6") int h8,
-                    @jakarta.ws.rs.PathParam("resourceId") String resourceId,
-                    @jakarta.ws.rs.QueryParam("q8") int q8) {
+                    @jakarta.ws.rs.QueryParam("method-1-q1") int q1,
+                    @jakarta.ws.rs.QueryParam("method-1-q2") int q2,
+                    @jakarta.ws.rs.HeaderParam("method-1-h1") int h3,
+                    @jakarta.ws.rs.BeanParam ListOptions listOptions,
+                    @jakarta.ws.rs.PathParam("method-1-p1") String resourceId,
+                    @jakarta.ws.rs.QueryParam("method-1-q4") int q4) {
                 return null;
             }
+
+            @jakarta.ws.rs.QueryParam("method-4")
+            public void field4(String field4) {
+            }
+
+            @jakarta.ws.rs.HeaderParam("method-5")
+            public void field5(String field5) {
+            }
+
+            @jakarta.ws.rs.PathParam("method-6")
+            public void field6(String field6) {
+            }
+
+            @jakarta.ws.rs.QueryParam("field-7")
+            String field7;
+
+            @jakarta.ws.rs.HeaderParam("field-8")
+            String field8;
+
+            @jakarta.ws.rs.PathParam("field-9")
+            String field9;
         }
 
         test(dynamicConfig(SmallRyeOASConfig.SMALLRYE_SORTED_PARAMETERS_ENABLE, Boolean.FALSE),
-                "params.unsorted-scan-order.json", Resource.class);
+                "params.unsorted-scan-order.json", Resource.class, ListOptions.class);
     }
 
     @Test

--- a/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.unsorted-scan-order.json
+++ b/extension-jaxrs/src/test/resources/io/smallrye/openapi/runtime/scanner/params.unsorted-scan-order.json
@@ -1,43 +1,204 @@
 {
   "openapi" : "3.1.0",
+  "components" : {
+    "schemas" : {
+      "UUID" : {
+        "type" : "string",
+        "format" : "uuid",
+        "pattern" : "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+      }
+    }
+  },
   "paths" : {
-    "/status/{resourceId}" : {
+    "/status/{method-1-p1}/{field-3}/{method-6}/{field-9}/{beanparam-field-3}/{beanparam-method-6}/{beanparam-field-9}/{beanparam-constructor-a-12}" : {
+      "parameters" : [ {
+        "name" : "field-1",
+        "in" : "query",
+        "schema" : {
+          "$ref" : "#/components/schemas/UUID"
+        }
+      }, {
+        "name" : "field-2",
+        "in" : "header",
+        "schema" : {
+          "$ref" : "#/components/schemas/UUID"
+        }
+      }, {
+        "name" : "field-3",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "$ref" : "#/components/schemas/UUID"
+        }
+      }, {
+        "name" : "field-7",
+        "in" : "query",
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "field-8",
+        "in" : "header",
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "field-9",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "method-4",
+        "in" : "query",
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "method-5",
+        "in" : "header",
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "method-6",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ],
       "get" : {
         "parameters" : [ {
-          "name" : "q7",
+          "name" : "method-1-q1",
           "in" : "query",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
           }
         }, {
-          "name" : "q9",
+          "name" : "method-1-q2",
           "in" : "query",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
           }
         }, {
-          "name" : "h6",
+          "name" : "method-1-h1",
           "in" : "header",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
           }
         }, {
-          "name" : "resourceId",
+          "name" : "beanparam-field-1",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-field-2",
+          "in" : "header",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-field-3",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-field-7",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-field-8",
+          "in" : "header",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-field-9",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        }, {
+          "name" : "beanparam-method-4",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "beanparam-method-5",
+          "in" : "header",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "beanparam-method-6",
           "in" : "path",
           "required" : true,
           "schema" : {
             "type" : "string"
           }
         }, {
-          "name" : "q8",
+          "name" : "beanparam-constructor-c-10",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "beanparam-constructor-d-11",
+          "in" : "header",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "beanparam-constructor-a-12",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "beanparam-method-41",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "beanparam-method-42",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "method-1-p1",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "method-1-q4",
           "in" : "query",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
           }
+        }, {
+          "in" : "query",
+          "name" : "method-additional-1"
+        }, {
+          "in" : "header",
+          "name" : "method-additional-2"
         } ],
         "responses" : {
           "200" : {


### PR DESCRIPTION
readParameters checked each annotation on the class, if it is parameter. Then checked if the annotation instances target is FIELD|METHOD|METHOD_PARAMETER, and then checked that target if it has any parameter annotations. I turned it around. We overall only check fields and methods now for parameter annotations. For fields we only require one isParameter check for the specific annotation instance. For methods, we check if the method could even be a bean property method first. Short circuit for parameterless methods (constructors, static initializers). This saves around 2/3 of the calls towards isResourceMethod (150k -> 50k). We also save on retrieving the annotations of each target again and again, if the target has multiple parameter annotations (resource methods, constructors).

Optimize JaxRsParameterProcessor.hasMethodHTTPMethodAnnotation further to save on the ArrayList allocation inside MethodInfo.declaredAnnotations(). Also compare by name directly instead of AnnotationInstance.

sorted-parameters.enable=false had the problem, that parameters picked up from beanparams where not sorted in declaration order. They where instead grouped by annotation (i.e. path param, query param, etc), and in each group in declaration order. The behaviour is now so that beanparams also follow declaration order; And their parameters are inserted right between the other parameters from the "parents" (e.g. the resource methods) parameters. This is also ensured for parameters declared on constructors. Jandex sorts method parameters alphabetically, so we have to resort based on parameter position.

Add a test to ensure the declaration order sorting stays consistent.

Saves about 80ms of quarkus:build.

related to #2630
replaces #2645