### PR TITLE
perf: reduce calls to FilteredIndexView.accepts

### DIFF
--- a/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
+++ b/core/src/main/java/io/smallrye/openapi/api/SmallRyeOpenAPI.java
@@ -712,7 +712,11 @@ public class SmallRyeOpenAPI {
                         .orElseGet(() -> ConfigProvider.getConfig(this.appClassLoader)));
                 IOContext<V, A, O, AB, OB> io = IOContext.forJson(JsonIO.newInstance(this.buildConfig));
                 this.modelIO = new OpenAPIDefinitionIO<>(io);
-                this.filteredIndex = new FilteredIndexView(builder.index, this.buildConfig);
+                if (builder.index instanceof FilteredIndexView) {
+                    this.filteredIndex = (FilteredIndexView) builder.index;
+                } else {
+                    this.filteredIndex = new FilteredIndexView(builder.index, this.buildConfig);
+                }
                 this.initialModel = builder.initialModel;
                 this.defaultRequiredProperties = builder.defaultRequiredProperties;
                 this.intermediateModel = builder.intermediateModel;

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/AugmentedIndexView.java
@@ -77,8 +77,9 @@ public class AugmentedIndexView implements IndexView {
         for (Type type : klass.interfaceTypes()) {
             interfaces.add(type);
 
-            if (containsClass(type)) {
-                interfaces.addAll(interfaces(getClass(type)));
+            ClassInfo classInfo = getClass(type);
+            if (classInfo != null) {
+                interfaces.addAll(interfaces(classInfo));
             }
         }
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/IgnoreResolver.java
@@ -335,14 +335,16 @@ public class IgnoreResolver {
             // Primitive and non-indexed types will result in a null
             if (classType.kind() == Type.Kind.PRIMITIVE ||
                     classType.kind() == Type.Kind.VOID ||
-                    (classType.kind() == Type.Kind.ARRAY && classType.asArrayType().constituent().kind() == Type.Kind.PRIMITIVE)
-                    ||
-                    !index.containsClass(classType)) {
+                    (classType.kind() == Type.Kind.ARRAY
+                            && classType.asArrayType().constituent().kind() == Type.Kind.PRIMITIVE)) {
                 return Visibility.UNSET;
             }
 
             // Find the real class implementation where the @JsonIgnoreType annotation may be.
             ClassInfo classInfo = index.getClass(classType);
+            if (classInfo == null) {
+                return Visibility.UNSET;
+            }
 
             if (ignoredTypes.contains(classInfo.name())) {
                 DataObjectLogging.logger.ignoringType(classInfo.name());

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/TypeResolver.java
@@ -537,8 +537,14 @@ public class TypeResolver {
             index.interfaces(currentClass)
                     .stream()
                     .filter(type -> type.kind() == Type.Kind.PARAMETERIZED_TYPE)
-                    .filter(index::containsClass)
-                    .map(type -> buildParamTypeResolutionMap(index.getClass(type), type))
+                    .map(type -> {
+                        ClassInfo klazz = index.getClass(type);
+                        if (klazz == null) {
+                            return null;
+                        }
+                        return buildParamTypeResolutionMap(klazz, type);
+                    })
+                    .filter(Objects::nonNull)
                     .forEach(stack::push);
 
             if (allOfMatch || (!currentType.equals(clazzType) && TypeUtil.isIncludedAllOf(context, clazz, currentType))) {

--- a/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/scanner/spi/AnnotationScanner.java
@@ -373,8 +373,9 @@ public interface AnnotationScanner {
                          * whether the view was directly specified on the method, or whether it was discovered
                          * as an inherited view from the view class hierarchy.
                          */
-                        if (index.containsClass(viewType)) {
-                            return index.inheritanceChain(index.getClass(viewType), viewType)
+                        ClassInfo classInfo = index.getClass(viewType);
+                        if (classInfo != null) {
+                            return index.inheritanceChain(classInfo, viewType)
                                     .values()
                                     .stream()
                                     .map(v -> Map.entry(v, viewType.equals(v)));

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/Annotations.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/Annotations.java
@@ -203,9 +203,13 @@ public final class Annotations {
         final boolean isArray = (AnnotationValue.Kind.ARRAY == value.kind());
         AnnotationValue.Kind kind = (isArray ? value.componentKind() : value.kind());
         AugmentedIndexView index = context.getAugmentedIndex();
-        ClassInfo annoClass = index.getClassByName(annotation.name());
 
-        if (kind == AnnotationValue.Kind.UNKNOWN && annoClass != null) {
+        if (kind != AnnotationValue.Kind.UNKNOWN) {
+            return kind;
+        }
+
+        ClassInfo annoClass = index.getClassByName(annotation.name());
+        if (annoClass != null) {
             MethodInfo valueMethod = annoClass.method(value.name());
             Type valueType = valueMethod.returnType().asArrayType().constituent();
 

--- a/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
+++ b/core/src/main/java/io/smallrye/openapi/runtime/util/TypeUtil.java
@@ -472,9 +472,9 @@ public class TypeUtil {
     }
 
     static ClassInfo getClassInfo(IndexView appIndex, DotName className) {
-        ClassInfo clazz = appIndex.getClassByName(className);
+        ClassInfo clazz = jdkIndex.getClassByName(className);
         if (clazz == null) {
-            clazz = jdkIndex.getClassByName(className);
+            clazz = appIndex.getClassByName(className);
         }
         return clazz;
     }


### PR DESCRIPTION
calls to FilteredIndexView.accepts are a bit expensive in my reproducer. This method does multiple checks on the class and package name. Most of them short circuit, since the config for these checks is not set by quarkus by default.

However, when reducing the invocation count of accepts from 42k -> 13k, there is still a noticeable improvement in document generation time.

Removed the possible double wrapping of the Index inside a FilterIndexView. Quarkus already gives us an FilterIndexView. Rewrote consecutive containsClass / getClass calls to a simple getClass with null check (where easily possible). 
Check the jdkIndex first in TypeUtil. This local index only contains some of the jdk classes, and is therefore quite small (avoids CompositeIndex scans / FilteredIndexView.accepts).

This saves about 30ms when doing a quarkus:build.

related to #2630